### PR TITLE
Add dbt-model-generator community skill

### DIFF
--- a/skills/dbt-model-generator/LICENSE
+++ b/skills/dbt-model-generator/LICENSE
@@ -1,0 +1,184 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship made available under
+      the License, as indicated by a copyright notice that is included in
+      or attached to the work (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other transformations
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean, as submitted to the Licensor for inclusion
+      in the Work by the copyright owner or by an individual or Legal Entity
+      authorized to submit on behalf of the copyright owner. For the purposes
+      of this definition, "submitted" means any form of electronic, verbal,
+      or written communication sent to the Licensor or its representatives,
+      including but not limited to communication on electronic mailing lists,
+      source code control systems, and issue tracking systems that are managed
+      by, or on behalf of, the Licensor for the purpose of discussing and
+      improving the Work, but excluding communication that is conspicuously
+      marked or otherwise designated in writing by the copyright owner as
+      "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any Legal Entity on behalf of
+      whom a Contribution has been received by the Licensor and subsequently
+      incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a cross-claim
+      or counterclaim in a lawsuit) alleging that the Work or any
+      Contribution embodied within the Work constitutes direct or contributory
+      patent infringement, then any patent licenses granted to You under
+      this License for that Work shall terminate as of the date such
+      litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or Derivative
+          Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, You must include a readable copy of the
+          attribution notices contained within such NOTICE file, in
+          at least one of the following places: within a NOTICE text
+          file distributed as part of the Derivative Works; within
+          the Source form or documentation, if provided along with the
+          Derivative Works; or, within a display generated by the
+          Derivative Works, if and wherever such third-party notices
+          normally appear. The contents of the NOTICE file are for
+          informational purposes only and do not modify the License.
+          You may add Your own attribution notices within Derivative
+          Works that You distribute, alongside or as an addendum to
+          the NOTICE text from the Work, provided that such additional
+          attribution notices cannot be construed as modifying the License.
+
+      You may add Your own license statement for Your modifications and
+      may provide additional grant of rights to use, copy, modify, merge,
+      publish, distribute, sublicense, and/or sell copies of the
+      Contribution, either on an unmodified basis, with modifications,
+      or as part of a larger work.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or exemplary damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or all other
+      commercial damages or losses), even if such Contributor has been
+      advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Vino Duraisamy
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/skills/dbt-model-generator/SKILL.md
+++ b/skills/dbt-model-generator/SKILL.md
@@ -1,0 +1,73 @@
+---
+id: dbt-model-generator
+name: dbt-model-generator
+skill-name: $dbt-model-generator
+description: "Automatically generate dbt dimensional models from raw Snowflake tables. Profiles data, recommends star schema/OBT/wide table, generates staging/dim/fact models with tests, and submits a PR."
+prompt: "$dbt-model-generator generate dbt models from MY_DB.RAW_SCHEMA"
+language: en
+status: Published
+author: Vino Duraisamy
+type: community
+---
+
+# dbt Model Generator
+
+Automates the creation of dbt models from raw Snowflake tables. Profiles the data, recommends a modeling pattern (star schema, OBT, or wide denormalized), generates staging/dim/fact models with tests, and submits a PR for engineer review.
+
+## When to Use
+
+- User wants to generate dbt models from raw Snowflake tables
+- User asks to "shift left" data modeling
+- User wants to automate dimensional modeling
+- User asks to create facts and dimensions from raw data
+- User wants to build a star schema from raw tables
+- User asks to auto-generate dbt code from Iceberg tables or any raw source
+- Do NOT use for: modifying existing dbt models, running dbt tests only, or dbt project configuration questions
+
+## Requirements
+
+- **dbt**: `dbt-core>=1.7,<2.0` with `dbt-snowflake>=1.7,<2.0`
+- **Python**: 3.9+
+- **Runtime**: `uv` (preferred), `pipx`, or `pip` — skill auto-detects what's available
+- **Git**: `git` CLI + `gh` CLI for PR creation
+- **Snowflake**: Active CoCo connection or environment-variable-based auth
+
+## Workflow
+
+```
+Start
+  ↓
+Step 1: Collect Parameters
+  ↓
+Step 2: Discover & Profile Raw Tables
+  ↓
+Step 3: Recommend Modeling Pattern
+  ↓  ⚠️ STOP — User approves pattern + classification
+Step 4: Generate dbt Project Scaffold
+  ↓
+Step 5: Generate Models (staging → dims → facts / OBT)
+  ↓
+Step 6: Generate Schema Tests & Docs
+  ↓
+Step 7: Validate (dbt parse + optional dbt run)
+  ↓  ⚠️ STOP — User reviews generated models
+Step 8: Git Commit & PR
+  ↓
+Done
+```
+
+## Parameters
+
+**Required:**
+- `<SOURCE_DATABASE>`: Snowflake database containing raw tables
+- `<SOURCE_SCHEMA>`: Schema within the database (or `*` for all schemas)
+
+**Optional:**
+- `<SOURCE_TABLE>`: Specific table to model (default: discover all tables in schema)
+- `<PROJECT_NAME>`: dbt project name (default: derived from database name)
+- `<PROJECT_PATH>`: Where to create the project on disk (default: `~/Documents/coco-dev/<PROJECT_NAME>`)
+- `<GITHUB_REPO>`: GitHub repo for PR (format: `owner/repo-name`)
+- `<WAREHOUSE>`: Snowflake warehouse (default: use active CoCo connection's warehouse)
+- `<ROLE>`: Snowflake role (default: use active CoCo connection's role)
+
+Full step-by-step detail, SQL queries, dbt templates, column classification rules, and troubleshooting in [references/workflow.md](references/workflow.md).

--- a/skills/dbt-model-generator/references/workflow.md
+++ b/skills/dbt-model-generator/references/workflow.md
@@ -1,0 +1,342 @@
+# dbt Model Generator — Workflow Detail
+
+Loaded when executing the generation workflow. Contains full SQL, dbt templates, decision heuristics, and troubleshooting for Steps 1–8.
+
+---
+
+### Step 1: Collect Parameters
+
+**Ask** the user:
+```
+To generate dimensional models, I need:
+1. Source database name?
+2. Source schema (or * for all)?
+3. Specific table (or all tables in schema)?
+4. GitHub repo for the PR (owner/repo)?
+```
+
+If the user provided a database/table in their request, extract those values and only ask for missing parameters.
+
+**Detect active Snowflake connection:** Run `cortex connections list` to get the current connection's account, warehouse, role, and database. Use these as defaults — don't ask the user to re-specify what CoCo already knows.
+
+### Step 2: Discover & Profile Raw Tables
+
+**Goal:** Understand every table's structure, row counts, column types, cardinality, and relationships.
+
+**⚠️ Cost awareness:** Profiling all tables in a large schema can be expensive. For schemas with >20 tables, ask the user before proceeding. Use `SAMPLE` for tables with >1M rows. An XSMALL warehouse is sufficient for profiling.
+
+**Actions:**
+
+1. **List tables** in the source database/schema:
+   ```sql
+   SELECT table_schema, table_name, row_count, bytes
+   FROM <SOURCE_DATABASE>.INFORMATION_SCHEMA.TABLES
+   WHERE table_schema = '<SOURCE_SCHEMA>' AND table_type = 'BASE TABLE'
+   ORDER BY table_schema, table_name
+   ```
+   If `<SOURCE_SCHEMA>` is `*`, use `table_schema NOT IN ('INFORMATION_SCHEMA')`.
+
+2. **For each table**, get full column metadata:
+   ```sql
+   SELECT column_name, data_type, is_nullable, ordinal_position,
+          character_maximum_length, numeric_precision, numeric_scale
+   FROM <SOURCE_DATABASE>.INFORMATION_SCHEMA.COLUMNS
+   WHERE table_schema = '<schema>' AND table_name = '<table>'
+   ORDER BY ordinal_position
+   ```
+
+3. **Statistical profiling** per table — do NOT use `SELECT * LIMIT N` (too weak for understanding distributions):
+   ```sql
+   -- For tables ≤1M rows, scan directly. For >1M rows, use SAMPLE.
+   SELECT
+     '<col>' AS column_name,
+     COUNT(*) AS total_rows,
+     COUNT("<col>") AS non_null_count,
+     ROUND(COUNT_IF("<col>" IS NULL) * 100.0 / COUNT(*), 1) AS null_pct,
+     APPROX_COUNT_DISTINCT("<col>") AS approx_distinct,
+     MIN("<col>")::VARCHAR AS min_val,
+     MAX("<col>")::VARCHAR AS max_val
+   FROM <SOURCE_DATABASE>.<schema>.<table>
+   -- Add: SAMPLE (100000 ROWS) for tables with row_count > 1000000
+   ```
+   Run one query per table with a UNION ALL across all columns, or use a loop. Also sample 5 rows for visual inspection:
+   ```sql
+   SELECT * FROM <SOURCE_DATABASE>.<schema>.<table> TABLESAMPLE (5 ROWS)
+   ```
+
+4. **Check for existing semantic views, tags, or comments** on the tables for additional context.
+
+5. **Identify relationships** across tables by matching column names (e.g., `*_ID` columns that appear in multiple tables).
+
+**Output:** A profiling summary per table: column list, types, cardinality, null rates, candidate keys, foreign key relationships, estimated scan cost.
+
+### Step 3: Recommend Modeling Pattern
+
+**Goal:** Based on profiling results, recommend the right modeling pattern — not every dataset needs a star schema.
+
+**Decision heuristics:**
+
+| Signal | Recommended Pattern |
+|---|---|
+| 1-2 source tables, no clear grain differences | **OBT (One Big Table)** — single wide denormalized model |
+| 1-3 tables, <100K rows total, simple analytics use case | **Wide denormalized table** — join + flatten in staging |
+| 3+ tables with distinct grains, shared dimensions, >100K rows | **Star schema** — facts + dimensions |
+| User explicitly requests a pattern | **Whatever the user asked for** |
+
+**Present recommendation to user:**
+```
+Based on profiling:
+- [N] source tables, [total rows] total rows
+- [describe key relationships found]
+
+Recommended pattern: [Star Schema / OBT / Wide Table]
+Reason: [explain why]
+
+If Star Schema:
+  Facts: [list with grain]
+  Dimensions: [list with keys and attributes]
+  Measures: [list]
+
+  [Star schema ASCII diagram]
+
+Classification rationale for each column...
+Data quality warnings: [any issues found]
+
+Do you approve this model? (Yes / Modify / Switch to [alternative pattern])
+```
+
+**⚠️ MANDATORY STOPPING POINT**: Do NOT proceed until user approves the pattern and classification.
+
+**Column classification rules (for star schema):**
+
+| Signal | Classification |
+|---|---|
+| Numeric columns with high cardinality (amounts, quantities, scores) | **Measure** (fact) |
+| `*_ID` columns with low-to-medium cardinality | **Foreign Key** to dimension |
+| `*_ID` column that is unique per row | **Primary Key / Natural Key** |
+| Categorical text with low cardinality | **Dimension attribute** |
+| Timestamps / dates | **Date dimension FK** or degenerate dimension |
+| Free text (long VARCHAR, reviews, descriptions) | **Degenerate dimension** |
+| String-encoded structured data (e.g., `"[2, 3]"`) | **Needs parsing** — note transformation needed |
+
+### Step 4: Generate dbt Project Scaffold
+
+**Goal:** Create a complete dbt project if one doesn't already exist, or integrate into an existing one.
+
+**Actions:**
+
+1. **Detect existing project:** Check if `<PROJECT_PATH>/dbt_project.yml` exists.
+   - **If exists:** Read it. Inspect directory structure (`models/` layout). Read existing `sources.yml` if present. Adapt generated models to match existing conventions.
+   - **If not exists:** Create a new scaffold (step 2 below).
+
+2. **For new projects**, create directory structure:
+   ```
+   <PROJECT_PATH>/
+   ├── dbt_project.yml
+   ├── profiles.yml
+   ├── packages.yml
+   ├── .gitignore
+   ├── models/
+   │   ├── sources.yml
+   │   ├── staging/
+   │   ├── dimensions/
+   │   └── facts/
+   ```
+
+3. **dbt_project.yml**: Configure model materializations:
+   - `staging/` → `materialized: view`
+   - `dimensions/` → `materialized: table`
+   - `facts/` → `materialized: table`
+
+4. **profiles.yml**: Generate from the **active CoCo Snowflake connection**:
+   ```yaml
+   <PROJECT_NAME>:
+     target: dev
+     outputs:
+       dev:
+         type: snowflake
+         account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
+         user: "{{ env_var('SNOWFLAKE_USER') }}"
+         authenticator: externalbrowser  # interactive-only — breaks in CI/CD. For non-interactive use, set authenticator: snowflake with username/password, or use the Snowflake CLI connection instead.
+         warehouse: <WAREHOUSE>
+         database: <SOURCE_DATABASE>
+         schema: <TARGET_SCHEMA>
+         role: <ROLE>
+         threads: 4
+   ```
+   Use `env_var()` for account/user — never hardcode credentials.
+
+5. **packages.yml**: Include dbt_utils with version pin:
+   ```yaml
+   packages:
+     - package: dbt-labs/dbt_utils
+       version: [">=1.0.0", "<2.0.0"]
+   ```
+   Note: dbt-core 1.9+ includes `dbt.generate_surrogate_key()` natively. Prefer the built-in over dbt_utils if on 1.9+.
+
+6. **sources.yml**: Define all source tables discovered in Step 2. If an existing `sources.yml` exists, **merge** — append new sources without overwriting existing entries.
+
+7. **.gitignore**: Include `target/`, `dbt_packages/`, `logs/`, `.user.yml`, `profiles.yml`.
+
+### Step 5: Generate Models
+
+**Naming convention:** `stg_<source_table>`, `dim_<entity>`, `fact_<business_process>`, `obt_<domain>`
+
+#### 5a: Staging Models (`stg_*.sql`)
+
+One staging model per source table. Each must:
+- Reference source via `{{ source('...', '...') }}`
+- Rename columns to snake_case
+- Cast types (string-encoded numbers, dates)
+- Parse structured strings (e.g., `"[x, y]"` → separate integer columns)
+- Convert unix timestamps to `TIMESTAMP` / `DATE`
+- Derive useful computed columns
+
+#### 5b: Dimension Models (`dim_*.sql`) — Star Schema only
+
+One model per identified dimension. Each must:
+- Use `{{ config(materialized='table') }}`
+- Generate surrogate key: `{{ dbt_utils.generate_surrogate_key(['natural_key']) }}` (or `{{ dbt.generate_surrogate_key(['natural_key']) }}` on dbt 1.9+)
+- Reference staging models via `{{ ref('stg_xxx') }}` — **never raw table names**
+- Select distinct dimension members from staging
+- For Type 1 SCD: use `ROW_NUMBER()` ordered by most recent timestamp
+- Include a `dim_date` model as a date spine with: `full_date`, `year`, `quarter`, `month`, `month_name`, `day_of_month`, `day_of_week`, `day_name`, `week_of_year`, `is_weekend`
+
+#### 5c: Fact Models (`fact_*.sql`) — Star Schema only
+
+One model per identified fact table. Each must:
+- Use `{{ config(materialized='table') }}`
+- Generate surrogate key for the fact row
+- Join to all dimension models using `{{ ref('dim_xxx') }}` — **all inter-model references MUST use `{{ ref() }}`**
+- Include all measures from staging
+- Include degenerate dimensions (long text kept on fact, not in a dim)
+
+#### 5d: OBT Model (`obt_*.sql`) — OBT pattern only
+
+Single wide model that:
+- Joins all staging models via `{{ ref('stg_xxx') }}`
+- Flattens all columns into one wide table
+- Uses `{{ config(materialized='table') }}`
+- Adds surrogate key for the primary grain
+
+### Step 6: Generate Schema Tests & Docs
+
+For every model, create a `schema.yml` with:
+
+**Tests:**
+- `unique` + `not_null` on all surrogate keys and natural keys
+- `relationships` tests between fact FKs and dimension PKs
+- `accepted_values` on categorical/enum columns where the domain is known
+- `not_null` on measures
+
+**Documentation:**
+- Column-level `description` for every column in every model
+
+### Step 7: Validate
+
+**Actions:**
+
+1. **Detect dbt runner** — use the first available:
+   ```
+   uv run --with 'dbt-snowflake>=1.7,<2.0'  →  preferred
+   pipx run --spec 'dbt-snowflake>=1.7,<2.0' dbt  →  fallback
+   dbt (if globally installed and version ≥1.7)  →  last resort
+   ```
+   Verify version: `dbt --version` must show ≥1.7.
+
+2. Install packages:
+   ```bash
+   <runner> dbt deps --project-dir <PROJECT_PATH> --profiles-dir <PROJECT_PATH>
+   ```
+
+3. Parse/compile the project:
+   ```bash
+   <runner> dbt parse --project-dir <PROJECT_PATH> --profiles-dir <PROJECT_PATH>
+   ```
+
+4. **If parse fails:** Fix errors and retry (max 3 attempts).
+
+5. Report results:
+   ```
+   ✅ dbt parse: X models, Y tests, Z sources — 0 errors
+   ```
+
+6. **If Snowflake connection is available**, also run:
+   ```bash
+   <runner> dbt run --project-dir <PROJECT_PATH> --profiles-dir <PROJECT_PATH>
+   <runner> dbt test --project-dir <PROJECT_PATH> --profiles-dir <PROJECT_PATH>
+   ```
+
+**⚠️ MANDATORY STOPPING POINT**: Present all generated models to the user for review before proceeding to Git/PR.
+
+### Step 8: Git Commit & PR
+
+**Actions:**
+
+1. **Detect git state:**
+   - If `<PROJECT_PATH>/.git` exists: check for conflicts or uncommitted changes.
+   - If no `.git`: run `git init`.
+   - Check if remote `origin` exists. Only add if missing:
+     ```bash
+     git remote add origin https://github.com/<GITHUB_REPO>.git
+     ```
+   - If remote exists but points to a different repo, warn the user and ask before changing it.
+
+2. **Create `.gitignore`** if it doesn't exist (exclude `target/`, `dbt_packages/`, `logs/`, `.user.yml`, `profiles.yml`).
+
+3. **Create feature branch** per source table:
+   - Branch name: `feature/dim-model-<source_table_lowercase>`
+   - If branch already exists, append a timestamp suffix.
+
+4. **Commit** with descriptive message listing all models, measures, and dimensions.
+
+5. **Push** branch and **create PR** via `gh pr create` with body containing:
+   - Summary of models generated
+   - Star schema ASCII diagram (or OBT column list)
+   - Data profiling stats (row counts, cardinality)
+   - Classification rationale (why each column was assigned its role)
+   - Data quality warnings
+   - Test plan checklist
+
+**PR body template:**
+```markdown
+## Summary
+- AI-generated [star schema / OBT / wide table] from `<SOURCE_DATABASE>.<SOURCE_SCHEMA>.<SOURCE_TABLE>`
+- [N] staging models, [N] dimensions, [N] fact tables, [N] schema tests
+
+## Model Diagram
+[ASCII diagram or column list]
+
+## Data Profiling
+| Table | Rows | Columns | Null % (max) | Candidate Keys |
+|---|---|---|---|---|
+
+## Column Classification Rationale
+| Column | Classification | Reason |
+|---|---|---|
+
+## Data Quality Warnings
+- [any issues found]
+
+## Test Plan
+- [ ] `dbt deps`
+- [ ] `dbt compile`
+- [ ] `dbt run`
+- [ ] `dbt test`
+- [ ] Spot-check joins and transformations
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|---|---|
+| `dbt parse` fails | Check column name quoting — mixed-case columns from Iceberg/Parquet need double quotes (e.g., `"reviewText"`) |
+| Snowflake connection fails during `dbt run` | Verify `profiles.yml` auth. Use `dbt parse` for offline validation |
+| `gh pr create` permission denied | Token needs `Contents (R&W)` and `Pull requests (R&W)` fine-grained permissions |
+| String-encoded data (e.g., `"[2, 3]"`) | Use `TRY_CAST` + `REGEXP_SUBSTR` in staging model for safe parsing |
+| `uv` not installed | Fall back to `pipx run --spec 'dbt-snowflake>=1.7' dbt` or global `dbt` |
+| Existing project has different directory layout | Read `dbt_project.yml` to detect `model-paths` and folder conventions; adapt accordingly |
+| Profiling is slow on large tables | Add `SAMPLE (100000 ROWS)` clause; use XSMALL warehouse for profiling |
+| Remote already configured to different repo | Warn user; don't silently overwrite. Ask before changing `origin` |


### PR DESCRIPTION
## Summary
- Adds `dbt-model-generator` skill that automates dimensional model generation from raw Snowflake tables
- Profiles data, recommends modeling pattern (star schema / OBT / wide table), generates staging/dim/fact dbt models with tests, and submits a PR for engineer review
- Includes full workflow reference with SQL queries, dbt templates, column classification rules, and troubleshooting

## Files
- `skills/dbt-model-generator/SKILL.md` — main skill with required frontmatter
- `skills/dbt-model-generator/references/workflow.md` — detailed step-by-step workflow (Steps 1-8)
- `skills/dbt-model-generator/LICENSE` — Apache 2.0

## Test plan
- [ ] Install skill locally: copy `skills/dbt-model-generator/` to `~/.snowflake/cortex/skills/`
- [ ] Invoke with `$dbt-model-generator` in a CoCo session
- [ ] Test against a real Snowflake schema with 3+ tables
- [ ] Verify generated dbt project passes `dbt parse`
- [ ] Confirm PR creation workflow works end-to-end

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)