### PR TITLE
Refresh _template-skill-name: align with Labs conventions + add builder-audience checklist

### DIFF
--- a/skills/_template-skill-name/SKILL.md
+++ b/skills/_template-skill-name/SKILL.md
@@ -15,7 +15,7 @@ prompt: "$my-skill-name [a realistic example prompt showing how a user would inv
 language: en
 status: Published   # Published | Archived | Hidden
 author: First Last
-type: Community     # Community (default) | Snowflake Staff | Partner
+type: community     # community (default) | snowflake | partner
 demo-url: https://www.youtube.com    # update with your video URL
 ---
 
@@ -136,9 +136,10 @@ Assistant: [Expected behavior]
 
 ## Skill Author Checklist
 
-- [ ] `id` uses verb-noun format (e.g., `deploy-agent`, `build-dashboard`)
+- [ ] `name` uses verb-noun format (e.g., `deploy-agent`, `build-dashboard`)
 - [ ] `description` includes trigger keywords and when to use/not use this skill
 - [ ] Steps use imperative voice (`Ask`, `Execute`, `Validate`)
 - [ ] Stopping points marked with ⚠️ before any destructive or irreversible action
 - [ ] Error handling included for likely failure modes
 - [ ] File is under 500 lines
+- [ ] Skill is written for **external Snowflake builders** (developers, data engineers) — not internal Snowflake staff. No references to internal-only systems, sales tooling, or SE/SA engagement framing.


### PR DESCRIPTION
## Summary

Two small corrections to the contributor template:

1. **`type:`** — lowercase to match the audit rubric and the public schema (`community` | `snowflake` | `partner`). The previous value `Community` would have failed the audit's `labs.frontmatter.values` check if a contributor copy-pasted it verbatim.
2. **Author checklist** — fix `id` to `name` (the actual frontmatter field) and add an explicit reminder that skills here target **external Snowflake builders** (developers, data engineers), not internal Snowflake staff. Lists internal references that disqualify a skill (Snowhouse, PST.SVCS, MEDDPICC, etc.).

## Test plan

- [x] Diff is minimal (3 inserts, 2 deletes); no behavioral change
- [x] Renders correctly on github.com (markdown)
