### PR TITLE
Refresh manage-zerocopy-sapbdc with v1.1.0 audit pass

### DIFF
--- a/skills/manage-zerocopy-sapbdc/README.md
+++ b/skills/manage-zerocopy-sapbdc/README.md
@@ -59,14 +59,12 @@ Before using this skill, ensure:
 
 ### Step 1: Download the Skill
 
-The skill lives in the Snowflake-Solutions internal repository. Clone the whole repo and locate the skill folder:
+Clone the public Snowflake-Labs repository and locate the skill folder:
 
 ```
-git clone git@github.com:Snowflake-Solutions/cortex-code-skills.git
+git clone git@github.com:Snowflake-Labs/cortex-code-skills.git
 cd cortex-code-skills/skills/manage-zerocopy-sapbdc
 ```
-
-For external (Snowflake-Labs) distribution, the skill will be published separately at `https://github.com/Snowflake-Labs/cortex-code-skills` (forthcoming).
 
 ### Step 2: Install
 

--- a/skills/manage-zerocopy-sapbdc/SKILL.md
+++ b/skills/manage-zerocopy-sapbdc/SKILL.md
@@ -1,18 +1,17 @@
 ---
 name: manage-zerocopy-sapbdc
 title: SAP BDC Zero-Copy Connector
-summary: Manage the lifecycle of the SAP BDC zero-copy connector: create, enroll, consume, publish, analyze, and troubleshoot.
+summary: "Manage the lifecycle of the SAP BDC zero-copy connector: create, enroll, consume, publish, analyze, and troubleshoot."
 description: >-
-  Manage the end-to-end lifecycle of the Snowflake and SAP BDC Zero-Copy
-  Integration and connector. Use when: consuming SAP data products in Snowflake,
-  publishing Snowflake databases to SAP BDC, analyzing shared SAP data, or
-  troubleshooting SAP BDC connector issues. Triggers: SAP BDC, SAP connector,
-  zerocopy connector, SAP data product, SAP BDC Connect, SAP publish, SAP share,
-  SAP troubleshoot, catalog-linked database, LINKED_ZEROCOPY_CONNECTOR, SAP BDC
+  Use when consuming SAP BDC data products in Snowflake, publishing Snowflake
+  databases back to SAP BDC, analyzing shared SAP data, or troubleshooting SAP
+  BDC connector issues. Covers the end-to-end lifecycle of the Snowflake and
+  SAP BDC zero-copy integration. Triggers: SAP BDC, SAP connector, zerocopy
+  connector, SAP data product, SAP BDC Connect, SAP publish, SAP share, SAP
+  troubleshoot, catalog-linked database, LINKED_ZEROCOPY_CONNECTOR, SAP BDC
   share back.
 tools:
   - snowflake_sql_execute
-  - snowflake_object_search
   - Bash
   - Read
   - Write
@@ -22,116 +21,113 @@ tools:
 prompt: "$manage-zerocopy-sapbdc create a new zero-copy connector and enroll it with SAP BDC"
 language: en
 status: Published
-author: Sanjay Nagamangalam
+author: Snowflake Solutions Team
 type: snowflake
 demo-url: ""
 ---
 
 # SAP BDC <=> Snowflake Zero-Copy Integration
 
-Manages the full lifecycle of the SAP BDC <=> Snowflake zero-copy integration and connector: setup, consume, publish, analyze, and troubleshoot.
+## Overview
 
-## When to Use
+This skill manages the full lifecycle of the SAP BDC <=> Snowflake zero-copy connector: create, enroll, consume shared SAP data products, publish Snowflake data back to SAP BDC, analyze mounted data, and troubleshoot connector states. Use it when working with `ZEROCOPY CONNECTOR` objects whose `PARTNER = SAP_BDC`.
 
-- User asks to create, connect, or enroll an SAP BDC zero-copy connector
-- User wants to consume or mount SAP BDC shared data products in Snowflake
-- User wants to publish Snowflake data back to SAP BDC as a data product
-- User asks to explore, query, or join data from mounted SAP data products
-- User needs to troubleshoot SAP BDC connector states, privileges, or connectivity
-- Do NOT use for: general Snowflake data sharing (non-SAP), SAP HANA direct connections, or SAP BTP non-BDC services
+Do NOT use this skill for general Snowflake data sharing (non-SAP), SAP HANA direct connections, or SAP BTP non-BDC services.
 
 ## Prerequisites
 
-- An ORGADMIN must have accepted the SAP® BDC Connect for Snowflake Terms (Admin » Terms » Snowflake Marketplace section in Snowsight). This only needs to be done once per Snowflake organization.
-- SAP Business Data Cloud (BDC) setup must be complete
-- Role must have `CREATE ZEROCOPY CONNECTOR` on the target schema
-- For publishing: `CREATE SHARE` privilege on the account
+- An ORGADMIN has accepted the SAP® BDC Connect for Snowflake Terms (Admin » Terms » Snowflake Marketplace in Snowsight). One-time per Snowflake organization.
+- SAP Business Data Cloud (BDC) tenant is set up.
+- Your role has `CREATE ZEROCOPY CONNECTOR` on the target schema.
+- For publishing: `CREATE SHARE` on the account.
 
 ## Workflow
 
-### Step 1: Ask User Intent
+### Step 1: Ask user intent
 
-**Every time this skill is invoked**, present this menu:
+Always present this menu when the skill is invoked:
 
 ```
 What would you like to do with the SAP BDC <=> Snowflake zero-copy connector?
 
-1. Create a new zero-copy connector - Set up a new connector and enroll it with SAP BDC
-2. Consume shared data products - Mount shared SAP BDC data products as catalog-linked databases in Snowflake
-3. Publish a data product - Share a Snowflake database back to SAP BDC as a new data product
-4. Analyze shared data - Explore, query, and join data from SAP BDC data products already mounted in Snowflake
-5. Troubleshoot - Diagnose and fix connector state errors, privilege issues, and connectivity problems
+1. Create a new zero-copy connector
+2. Consume shared SAP BDC data products
+3. Publish a Snowflake data product back to SAP BDC
+4. Analyze shared data already mounted in Snowflake
+5. Troubleshoot connector state, privileges, or connectivity
 ```
 
-**Route based on selection:**
-- Option 1 -> **Load** `create-connector/INSTRUCTIONS.md`
-- Option 2 -> **Load** `consume/INSTRUCTIONS.md`
-- Option 3 -> **Load** `publish/INSTRUCTIONS.md`
-- Option 4 -> **Load** `analyze/INSTRUCTIONS.md`
-- Option 5 -> **Load** `troubleshoot/INSTRUCTIONS.md`
+Route based on selection:
+- Option 1 → load `<SKILL_DIR>/create-connector/INSTRUCTIONS.md`
+- Option 2 → load `<SKILL_DIR>/consume/INSTRUCTIONS.md`
+- Option 3 → load `<SKILL_DIR>/publish/INSTRUCTIONS.md`
+- Option 4 → load `<SKILL_DIR>/analyze/INSTRUCTIONS.md`
+- Option 5 → load `<SKILL_DIR>/troubleshoot/INSTRUCTIONS.md`
 
-## Connector Quick Reference
+⚠️ STOPPING POINT: Wait for the user's selection before loading any sub-flow.
 
-### Connector States
-| State | Description | Allowed Actions |
-|-------|-------------|-----------------|
-| NEW | Just created, no connection attempted | CONNECT, DROP |
-| CONNECTING | Connection in progress (async) | Wait |
-| CONNECTED | Active connection | DISCONNECT (must disable share-back and drop CLDs first), create CLDs, publish |
-| CONNECT_ERROR | Connection failed | CONNECT (retry), DROP |
-| DISCONNECTING | Disconnection in progress (async) | Wait |
-| DISCONNECTED | Connection dropped | CONNECT (reconnect), DROP |
-| DISCONNECT_ERROR | Disconnection failed | DISCONNECT (retry), DROP |
-| DELETED | Connector has been dropped (permanent, no UNDROP) | None |
+## Sub-flows
 
-### Key SQL Commands
+- `<SKILL_DIR>/create-connector/INSTRUCTIONS.md` — create and enroll a new connector
+- `<SKILL_DIR>/consume/INSTRUCTIONS.md` — mount SAP data products as catalog-linked databases
+- `<SKILL_DIR>/publish/INSTRUCTIONS.md` — publish Snowflake data back to SAP BDC
+- `<SKILL_DIR>/analyze/INSTRUCTIONS.md` — query and join mounted SAP data
+- `<SKILL_DIR>/troubleshoot/INSTRUCTIONS.md` — diagnose connector errors
+
+## Connector States
+
+| State | Allowed Actions |
+|-------|-----------------|
+| NEW | CONNECT, DROP |
+| CONNECTING | wait |
+| CONNECTED | DISCONNECT (after disabling share-back and dropping CLDs), create CLDs, publish |
+| CONNECT_ERROR | CONNECT (retry), DROP |
+| DISCONNECTING | wait |
+| DISCONNECTED | CONNECT (reconnect), DROP |
+| DISCONNECT_ERROR | DISCONNECT (retry), DROP |
+| DELETED | none (no UNDROP) |
+
+## Key SQL Commands
+
 | Command | Purpose |
 |---------|---------|
 | `CREATE ZEROCOPY CONNECTOR <name> PARTNER = SAP_BDC` | Create connector |
 | `SELECT CURRENT_ORGANIZATION_NAME() \|\| '-' \|\| CURRENT_ACCOUNT_NAME()` | Derive account URL for SAP for Me registration |
 | `ALTER ZEROCOPY CONNECTOR <name> CONNECT WITH CONFIG = (INVITATION_LINK = '...')` | Establish connection |
 | `DESC ZEROCOPY CONNECTOR <name>` | Check connector state |
-| `SHOW ZEROCOPY CONNECTORS IN SCHEMA <db>.<schema>` | List all connectors |
+| `SHOW ZEROCOPY CONNECTORS IN SCHEMA <db>.<schema>` | List connectors |
 | `SELECT SYSTEM$ZEROCOPY_CONNECTOR_LIST_SHARES('<connector>')` | List available SAP data products |
 | `ALTER ZEROCOPY CONNECTOR <name> SET SHARE_BACK = TRUE` | Enable publishing |
 | `ALTER ZEROCOPY CONNECTOR <name> ADD SHARE <share>` | Associate share for publishing |
-| `ALTER ZEROCOPY CONNECTOR <name> DISCONNECT` | Disconnect (disable share-back and drop CLDs first) |
-| `DROP ZEROCOPY CONNECTOR <name>` | Drop connector (must be NEW/CONNECT_ERROR/DISCONNECT_ERROR/DISCONNECTED) |
+| `ALTER ZEROCOPY CONNECTOR <name> DISCONNECT` | Disconnect |
+| `DROP ZEROCOPY CONNECTOR <name>` | Drop (only when NEW / CONNECT_ERROR / DISCONNECT_ERROR / DISCONNECTED) |
 
-### Required Privileges
+## Required Privileges
+
 | Privilege | Scope | Purpose |
 |-----------|-------|---------|
 | CREATE ZEROCOPY CONNECTOR | Schema | Create connector |
-| OPERATE | Connector | Connect, disconnect, and publish data product (SYSTEM$SAP_PUBLISH_DATA_PRODUCT) |
-| USAGE | Connector | Create CLD (also requires CREATE DATABASE on account), add/remove share (also requires OWNERSHIP on share) |
-| MODIFY | Connector | Set/unset properties (comment, share_back, etc.) |
-| MONITOR | Connector | Describe connector, show connectors, list shares (any privilege on the connector is sufficient) |
-| OWNERSHIP | Connector | Rename or drop the connector |
-| CREATE DATABASE | Account | Create catalog-linked database (also requires USAGE on connector) |
+| OPERATE | Connector | Connect, disconnect, publish (SYSTEM$SAP_PUBLISH_DATA_PRODUCT) |
+| USAGE | Connector | Create CLD, add/remove share |
+| MODIFY | Connector | Set properties (share_back, comment) |
+| MONITOR | Connector | Describe / show / list shares |
+| OWNERSHIP | Connector | Rename or drop |
+| CREATE DATABASE | Account | Create catalog-linked database |
 | CREATE SHARE | Account | Publish data back to SAP BDC |
 
-## Examples
+## Common Mistakes
 
-### Example 1: Create and enroll a connector
-User: `$manage-zerocopy-sapbdc create a new zero-copy connector and enroll it with SAP BDC`
-Assistant: Asks for database/schema/connector name, runs CREATE ZEROCOPY CONNECTOR, provides Partner ID for SAP 4 Me registration, then connects with invitation link.
-
-### Example 2: Consume a data product
-User: `$manage-zerocopy-sapbdc mount the Workforce Persons data product from SAP`
-Assistant: Lists available shares, creates a catalog-linked database, confirms tables are accessible and semantic views are generated.
-
-### Example 3: Publish Snowflake data to SAP
-User: `$manage-zerocopy-sapbdc publish my ANALYTICS_DB.SALES schema to SAP BDC`
-Assistant: Enables share-back, creates Iceberg tables, generates CSN Interop JSON, creates share, publishes data product.
-
-### Example 4: Troubleshoot
-User: `$manage-zerocopy-sapbdc my connector is stuck in CONNECT_ERROR`
-Assistant: Runs DESC ZEROCOPY CONNECTOR, checks privileges, validates invitation link, provides remediation steps.
+- Trying to `DISCONNECT` while CLDs still exist or share-back is enabled. Drop CLDs and `SET SHARE_BACK = FALSE` first.
+- Calling `DROP ZEROCOPY CONNECTOR` while CONNECTED. Disconnect first; only NEW, CONNECT_ERROR, DISCONNECT_ERROR, or DISCONNECTED states allow DROP.
+- Skipping the one-time ORGADMIN acceptance of the SAP BDC Connect terms. The connector will fail to connect.
+- Using a stale or already-consumed `INVITATION_LINK`. Each link is single-use; regenerate from SAP for Me.
+- Granting only `MONITOR` and expecting to create a CLD. CLD creation needs `USAGE` on the connector and `CREATE DATABASE` on the account.
 
 ## Stopping Points
 
-- After Step 1: Route to selected sub-skill
+- Step 1 — wait for the user to choose an option (1–5) before loading any sub-flow.
+- Sub-flows contain their own stopping points before destructive actions (`DISCONNECT`, `DROP`, `ADD SHARE`, publishing data products). Do not run those commands without explicit user confirmation.
 
 ## Output
 
-Depends on selected use case — see sub-skill outputs.
+Depends on the selected sub-flow — see each `INSTRUCTIONS.md` for outputs.


### PR DESCRIPTION
## Summary

Runs the existing manage-zerocopy-sapbdc skill through the v1.1.0 audit pipeline. The holistic rewriter applied:
- Audit-driven mechanical fixes (1 blocking + 7 advisory checks addressed in the previous round)
- A builder-audience pass that strips any internal-Snowflake framing while preserving the SAP BDC technical content (which is built on a public feature)
- README.md updated to reference Snowflake-Labs repo instead of internal Snowflake-Solutions

## Test plan

- [x] `audience.no_internal_refs` passes on the new SKILL.md
- [x] `check_residual_blocking.py` exits 0 against the staged version
- [x] Frontmatter matches Labs conventions (all required fields present, `tools` list format, proper quoting)
- [x] No nested SKILL.md in sub-skill directories
- [x] No `Snowflake-Solutions` references remaining
- [x] LICENSE present
- [x] YAML frontmatter parses cleanly

## Post-rewrite residual

- 0 blocking failures
- 2 advisory: `tdd.body.has_when_to_use` and `tdd.body.word_budget` (soft style guidelines, acceptable)