### PR TITLE
Promote entity-resolution from Snowflake-Solutions

### DIFF
--- a/skills/entity-resolution/INTEGRATION-TESTING.md
+++ b/skills/entity-resolution/INTEGRATION-TESTING.md
@@ -1,0 +1,838 @@
+# Integration Testing — Entity Resolution Skill
+
+Benchmark the entity-resolution skill against classic academic ER datasets with known ground truth. Measures precision, recall, and F1 across all applicable matching techniques.
+
+## 1. Introduction
+
+### Purpose
+
+The entity-resolution skill includes [domain-specific functional tests](src/tests/) that validate workflow correctness using small synthetic fixtures (10-12 records per domain). This document defines **benchmark integration tests** that evaluate the skill against published research datasets where ground truth is known, enabling:
+
+- Quantitative skill quality assessment (precision, recall, F1)
+- Technique comparison (Fuzzy vs AI-Judged vs Contrastive vs Full Pipeline)
+- Regression detection across skill changes
+- Evidence generation for `skill_evidence.yaml`
+
+### Relationship to Existing Tests
+
+| Test Suite | Scope | Records | Ground Truth | Goal |
+|------------|-------|---------|-------------|------|
+| Functional (existing) | 5 domain profiles | 10-12 each | Hand-crafted expected pairs | Workflow correctness |
+| Benchmark (this doc) | 5 academic datasets | 1K-67K each | Published labeled pairs | Quality measurement |
+
+### Methodology
+
+Each benchmark follows the skill's standard workflow (Profile → Normalize → Block → Match → Score) but adds a held-out evaluation step. Ground truth pairs are split 70/30:
+
+- **Training set (70%)** — Used by contrastive embeddings (Phase 4c) for supervised training
+- **Test set (30%)** — Held out for evaluation of ALL techniques (including contrastive)
+
+Non-contrastive techniques (Fuzzy, AI-Judged, Full Pipeline) do not use the training set at all — they are unsupervised/zero-shot. The split exists solely to give contrastive a fair comparison: it trains on the 70% and is evaluated on the same 30% as everyone else.
+
+---
+
+## 2. Dataset Catalog
+
+All datasets are from the [Magellan Data Repository](https://sites.google.com/site/anhabordeaux/magellan/dataset-library) and the [DITTO benchmark suite](https://github.com/megagonlabs/ditto) — standard references in entity resolution research.
+
+### 2.1 DBLP-ACM
+
+| Property | Value |
+|----------|-------|
+| Domain | Bibliographic (academic publications) |
+| Task | Cross-source matching |
+| Table A records | 2,616 (DBLP) |
+| Table B records | 2,294 (ACM) |
+| Ground truth pairs | 2,224 |
+| Key columns | `title`, `authors`, `venue`, `year` |
+| Characteristics | Clean, well-structured; title and author fields are highly discriminative |
+| Difficulty | Easy — high textual overlap between matching records |
+| Skill profile | Generic (no authoritative IDs) |
+| Best known contrastive F1 | 0.9904 (RoBERTa-base, NER disabled) |
+
+### 2.2 DBLP-Scholar
+
+| Property | Value |
+|----------|-------|
+| Domain | Bibliographic (academic publications) |
+| Task | Cross-source matching (asymmetric scale) |
+| Table A records | 2,616 (DBLP) |
+| Table B records | 64,263 (Google Scholar) |
+| Ground truth pairs | 5,347 |
+| Key columns | `title`, `authors`, `venue`, `year` |
+| Characteristics | Highly asymmetric (1:25 ratio); Scholar records are noisy with truncated titles and inconsistent author formatting |
+| Difficulty | Medium — scale asymmetry + noise amplify false positive risk |
+| Skill profile | Generic (no authoritative IDs) |
+
+### 2.3 Walmart-Amazon
+
+| Property | Value |
+|----------|-------|
+| Domain | Product (e-commerce) |
+| Task | Cross-source matching |
+| Table A records | 2,554 (Walmart) |
+| Table B records | 22,074 (Amazon) |
+| Ground truth pairs | 1,154 |
+| Key columns | `title`, `category`, `brand`, `modelno`, `price` |
+| Characteristics | Heterogeneous product descriptions; brand/model info inconsistent; price varies across sources |
+| Difficulty | Hard — noisy, sparse, heterogeneous attributes |
+| Skill profile | Retail/CPG or Generic |
+| Best known contrastive F1 | 0.8701 (RoBERTa-base, NER disabled) |
+
+### 2.4 Amazon-Google
+
+| Property | Value |
+|----------|-------|
+| Domain | Product (e-commerce) |
+| Task | Cross-source matching |
+| Table A records | 1,363 (Amazon) |
+| Table B records | 3,226 (Google Products) |
+| Ground truth pairs | 1,300 |
+| Key columns | `title`, `manufacturer`, `price` |
+| Characteristics | Google side has very sparse attributes; manufacturer field often missing; price inconsistent |
+| Difficulty | Hard — attribute sparsity on one side |
+| Skill profile | Generic |
+
+### 2.5 Abt-Buy
+
+| Property | Value |
+|----------|-------|
+| Domain | E-commerce products |
+| Task | Cross-source matching |
+| Table A records | 1,081 (Abt.com) |
+| Table B records | 1,092 (Buy.com) |
+| Ground truth pairs | 1,098 |
+| Key columns | `name`, `description`, `price` |
+| Characteristics | Long product descriptions; name field contains most signal; description field has varying verbosity |
+| Difficulty | Medium — description-heavy matching |
+| Skill profile | Generic |
+
+---
+
+## 3. Data Preparation
+
+### 3.1 Obtaining the Data
+
+Download the datasets from the Magellan Data Repository or the DITTO benchmark GitHub. Each dataset consists of two CSV files (tableA.csv, tableB.csv) and a ground truth mapping file.
+
+Stage the CSV files in Snowflake:
+
+```sql
+-- Create a named stage for benchmark data
+CREATE STAGE IF NOT EXISTS ER_BENCHMARK_STAGE
+    FILE_FORMAT = (TYPE = CSV FIELD_OPTIONALLY_ENCLOSED_BY = '"' SKIP_HEADER = 1
+                   FIELD_DELIMITER = ',' ESCAPE_UNENCLOSED_FIELD = NONE);
+
+-- Upload CSVs (from local machine)
+-- PUT file:///path/to/dblp_acm/tableA.csv @ER_BENCHMARK_STAGE/dblp_acm/;
+-- PUT file:///path/to/dblp_acm/tableB.csv @ER_BENCHMARK_STAGE/dblp_acm/;
+-- PUT file:///path/to/dblp_acm/matches.csv @ER_BENCHMARK_STAGE/dblp_acm/;
+-- (repeat for each dataset)
+```
+
+### 3.2 Schema Definitions
+
+Each dataset gets three tables: `<DATASET>_A`, `<DATASET>_B`, and `<DATASET>_GROUND_TRUTH`.
+
+#### DBLP-ACM
+
+```sql
+CREATE OR REPLACE TABLE DBLP_ACM_A (
+    id        VARCHAR,
+    title     VARCHAR,
+    authors   VARCHAR,
+    venue     VARCHAR,
+    year      INT
+);
+
+CREATE OR REPLACE TABLE DBLP_ACM_B (
+    id        VARCHAR,
+    title     VARCHAR,
+    authors   VARCHAR,
+    venue     VARCHAR,
+    year      INT
+);
+
+CREATE OR REPLACE TABLE DBLP_ACM_GROUND_TRUTH (
+    source_id_left   VARCHAR,   -- References DBLP_ACM_A.id
+    source_id_right  VARCHAR    -- References DBLP_ACM_B.id
+);
+```
+
+#### DBLP-Scholar
+
+```sql
+CREATE OR REPLACE TABLE DBLP_SCHOLAR_A (
+    id        VARCHAR,
+    title     VARCHAR,
+    authors   VARCHAR,
+    venue     VARCHAR,
+    year      INT
+);
+
+CREATE OR REPLACE TABLE DBLP_SCHOLAR_B (
+    id        VARCHAR,
+    title     VARCHAR,
+    authors   VARCHAR,
+    venue     VARCHAR,
+    year      INT
+);
+
+CREATE OR REPLACE TABLE DBLP_SCHOLAR_GROUND_TRUTH (
+    source_id_left   VARCHAR,
+    source_id_right  VARCHAR
+);
+```
+
+#### Walmart-Amazon
+
+```sql
+CREATE OR REPLACE TABLE WALMART_AMAZON_A (
+    id        VARCHAR,
+    title     VARCHAR,
+    category  VARCHAR,
+    brand     VARCHAR,
+    modelno   VARCHAR,
+    price     FLOAT
+);
+
+CREATE OR REPLACE TABLE WALMART_AMAZON_B (
+    id        VARCHAR,
+    title     VARCHAR,
+    category  VARCHAR,
+    brand     VARCHAR,
+    modelno   VARCHAR,
+    price     FLOAT
+);
+
+CREATE OR REPLACE TABLE WALMART_AMAZON_GROUND_TRUTH (
+    source_id_left   VARCHAR,
+    source_id_right  VARCHAR
+);
+```
+
+#### Amazon-Google
+
+```sql
+CREATE OR REPLACE TABLE AMAZON_GOOGLE_A (
+    id            VARCHAR,
+    title         VARCHAR,
+    description   VARCHAR,
+    manufacturer  VARCHAR,
+    price         FLOAT
+);
+
+CREATE OR REPLACE TABLE AMAZON_GOOGLE_B (
+    id            VARCHAR,
+    title         VARCHAR,
+    description   VARCHAR,
+    manufacturer  VARCHAR,
+    price         FLOAT
+);
+
+CREATE OR REPLACE TABLE AMAZON_GOOGLE_GROUND_TRUTH (
+    source_id_left   VARCHAR,
+    source_id_right  VARCHAR
+);
+```
+
+#### Abt-Buy
+
+```sql
+CREATE OR REPLACE TABLE ABT_BUY_A (
+    id           VARCHAR,
+    name         VARCHAR,
+    description  VARCHAR,
+    price        FLOAT
+);
+
+CREATE OR REPLACE TABLE ABT_BUY_B (
+    id           VARCHAR,
+    name         VARCHAR,
+    description  VARCHAR,
+    price        FLOAT
+);
+
+CREATE OR REPLACE TABLE ABT_BUY_GROUND_TRUTH (
+    source_id_left   VARCHAR,
+    source_id_right  VARCHAR
+);
+```
+
+### 3.3 Data Loading
+
+Load from the staged CSVs:
+
+```sql
+COPY INTO DBLP_ACM_A FROM @ER_BENCHMARK_STAGE/dblp_acm/tableA.csv;
+COPY INTO DBLP_ACM_B FROM @ER_BENCHMARK_STAGE/dblp_acm/tableB.csv;
+COPY INTO DBLP_ACM_GROUND_TRUTH FROM @ER_BENCHMARK_STAGE/dblp_acm/matches.csv;
+-- Repeat for each dataset
+```
+
+### 3.4 Combined Source Table
+
+The entity-resolution skill expects a single source table with a `source_table` discriminator. Create a combined view per dataset:
+
+```sql
+-- Example for DBLP-ACM (bibliographic)
+CREATE OR REPLACE TABLE DBLP_ACM_SOURCE AS
+SELECT id AS source_id, 'dblp' AS source_table,
+       title AS raw_name, authors AS raw_authors, venue AS raw_venue, year AS raw_year
+FROM DBLP_ACM_A
+UNION ALL
+SELECT id AS source_id, 'acm' AS source_table,
+       title AS raw_name, authors AS raw_authors, venue AS raw_venue, year AS raw_year
+FROM DBLP_ACM_B;
+
+-- Example for Walmart-Amazon (product)
+CREATE OR REPLACE TABLE WALMART_AMAZON_SOURCE AS
+SELECT id AS source_id, 'walmart' AS source_table,
+       title AS raw_name, category AS raw_category, brand AS raw_brand,
+       modelno AS raw_modelno, price AS raw_price
+FROM WALMART_AMAZON_A
+UNION ALL
+SELECT id AS source_id, 'amazon' AS source_table,
+       title AS raw_name, category AS raw_category, brand AS raw_brand,
+       modelno AS raw_modelno, price AS raw_price
+FROM WALMART_AMAZON_B;
+
+-- Example for Amazon-Google (product)
+CREATE OR REPLACE TABLE AMAZON_GOOGLE_SOURCE AS
+SELECT id AS source_id, 'amazon' AS source_table,
+       title AS raw_name, description AS raw_description,
+       manufacturer AS raw_manufacturer, price AS raw_price
+FROM AMAZON_GOOGLE_A
+UNION ALL
+SELECT id AS source_id, 'google' AS source_table,
+       title AS raw_name, description AS raw_description,
+       manufacturer AS raw_manufacturer, price AS raw_price
+FROM AMAZON_GOOGLE_B;
+
+-- Example for Abt-Buy (e-commerce)
+CREATE OR REPLACE TABLE ABT_BUY_SOURCE AS
+SELECT id AS source_id, 'abt' AS source_table,
+       name AS raw_name, description AS raw_description, price AS raw_price
+FROM ABT_BUY_A
+UNION ALL
+SELECT id AS source_id, 'buy' AS source_table,
+       name AS raw_name, description AS raw_description, price AS raw_price
+FROM ABT_BUY_B;
+
+-- DBLP-Scholar follows the same pattern as DBLP-ACM
+CREATE OR REPLACE TABLE DBLP_SCHOLAR_SOURCE AS
+SELECT id AS source_id, 'dblp' AS source_table,
+       title AS raw_name, authors AS raw_authors, venue AS raw_venue, year AS raw_year
+FROM DBLP_SCHOLAR_A
+UNION ALL
+SELECT id AS source_id, 'scholar' AS source_table,
+       title AS raw_name, authors AS raw_authors, venue AS raw_venue, year AS raw_year
+FROM DBLP_SCHOLAR_B;
+```
+
+### 3.5 Train/Test Split
+
+Split ground truth 70/30 using a deterministic hash for reproducibility:
+
+```sql
+-- Template: replace <DATASET> with the dataset name
+CREATE OR REPLACE TABLE <DATASET>_GT_TRAIN AS
+SELECT * FROM <DATASET>_GROUND_TRUTH
+WHERE ABS(HASH(source_id_left || '|' || source_id_right)) % 100 < 70;
+
+CREATE OR REPLACE TABLE <DATASET>_GT_TEST AS
+SELECT * FROM <DATASET>_GROUND_TRUTH
+WHERE ABS(HASH(source_id_left || '|' || source_id_right)) % 100 >= 70;
+```
+
+Verify split proportions:
+
+```sql
+SELECT
+    'train' AS split, COUNT(*) AS pairs FROM <DATASET>_GT_TRAIN
+UNION ALL
+SELECT
+    'test' AS split, COUNT(*) AS pairs FROM <DATASET>_GT_TEST;
+```
+
+**Split purpose:**
+- `GT_TRAIN` — Used ONLY by contrastive embeddings (Phase 4c) as supervised training signal
+- `GT_TEST` — Used by ALL techniques for evaluation (precision/recall/F1)
+
+Non-contrastive techniques (Fuzzy, AI-Judged) are unsupervised and never see any ground truth during execution.
+
+---
+
+## 4. Technique-Dataset Matrix
+
+Every applicable technique is benchmarked on every dataset.
+
+| Technique | Phase | DBLP-ACM | DBLP-Scholar | Walmart-Amazon | Amazon-Google | Abt-Buy |
+|-----------|-------|----------|--------------|---------------|--------------|---------|
+| Deterministic (Tier 1) | 4 | N/A | N/A | N/A | N/A | N/A |
+| Fuzzy Embedding (Tier 2) | 4 | yes | yes | yes | yes | yes |
+| AI-Judged (Tier 3) | 4 | yes | yes | yes | yes | yes |
+| Contrastive Embeddings | 4c | yes | yes | yes | yes | yes |
+| Full Pipeline (Tier 2 → 3) | 4 | yes | yes | yes | yes | yes |
+| Agentic (Tier 1→1.5→2) | 4b | N/A | N/A | N/A | N/A | N/A |
+
+**Why N/A for Deterministic:** These academic datasets contain no authoritative identifiers (NPI, DUNS, GTIN, etc.). All matching is attribute-based.
+
+**Why N/A for Agentic:** Phase 4b requires a reference corpus + Cortex Search Service. These benchmarks are symmetric cross-source matching tasks, not entity linking against a reference.
+
+### Contrastive Model Selection
+
+| Dataset | Language | Recommended Model | NER Mode | Rationale |
+|---------|----------|-------------------|----------|-----------|
+| DBLP-ACM | English | `roberta-base` | `none` | English bibliographic; best known F1=0.9904 |
+| DBLP-Scholar | English | `roberta-base` | `none` | Same domain as DBLP-ACM |
+| Walmart-Amazon | English | `roberta-base` | `none` | English product data; NER is neutral (see contrastive benchmarks) |
+| Amazon-Google | English | `roberta-base` | `none` | English product data |
+| Abt-Buy | English | `roberta-base` | `none` | English e-commerce |
+
+All datasets are English-only, so `roberta-base` without NER is the recommended encoder per the model selection logic in `references/templates/contrastive-embeddings.md`.
+
+---
+
+## 5. Per-Benchmark Test Protocols
+
+### 5.1 CoCo Prompt Templates
+
+Each benchmark test invokes the skill via `cortex -p` with a structured prompt. The prompt bypasses Phase 0 discovery by providing all answers inline.
+
+#### Single-Technique Prompt (Fuzzy Only)
+
+```
+I need to run entity resolution on the table {db}.{schema}.DBLP_ACM_SOURCE.
+This is a bibliographic dataset with columns: source_id, source_table, raw_name,
+raw_authors, raw_venue, raw_year. No authoritative identifiers.
+Use the generic domain profile.
+
+IMPORTANT: Use ONLY Tier 2 fuzzy matching (AI_EMBED + Jaro-Winkler similarity).
+Do NOT use Tier 3 AI-judged classification. Do NOT use contrastive embeddings.
+
+Write all output tables (normalized_entities, candidate_pairs, match_results,
+entity_groups) to the schema {db}.{schema}.
+
+Use table name prefix DBLP_ACM_FUZZY_ for all output tables.
+```
+
+#### Single-Technique Prompt (AI-Judged Only)
+
+```
+I need to run entity resolution on the table {db}.{schema}.DBLP_ACM_SOURCE.
+This is a bibliographic dataset with columns: source_id, source_table, raw_name,
+raw_authors, raw_venue, raw_year. No authoritative identifiers.
+Use the generic domain profile.
+
+Run the full Tier 2 + Tier 3 matching pipeline:
+- Tier 2: AI_EMBED + Jaro-Winkler for initial scoring
+- Tier 3: AI_CLASSIFY on all probable_match results from Tier 2
+
+Write all output tables to {db}.{schema} with prefix DBLP_ACM_AIJUDGED_.
+```
+
+#### Single-Technique Prompt (Contrastive Embeddings)
+
+```
+I need to run entity resolution on the table {db}.{schema}.DBLP_ACM_SOURCE.
+This is a bibliographic dataset with columns: source_id, source_table, raw_name,
+raw_authors, raw_venue, raw_year. No authoritative identifiers.
+Use the generic domain profile.
+
+Use contrastive embeddings as the SOLE matching approach (Phase 4c standalone mode).
+Ground truth training pairs are in {db}.{schema}.DBLP_ACM_GT_TRAIN (columns:
+source_id_left, source_id_right).
+Use roberta-base encoder with NER disabled.
+GPU compute pool: <COMPUTE_POOL_NAME>
+
+Write all output tables to {db}.{schema} with prefix DBLP_ACM_CONTRASTIVE_.
+```
+
+#### Full Pipeline Prompt
+
+```
+I need to run entity resolution on the table {db}.{schema}.DBLP_ACM_SOURCE.
+This is a bibliographic dataset with columns: source_id, source_table, raw_name,
+raw_authors, raw_venue, raw_year. No authoritative identifiers.
+Use the generic domain profile.
+
+Run the FULL matching pipeline:
+- Tier 2: Fuzzy (AI_EMBED + Jaro-Winkler)
+- Tier 3: AI-judged on probable_match results
+
+Write all output tables to {db}.{schema} with prefix DBLP_ACM_FULL_.
+```
+
+### 5.2 Dataset-Specific Column Mappings
+
+The prompt must map each dataset's columns to the skill's expected format. The skill's normalization phase adapts to whatever columns are present.
+
+| Dataset | raw_name maps to | Additional columns |
+|---------|-----------------|-------------------|
+| DBLP-ACM | `title` | `raw_authors`, `raw_venue`, `raw_year` |
+| DBLP-Scholar | `title` | `raw_authors`, `raw_venue`, `raw_year` |
+| Walmart-Amazon | `title` | `raw_category`, `raw_brand`, `raw_modelno`, `raw_price` |
+| Amazon-Google | `title` | `raw_description`, `raw_manufacturer`, `raw_price` |
+| Abt-Buy | `name` | `raw_description`, `raw_price` |
+
+### 5.3 Expected Output Tables
+
+Each technique run produces a set of output tables with a technique-specific prefix:
+
+| Table | Purpose | Key Columns |
+|-------|---------|-------------|
+| `<PREFIX>NORMALIZED_ENTITIES` | Standardized entity fields | `SOURCE_ID`, `NORMALIZED_NAME`, ... |
+| `<PREFIX>CANDIDATE_PAIRS` | Blocked candidate pairs | `ID_LEFT`, `ID_RIGHT` |
+| `<PREFIX>MATCH_RESULTS` | Final match decisions | `ID_LEFT`, `ID_RIGHT`, `DECISION`, `CONFIDENCE`, `MATCH_METHOD` |
+| `<PREFIX>ENTITY_GROUPS` | Transitive closure groups | `ENTITY_ID`, `ENTITY_GROUP_ID` |
+
+Contrastive runs additionally produce:
+
+| Table | Purpose |
+|-------|---------|
+| `<PREFIX>CONTRASTIVE_EMBEDDINGS` | Trained embeddings per entity |
+| `<PREFIX>BLOCKING_CANDIDATES` | Cosine similarity pairs |
+| `<PREFIX>THRESHOLD_RESULTS` | Threshold sweep with P/R/F1 |
+| `<PREFIX>PREDICTED_MATCHES` | Matches at optimal threshold |
+
+---
+
+## 6. Evaluation Framework
+
+### 6.1 Core Evaluation Query
+
+Compute precision, recall, and F1 for any technique's match results against the held-out test set:
+
+```sql
+WITH predicted_matches AS (
+    -- Normalize pair ordering for consistent join
+    SELECT
+        LEAST(ID_LEFT, ID_RIGHT) AS id_a,
+        GREATEST(ID_LEFT, ID_RIGHT) AS id_b
+    FROM <PREFIX>MATCH_RESULTS
+    WHERE DECISION = 'match'
+),
+ground_truth AS (
+    SELECT
+        LEAST(SOURCE_ID_LEFT, SOURCE_ID_RIGHT) AS id_a,
+        GREATEST(SOURCE_ID_LEFT, SOURCE_ID_RIGHT) AS id_b
+    FROM <DATASET>_GT_TEST
+),
+metrics AS (
+    SELECT
+        (SELECT COUNT(*) FROM predicted_matches p
+         INNER JOIN ground_truth g ON p.id_a = g.id_a AND p.id_b = g.id_b) AS tp,
+        (SELECT COUNT(*) FROM predicted_matches p
+         LEFT JOIN ground_truth g ON p.id_a = g.id_a AND p.id_b = g.id_b
+         WHERE g.id_a IS NULL) AS fp,
+        (SELECT COUNT(*) FROM ground_truth g
+         LEFT JOIN predicted_matches p ON g.id_a = p.id_a AND g.id_b = p.id_b
+         WHERE p.id_a IS NULL) AS fn
+)
+SELECT
+    tp, fp, fn,
+    ROUND(tp / NULLIF(tp + fp, 0), 4) AS precision,
+    ROUND(tp / NULLIF(tp + fn, 0), 4) AS recall,
+    ROUND(2.0 * (tp / NULLIF(tp + fp, 0)) * (tp / NULLIF(tp + fn, 0))
+        / NULLIF((tp / NULLIF(tp + fp, 0)) + (tp / NULLIF(tp + fn, 0)), 0), 4) AS f1
+FROM metrics;
+```
+
+### 6.2 Per-Technique Evaluation
+
+For the full pipeline, also break down by match method:
+
+```sql
+SELECT
+    MATCH_METHOD,
+    COUNT(*) AS total_decisions,
+    SUM(CASE WHEN DECISION = 'match' THEN 1 ELSE 0 END) AS matches,
+    SUM(CASE WHEN DECISION = 'probable_match' THEN 1 ELSE 0 END) AS probable,
+    SUM(CASE WHEN DECISION = 'no_match' THEN 1 ELSE 0 END) AS no_match
+FROM <PREFIX>MATCH_RESULTS
+GROUP BY MATCH_METHOD
+ORDER BY MATCH_METHOD;
+```
+
+### 6.3 Contrastive Threshold Sweep Evaluation
+
+For contrastive embeddings, evaluate across the full threshold sweep against the test set (not the training set):
+
+```sql
+-- Adapt the threshold sweep from contrastive-embeddings.md Section 5
+-- Replace ground_truth with <DATASET>_GT_TEST
+CREATE OR REPLACE TABLE <PREFIX>THRESHOLD_EVAL AS
+WITH thresholds AS (
+    SELECT column1 AS threshold FROM VALUES
+        (0.50),(0.55),(0.60),(0.65),(0.70),(0.72),(0.74),(0.76),
+        (0.78),(0.80),(0.82),(0.84),(0.86),(0.88),(0.90),(0.92),(0.94),(0.96)
+),
+test_gt AS (
+    SELECT
+        LEAST(SOURCE_ID_LEFT, SOURCE_ID_RIGHT) AS id_a,
+        GREATEST(SOURCE_ID_LEFT, SOURCE_ID_RIGHT) AS id_b
+    FROM <DATASET>_GT_TEST
+),
+predictions AS (
+    SELECT
+        t.threshold,
+        LEAST(bc.ID_LEFT, bc.ID_RIGHT) AS id_a,
+        GREATEST(bc.ID_LEFT, bc.ID_RIGHT) AS id_b
+    FROM thresholds t
+    CROSS JOIN <PREFIX>BLOCKING_CANDIDATES bc
+    WHERE bc.COSINE_SIM >= t.threshold
+),
+metrics AS (
+    SELECT
+        p.threshold,
+        COUNT(DISTINCT CASE WHEN g.id_a IS NOT NULL
+              THEN p.id_a || '|' || p.id_b END) AS tp,
+        COUNT(DISTINCT CASE WHEN g.id_a IS NULL
+              THEN p.id_a || '|' || p.id_b END) AS fp,
+        (SELECT COUNT(*) FROM test_gt)
+            - COUNT(DISTINCT CASE WHEN g.id_a IS NOT NULL
+              THEN p.id_a || '|' || p.id_b END) AS fn
+    FROM predictions p
+    LEFT JOIN test_gt g ON p.id_a = g.id_a AND p.id_b = g.id_b
+    GROUP BY p.threshold
+)
+SELECT
+    threshold, tp, fp, fn,
+    ROUND(tp / NULLIF(tp + fp, 0), 4) AS precision,
+    ROUND(tp / NULLIF(tp + fn, 0), 4) AS recall,
+    ROUND(2.0 * (tp / NULLIF(tp + fp, 0)) * (tp / NULLIF(tp + fn, 0))
+        / NULLIF((tp / NULLIF(tp + fp, 0)) + (tp / NULLIF(tp + fn, 0)), 0), 4) AS f1
+FROM metrics
+ORDER BY threshold;
+```
+
+### 6.4 Cross-Technique Comparison Report
+
+After running all techniques on a dataset, produce a comparison table:
+
+```sql
+-- Collect results from each technique's evaluation into a summary
+SELECT 'Fuzzy (Tier 2)' AS technique, precision, recall, f1
+FROM <DATASET>_FUZZY_EVAL
+UNION ALL
+SELECT 'AI-Judged (Tier 2+3)', precision, recall, f1
+FROM <DATASET>_AIJUDGED_EVAL
+UNION ALL
+SELECT 'Contrastive', precision, recall, f1
+FROM <DATASET>_CONTRASTIVE_EVAL
+UNION ALL
+SELECT 'Full Pipeline', precision, recall, f1
+FROM <DATASET>_FULL_EVAL
+ORDER BY f1 DESC;
+```
+
+---
+
+## 7. Expected Results & Baselines
+
+### 7.1 Known Contrastive Baselines
+
+From the existing 10-experiment ablation study (`skill_evidence.yaml`):
+
+| Dataset | Model | NER | F1 | Precision | Recall |
+|---------|-------|-----|-----|-----------|--------|
+| DBLP-ACM | RoBERTa-base | none | **0.9904** | 0.982 | 0.999 |
+| DBLP-ACM | XLM-RoBERTa-base | ditto-general | 0.9818 | 0.970 | 0.994 |
+| DBLP-ACM | MiniLM-L6-v2 | none | 0.9797 | 0.970 | 0.990 |
+| Walmart-Amazon | RoBERTa-base | none | **0.8701** | 0.795 | 0.961 |
+| Walmart-Amazon | XLM-RoBERTa-base | ditto-product | 0.8556 | 0.830 | 0.883 |
+| Walmart-Amazon | MiniLM-L6-v2 | none | 0.7706 | 0.692 | 0.752 |
+
+### 7.2 Expected Ranges for Other Techniques
+
+These are expected ranges based on the characteristics of each technique and dataset. Actual results will vary.
+
+| Dataset | Fuzzy (Tier 2) | AI-Judged (Tier 2+3) | Contrastive | Full Pipeline |
+|---------|---------------|---------------------|------------|---------------|
+| DBLP-ACM | F1 0.85-0.95 | F1 0.90-0.97 | F1 0.97-0.99 | F1 0.90-0.97 |
+| DBLP-Scholar | F1 0.70-0.85 | F1 0.80-0.90 | F1 0.90-0.97 | F1 0.80-0.92 |
+| Walmart-Amazon | F1 0.50-0.70 | F1 0.65-0.80 | F1 0.85-0.90 | F1 0.65-0.82 |
+| Amazon-Google | F1 0.45-0.65 | F1 0.60-0.75 | F1 0.80-0.88 | F1 0.60-0.78 |
+| Abt-Buy | F1 0.55-0.70 | F1 0.65-0.80 | F1 0.82-0.90 | F1 0.65-0.82 |
+
+**Key expectations:**
+1. Contrastive embeddings should outperform all other techniques on every dataset (supervised advantage)
+2. AI-Judged should beat Fuzzy-only (LLM reasoning resolves ambiguous pairs)
+3. Full Pipeline should approximate AI-Judged (Tier 3 upgrades probable_match results)
+4. The gap between Contrastive and others should be largest on hard/noisy datasets (Walmart-Amazon, Amazon-Google)
+
+### 7.3 Minimum Quality Gates
+
+A benchmark run **passes** if:
+
+| Dataset | Technique | Minimum F1 |
+|---------|-----------|-----------|
+| DBLP-ACM | Fuzzy | 0.80 |
+| DBLP-ACM | Contrastive | 0.95 |
+| DBLP-ACM | Full Pipeline | 0.85 |
+| Walmart-Amazon | Fuzzy | 0.45 |
+| Walmart-Amazon | Contrastive | 0.80 |
+| Walmart-Amazon | Full Pipeline | 0.60 |
+
+Other dataset/technique combinations: F1 > 0.40 (sanity floor). These gates are intentionally conservative — they catch regressions, not aspirational targets.
+
+---
+
+## 8. Test Execution Guide
+
+### 8.1 Prerequisites
+
+| Requirement | Needed For | Notes |
+|-------------|-----------|-------|
+| Snowflake account + warehouse | All | MEDIUM warehouse recommended |
+| Cortex Code CLI (`cortex`) | Phase 2 (invoke) | Latest version |
+| GPU compute pool (`GPU_NV_S`) | Contrastive only | NVIDIA T4 sufficient |
+| External access integrations | Contrastive only | `PYPI_EAI`, `HF_EAI` |
+| Benchmark CSV files staged | Phase 1 (setup) | See Section 3 |
+
+### 8.2 Environment Variables
+
+```bash
+export SNOWFLAKE_ACCOUNT=...
+export SNOWFLAKE_USER=...
+export SNOWFLAKE_PASSWORD=...
+export SNOWFLAKE_WAREHOUSE=COMPUTE_WH
+export SNOWFLAKE_DATABASE=ENTITY_RESOLUTION_TEST
+export SNOWFLAKE_ROLE=...
+export CORTEX_CONNECTION=demoaccount
+# For contrastive benchmarks:
+export ER_COMPUTE_POOL=GPU_NV_S_POOL
+```
+
+### 8.3 Running Benchmarks
+
+#### Pytest Markers
+
+Benchmarks use dedicated markers that are separate from the functional test markers:
+
+```
+benchmark          — All benchmark tests
+bench_dblp_acm     — DBLP-ACM dataset
+bench_dblp_scholar — DBLP-Scholar dataset
+bench_walmart_amazon — Walmart-Amazon dataset
+bench_amazon_google — Amazon-Google dataset
+bench_abt_buy      — Abt-Buy dataset
+```
+
+#### Makefile Targets
+
+```bash
+# Phase 1: Load benchmark data into Snowflake
+make bench-setup-dblp-acm
+make bench-setup-all
+
+# Phase 2: Invoke skill (one technique at a time)
+make bench-invoke-dblp-acm-fuzzy
+make bench-invoke-dblp-acm-contrastive
+make bench-invoke-dblp-acm-full
+make bench-invoke-dblp-acm-all       # All techniques for DBLP-ACM
+
+# Phase 3: Evaluate results
+make bench-validate-dblp-acm
+make bench-validate-all
+
+# Full run (all 3 phases, all datasets, all techniques)
+make bench-all
+```
+
+#### Running a Single Dataset End-to-End
+
+```bash
+# Setup → Invoke (all techniques) → Validate
+make bench-dblp-acm
+```
+
+#### Running All Benchmarks
+
+```bash
+make bench-all
+```
+
+**Estimated wall-clock time:**
+
+| Component | Time per Dataset | Notes |
+|-----------|-----------------|-------|
+| Setup (data load) | 1-5 min | Depends on dataset size |
+| Fuzzy invoke | 5-15 min | Embedding generation is the bottleneck |
+| AI-Judged invoke | 10-30 min | LLM calls on probable matches |
+| Contrastive invoke | 15-45 min | GPU training + embedding + sweep |
+| Full Pipeline invoke | 10-30 min | Tier 2 + Tier 3 cascade |
+| Validation | 1-2 min | SQL evaluation queries only |
+
+Total for all 5 datasets × 4 techniques: approximately 3-8 hours.
+
+### 8.4 Test File Structure
+
+```
+src/tests/
+├── conftest.py                          # Shared fixtures (existing)
+├── fixtures/
+│   ├── benchmark_dblp_acm.sql           # Schema + data load for DBLP-ACM
+│   ├── benchmark_dblp_scholar.sql       # Schema + data load for DBLP-Scholar
+│   ├── benchmark_walmart_amazon.sql     # Schema + data load for Walmart-Amazon
+│   ├── benchmark_amazon_google.sql      # Schema + data load for Amazon-Google
+│   └── benchmark_abt_buy.sql           # Schema + data load for Abt-Buy
+├── phase1_setup/
+│   ├── test_setup_bench_dblp_acm.py
+│   ├── test_setup_bench_dblp_scholar.py
+│   ├── test_setup_bench_walmart_amazon.py
+│   ├── test_setup_bench_amazon_google.py
+│   └── test_setup_bench_abt_buy.py
+├── phase2_invoke/
+│   ├── test_invoke_bench_dblp_acm.py    # Invokes all 4 techniques
+│   ├── test_invoke_bench_dblp_scholar.py
+│   ├── test_invoke_bench_walmart_amazon.py
+│   ├── test_invoke_bench_amazon_google.py
+│   └── test_invoke_bench_abt_buy.py
+└── phase3_validate/
+    ├── test_validate_bench_dblp_acm.py  # Evaluates all techniques
+    ├── test_validate_bench_dblp_scholar.py
+    ├── test_validate_bench_walmart_amazon.py
+    ├── test_validate_bench_amazon_google.py
+    └── test_validate_bench_abt_buy.py
+```
+
+---
+
+## 9. Updating skill_evidence.yaml
+
+After running benchmarks, update `skill_evidence.yaml` with new evidence entries:
+
+```yaml
+evidence_links:
+  # ... existing contrastive experiment entries ...
+
+  # Benchmark integration tests
+  - description: 'Benchmark: DBLP-ACM Full Pipeline (F1=X.XXXX)'
+    type: benchmark
+    schema: ER_BENCHMARK.BENCH_DBLP_ACM
+  - description: 'Benchmark: DBLP-ACM Fuzzy-only (F1=X.XXXX)'
+    type: benchmark
+    schema: ER_BENCHMARK.BENCH_DBLP_ACM_FUZZY
+  - description: 'Benchmark: Walmart-Amazon Full Pipeline (F1=X.XXXX)'
+    type: benchmark
+    schema: ER_BENCHMARK.BENCH_WALMART_AMAZON
+  # ... etc for each dataset × technique ...
+```
+
+Each benchmark run should also produce a comparison view:
+
+```sql
+CREATE OR REPLACE VIEW BENCHMARK_COMPARISON AS
+SELECT
+    '<DATASET>' AS dataset,
+    '<TECHNIQUE>' AS technique,
+    precision, recall, f1,
+    CURRENT_TIMESTAMP() AS run_timestamp
+FROM <DATASET>_<TECHNIQUE>_EVAL
+-- UNION ALL for each dataset × technique combination
+ORDER BY dataset, f1 DESC;
+```
+
+This view provides a single-query summary of all benchmark results for evidence and reporting.

--- a/skills/entity-resolution/LICENSE
+++ b/skills/entity-resolution/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/entity-resolution/SKILL.md
+++ b/skills/entity-resolution/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: entity-resolution
+title: Resolve Entities
+summary: End-to-end entity resolution pipeline using Snowflake Cortex AI Functions to match, link, and dedupe records.
+description: Use when you need to match records across datasets, deduplicate within a dataset, build a golden record, or link source records to a reference corpus. Orchestrates profiling, normalization, blocking, multi-tier matching (deterministic, fuzzy, AI-judged, agentic, contrastive), human review, and operationalization via dynamic tables. Industry-agnostic with optional domain profiles for pharma, financial services, retail/CPG, healthcare, and insurance. Triggers: entity resolution, record matching, deduplication, record linkage, fuzzy matching, golden record, master data, MDM, merge records, match entities, link records, dedupe, duplicate detection, identity resolution.
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+prompt: Help me resolve entities across my customer and prospect tables.
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+# Resolve Entities
+
+## Overview
+
+Determine whether records refer to the same real-world entity. This skill orchestrates Cortex AI Functions, dynamic tables, Streamlit, and optionally Cortex Agents and Snowflake ML through a structured pipeline: profile → normalize → block → match → score → review → operationalize.
+
+Two workflow paths:
+
+- **Path A — Pair-Based Matching (Deduplication / Cross-Match):** generate candidate pairs via blocking, score through 3 tiers.
+- **Path B — Agentic Matching (Entity Linking):** resolve source records against a reference corpus via tiered escalation.
+
+Optional add-on:
+
+- **Contrastive Embeddings:** train a domain-adapted encoder via SupConLoss when labeled data and GPU compute are available.
+
+## When to Use
+
+- Match or link records across datasets
+- Deduplicate records within a single dataset
+- Build a golden record from multiple sources
+- Assess match-readiness of source data
+- Operationalize an ongoing matching pipeline
+
+For unstructured inputs (PDFs, scans), call `cortex-ai-functions` (`AI_EXTRACT`, `AI_PARSE_DOCUMENT`) first, then feed structured output here.
+
+## Domain Profiles
+
+Load the matching profile from `references/profiles/`:
+
+| Keywords | Profile | Tier 1 IDs |
+|---|---|---|
+| pharma, NPI, DEA, NCPDP | `pharma.md` | NPI, DEA, NCPDP |
+| bank, KYC, AML, LEI | `financial-services.md` | LEI, DUNS, Tax ID, CRD |
+| retail, CPG, GTIN, UPC | `retail-cpg.md` | GTIN/UPC, GLN, Supplier ID |
+| provider, hospital, taxonomy | `healthcare-provider.md` | NPI, Taxonomy Code |
+| insurance, payer, NAIC | `insurance-payer.md` | NAIC, CMS Payer ID, Plan ID |
+| *(none)* | `generic.md` | Name + address only |
+
+## Workflow
+
+### Step 0: Discovery
+
+Use `ask_user_question` to collect: goal (dedupe / cross-match / link to reference / profile-only), domain, source and reference tables, volume, output schema, HITL preference, pipeline cadence (one-time vs ongoing), data language, and approach (recommended / specific / benchmark multiple). Present a discovery summary.
+
+⚠️ STOPPING POINT: User confirms the summary before any work begins.
+
+### Step 1: Profiling
+
+Delegate to `profiling-tables`. ER-specific checks:
+
+1. Identifier detection from the loaded domain profile (Tier 1 candidates)
+2. Name/address column detection via `AI_CLASSIFY`
+3. Completeness, format consistency, duplicate density, volume
+
+⚠️ STOPPING POINT: Present profiling report and match-readiness checklist.
+
+### Step 1b: Cost Estimation
+
+Load `references/templates/cost-estimator.md`. Estimate based on volume, path, expected tier distribution, and warehouse sizing.
+
+⚠️ STOPPING POINT: User acknowledges and accepts the estimate.
+
+### Step 2: Normalization
+
+Delegate to `cortex-ai-functions` for `AI_EXTRACT` (address parsing) and `AI_COMPLETE` (edge-case names). Load `references/templates/normalization.md`. Materialize `normalized_entities` with `source_id`, normalized fields, raw originals, and `blocking_key`.
+
+⚠️ STOPPING POINT: Validate 10–20 sample rows, NULL counts per normalized field, and identifier format compliance.
+
+### Step 3: Blocking
+
+Load `references/templates/blocking.md`. Reduce O(n²) pair space via blocking keys (geographic, category, phonetic, or ID prefix). Self-join within blocks: `a.source_id < b.source_id`.
+
+⚠️ STOPPING POINT: Review blocking statistics. Red flags: any block > 100K pairs, reduction ratio > 10%, or very few pairs.
+
+### Step 4: Multi-Tier Matching (Path A)
+
+Load `references/templates/matching.md`.
+
+- **Tier 1 — Deterministic:** exact match on authoritative IDs. Pure SQL, no AI cost.
+- **Tier 2 — Fuzzy:** `AI_EMBED` (`snowflake-arctic-embed-l-v2.0`) + `VECTOR_COSINE_SIMILARITY`, supplemented by `JAROWINKLER_SIMILARITY` on name/street. Starting thresholds: ≥ 0.92 match, ≥ 0.80 probable_match, < 0.80 no_match.
+- **Tier 3 — AI-Judged:** `AI_CLASSIFY` on Tier 2 `probable_match` rows only (cost control).
+
+Resolve transitive matches and assign `entity_group_id` to connected components.
+
+⚠️ STOPPING POINT: Review counts by tier and decision, sample rows, and threshold tuning (adjust in 0.02–0.03 increments against a labeled sample).
+
+### Step 4b: Agentic Matching (Path B)
+
+Load `references/templates/agentic-matching.md`. Prerequisites: normalized entities, embeddings on source and reference, top-N candidates, Cortex Search Service over the reference corpus (`references/templates/search-service.md`), and a semantic model YAML.
+
+- **Tier 1 — High-Confidence Triage:** cosine + Jaro-Winkler with domain guards (chain stores, multi-tenant buildings, address floor).
+- **Tier 1.5 — Search + Classify:** Cortex Search top-N then `AI_COMPLETE` (cost-effective model). Confidence ≥ 0.80 + name/address alignment.
+- **Tier 2 — Cortex Agent:** 3 tools — `cortex_search` (primary), `cortex_analyst_text_to_sql` (fallback), `web_search` (last resort). Budget: 6 tool calls, 90s, 16K tokens per entity. See `references/templates/agent-definition.md` and `references/templates/orchestration.md`. Delegate to `cortex-agent`.
+
+UNION ALL all tiers into a crosswalk with tier attribution. Records entities confirmed active but missing from the reference corpus as discoveries.
+
+⚠️ STOPPING POINT: Review per-tier match/closure/discovery distributions and web search usage.
+
+### Step 4c: Contrastive Embeddings (Standalone or Tier 2 Replacement)
+
+Load `references/templates/contrastive-embeddings.md`. Prerequisites: ≥ 500 labeled entities across ≥ 200 clusters, GPU pool (`GPU_NV_S`), `PYPI_EAI` and `HF_EAI` external access integrations.
+
+1. **Model selection:** English-only → `roberta-base` (NER off); multilingual → `xlm-roberta-base` (NER on); resource-constrained → `all-MiniLM-L6-v2`.
+2. **Serialize** entities with `[COL]/[VAL]` tokens; derive cluster IDs via Union-Find.
+3. **Train** via stored procedure on the GPU pool — delegate to `machine-learning` for setup and monitoring.
+4. **Block** by cosine ≥ 0.50, run threshold sweep against ground truth, materialize matches at optimal F1.
+5. **Add-on mode:** replace `AI_EMBED` in Tier 2 of Path A; use match/no-match thresholds with escalation to Tier 3 in between.
+
+⚠️ STOPPING POINT: Review threshold sweep, optimal F1/precision/recall, and (if add-on) comparison with `AI_EMBED` Tier 2.
+
+### Step 5: Human-in-the-Loop Review
+
+Delegate to `developing-with-streamlit`. Load `references/hitl-app.md`. App requirements:
+
+- Side-by-side source vs. resolved entity with field-level match indicators
+- Accept / reject / flag with optional comment
+- Sequential nav, progress tracking
+- Decisions persisted to `REVIEW_DECISIONS`
+- Material Design CSS, no emojis, no third-party MUI
+
+⚠️ STOPPING POINT: Deploy app and wait for the review cycle to complete.
+
+### Step 6: Operationalize
+
+Load `references/operationalize.md`.
+
+1. **Dynamic tables pipeline** — delegate to `dynamic-tables` (normalize → block → match cascade)
+2. **Entity master table** — golden record view aggregating best values per `entity_group_id`
+3. **Source quality monitoring** — delegate to `data-quality`
+
+Extensions: `cortex-agent` for NL queries over match results; `machine-learning` for a custom classifier replacing or augmenting Tier 2/3.
+
+⚠️ STOPPING POINT: User approves pipeline design before creating dynamic tables.
+
+## Benchmark Mode
+
+When the user selects benchmark in Step 0, run each chosen approach on the same labeled sample (200–500 stratified pairs; if absent, deploy a lightweight HITL labeling app). Produce a comparison table of precision, recall, F1, cost ($), and latency (sec). Then ask which approach to use for the full run.
+
+## Common Mistakes
+
+- **Skipping profiling** — jumping straight to matching without identifying authoritative IDs over-relies on fuzzy tiers and inflates cost.
+- **Coarse blocking** — any block > 100K pairs explodes the comparison space; tighten keys.
+- **Skipping Tier 1** — deterministic ID matches are free and high-precision; always run them first.
+- **Sending all pairs to Tier 3** — `AI_CLASSIFY` should only see Tier 2 `probable_match` rows. `match` and `no_match` are already decided.
+- **Hardcoded thresholds** — 0.92 / 0.80 are starting points. Tune in 0.02–0.03 steps against a labeled sample.
+- **No transitive resolution** — A=B and B=C implies A=C; missing this fragments entity groups.
+- **Cosine without name check** — high cosine on short text can match unrelated entities. Supplement with `JAROWINKLER_SIMILARITY` on names and streets.
+- **Unbudgeted agents** — Cortex Agents can recurse expensively. Enforce tool-call, token, and wall-clock limits per entity.
+- **Contrastive without ground truth** — fewer than ~500 labeled entities across ~200 clusters yields unstable embeddings; fall back to `AI_EMBED`.
+- **Reusing thresholds across domains** — pharma name matching is not retail product matching; recalibrate per domain profile.
+
+## Stopping Points
+
+- Step 0 — confirm discovery summary
+- Step 1 — confirm profiling and match-readiness
+- Step 1b — accept cost estimate
+- Step 2 — validate sample normalization
+- Step 3 — confirm blocking statistics
+- Step 4 — review match results and thresholds (or benchmark comparison)
+- Step 4b — review per-tier agentic results
+- Step 4c — review contrastive threshold sweep
+- Step 5 — wait for HITL review completion
+- Step 6 — approve pipeline design before operationalizing
+
+## Output
+
+- Discovery summary, profiling report, normalized entities table
+- Candidate pairs with blocking diagnostics (Path A) or top-N candidates (Path B)
+- Match results with confidence, tier attribution, `entity_group_id`
+- Crosswalk and entity discoveries (Path B)
+- Contrastive embeddings table and threshold sweep (Step 4c)
+- Benchmark comparison report (benchmark mode)
+- Streamlit review app (if HITL selected)
+- Dynamic tables pipeline and entity master table (if ongoing)
+
+## References
+
+See `references/profiles/` for domain profiles and `references/templates/` for SQL patterns: `normalization.md`, `blocking.md`, `matching.md`, `agentic-matching.md`, `search-service.md`, `agent-definition.md`, `orchestration.md`, `contrastive-embeddings.md`, `cost-estimator.md`, `incremental.md`. App spec: `references/hitl-app.md`. Operationalization: `references/operationalize.md`.

--- a/skills/entity-resolution/er_hitl_review.py
+++ b/skills/entity-resolution/er_hitl_review.py
@@ -1,0 +1,590 @@
+"""
+Entity Resolution HITL Review App
+Joins MATCH_RESULTS with NORMALIZED_ENTITIES for side-by-side comparison.
+Writes decisions to REVIEW_DECISIONS via MERGE.
+Deployed to Snowflake Streamlit in Snowflake (SiS).
+"""
+import streamlit as st
+import streamlit.components.v1 as components
+from snowflake.snowpark.context import get_active_session
+
+st.set_page_config(page_title="Entity Resolution Review", layout="wide")
+
+session = get_active_session()
+
+DB_SCHEMA = "ER_SKILL_TEST_DB1.NPI"
+MATCH_TABLE = f"{DB_SCHEMA}.MATCH_RESULTS"
+NORM_TABLE = f"{DB_SCHEMA}.NORMALIZED_ENTITIES"
+DECISIONS_TABLE = f"{DB_SCHEMA}.REVIEW_DECISIONS"
+SOURCE_TABLE_NAME = MATCH_TABLE
+
+# ── Material Design CSS ──────────────────────────────────────────────────────
+
+st.markdown("""<style>
+/* Remove default Streamlit top padding */
+.stApp > header { display: none; }
+div[data-testid="stAppViewContainer"] > div:first-child { padding-top: 0; }
+.block-container { padding-top: 1rem !important; }
+.stApp { margin-top: -2rem; }
+
+/* Material Design typography */
+.stApp {
+    font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* Material chip styles */
+.chip-accept {
+    background-color: #C8E6C9; color: #2E7D32;
+    padding: 4px 12px; border-radius: 16px; font-size: 13px; font-weight: 500; display: inline-block;
+}
+.chip-reject {
+    background-color: #FFCDD2; color: #C62828;
+    padding: 4px 12px; border-radius: 16px; font-size: 13px; font-weight: 500; display: inline-block;
+}
+.chip-flag {
+    background-color: #FFE0B2; color: #E65100;
+    padding: 4px 12px; border-radius: 16px; font-size: 13px; font-weight: 500; display: inline-block;
+}
+.chip-exact {
+    background-color: #C8E6C9; color: #2E7D32;
+    padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 500;
+}
+.chip-similar {
+    background-color: #FFE0B2; color: #E65100;
+    padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 500;
+}
+.chip-different {
+    background-color: #FFCDD2; color: #C62828;
+    padding: 2px 8px; border-radius: 12px; font-size: 11px; font-weight: 500;
+}
+
+/* Signal card styles (uniform small font) */
+.signal-card {
+    display: inline-block; background: #F5F5F5; border-radius: 8px;
+    padding: 6px 14px; margin-right: 8px; text-align: center;
+}
+.signal-label {
+    display: block; font-size: 11px; font-weight: 500; color: #757575;
+    text-transform: uppercase; letter-spacing: 0.5px;
+}
+.signal-value {
+    display: block; font-size: 13px; font-weight: 600; color: #212121;
+}
+.signal-value-green { display: block; font-size: 13px; font-weight: 600; color: #2E7D32; }
+.signal-value-amber { display: block; font-size: 13px; font-weight: 600; color: #E65100; }
+.signal-value-red { display: block; font-size: 13px; font-weight: 600; color: #C62828; }
+
+/* Reasoning card */
+.reasoning-card {
+    background: #FAFAFA; border-left: 3px solid #1976D2; border-radius: 4px;
+    padding: 10px 16px; margin: 8px 0;
+}
+.reasoning-label {
+    font-size: 11px; font-weight: 500; color: #757575;
+    text-transform: uppercase; letter-spacing: 0.5px; display: block; margin-bottom: 4px;
+}
+.reasoning-text {
+    font-size: 13px; color: #424242; line-height: 1.5; margin: 0;
+}
+
+/* Shortcut hint */
+.shortcut-hint {
+    text-align: center; font-size: 11px; color: #9E9E9E; padding: 8px 0; letter-spacing: 0.3px;
+}
+
+/* Material button overrides */
+.stButton > button {
+    border-radius: 4px; font-weight: 500; text-transform: uppercase;
+    letter-spacing: 0.5px; font-size: 13px; padding: 8px 24px; transition: box-shadow 0.2s;
+}
+.stButton > button:hover { box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
+
+/* Field comparison table */
+.cmp-table { width: 100%; border-collapse: collapse; margin: 4px 0; }
+.cmp-table th {
+    text-align: left; font-size: 12px; font-weight: 500; color: #757575;
+    text-transform: uppercase; letter-spacing: 0.5px; padding: 6px 12px;
+    border-bottom: 2px solid #E0E0E0;
+}
+.cmp-table td {
+    padding: 8px 12px; font-size: 14px; color: #212121; border-bottom: 1px solid #EEEEEE;
+}
+.cmp-table td.field-label { font-weight: 500; color: #616161; font-size: 13px; width: 120px; }
+</style>""", unsafe_allow_html=True)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def safe(val):
+    """Convert a value to display string, handling None/NaN."""
+    if val is None:
+        return ""
+    try:
+        import math
+        if math.isnan(val):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(val).strip()
+
+
+def signal_color_class(val):
+    """Return CSS class for a numeric signal value."""
+    try:
+        v = float(val)
+    except (TypeError, ValueError):
+        return "signal-value"
+    if v >= 0.85:
+        return "signal-value-green"
+    if v >= 0.70:
+        return "signal-value-amber"
+    return "signal-value-red"
+
+
+def match_chip(src_val, res_val, jw_score=None):
+    """Return HTML chip for field-level match indicator."""
+    s, r = safe(src_val).upper(), safe(res_val).upper()
+    if not s or not r:
+        return ""
+    if s == r:
+        return '<span class="chip-exact">Exact</span>'
+    if jw_score is not None:
+        try:
+            if float(jw_score) >= 0.80:
+                return '<span class="chip-similar">Similar</span>'
+        except (TypeError, ValueError):
+            pass
+    return '<span class="chip-different">Different</span>'
+
+
+# ── Data Loading ─────────────────────────────────────────────────────────────
+
+REVIEW_QUERY = f"""
+SELECT
+    m.ID_LEFT,
+    m.ID_RIGHT,
+    m.DECISION,
+    m.CONFIDENCE,
+    m.MATCH_METHOD,
+    m.COSINE_SIM,
+    m.NAME_JW,
+    m.STREET_JW,
+    m.MATCHED_ON,
+    nl.RAW_NAME        AS SRC_RAW_NAME,
+    nl.RAW_ADDRESS     AS SRC_RAW_ADDRESS,
+    nl.NORMALIZED_NAME AS SRC_NORM_NAME,
+    nl.NORMALIZED_STREET AS SRC_NORM_STREET,
+    nl.NORMALIZED_CITY AS SRC_NORM_CITY,
+    nl.NORMALIZED_STATE AS SRC_NORM_STATE,
+    nl.NORMALIZED_ZIP  AS SRC_NORM_ZIP,
+    nl.ORIGINAL_NPI    AS SRC_ORIGINAL_NPI,
+    nr.RAW_NAME        AS RES_RAW_NAME,
+    nr.RAW_ADDRESS     AS RES_RAW_ADDRESS,
+    nr.NORMALIZED_NAME AS RES_NORM_NAME,
+    nr.NORMALIZED_STREET AS RES_NORM_STREET,
+    nr.NORMALIZED_CITY AS RES_NORM_CITY,
+    nr.NORMALIZED_STATE AS RES_NORM_STATE,
+    nr.NORMALIZED_ZIP  AS RES_NORM_ZIP,
+    nr.ORIGINAL_NPI    AS RES_ORIGINAL_NPI
+FROM {MATCH_TABLE} m
+JOIN {NORM_TABLE} nl ON nl.SOURCE_ID = m.ID_LEFT
+JOIN {NORM_TABLE} nr ON nr.SOURCE_ID = m.ID_RIGHT
+LEFT JOIN {DECISIONS_TABLE} rd
+    ON rd.ID_LEFT = m.ID_LEFT AND rd.ID_RIGHT = m.ID_RIGHT
+WHERE m.DECISION = 'match'
+"""
+
+
+@st.cache_data(ttl=30)
+def load_stats():
+    """Count total matches and review status."""
+    df = session.sql(f"""
+        SELECT
+            COUNT(*) AS total,
+            SUM(CASE WHEN rd.ID_LEFT IS NULL THEN 1 ELSE 0 END) AS unreviewed,
+            SUM(CASE WHEN rd.REVIEWER_DECISION = 'accept' THEN 1 ELSE 0 END) AS accepted,
+            SUM(CASE WHEN rd.REVIEWER_DECISION = 'reject' THEN 1 ELSE 0 END) AS rejected,
+            SUM(CASE WHEN rd.REVIEWER_DECISION = 'flag' THEN 1 ELSE 0 END) AS flagged
+        FROM {MATCH_TABLE} m
+        LEFT JOIN {DECISIONS_TABLE} rd
+            ON rd.ID_LEFT = m.ID_LEFT AND rd.ID_RIGHT = m.ID_RIGHT
+        WHERE m.DECISION = 'match'
+    """).to_pandas()
+    return df.iloc[0]
+
+
+@st.cache_data(ttl=10)
+def load_unreviewed():
+    """Load unreviewed match records with entity details."""
+    return session.sql(
+        REVIEW_QUERY + "\n    AND rd.ID_LEFT IS NULL\nORDER BY m.ID_LEFT"
+    ).to_pandas()
+
+
+def save_decision(id_left, id_right, decision, comment):
+    """MERGE a review decision using parameterized queries to prevent SQL injection."""
+    session.sql(
+        f"""
+        MERGE INTO {DECISIONS_TABLE} tgt
+        USING (SELECT
+            ? AS ID_LEFT,
+            ? AS ID_RIGHT,
+            ? AS SOURCE_TABLE,
+            ? AS REVIEWER_DECISION,
+            ? AS REVIEWER_COMMENT,
+            CURRENT_USER() AS REVIEWED_BY,
+            CURRENT_TIMESTAMP() AS REVIEWED_AT
+        ) src
+        ON tgt.ID_LEFT = src.ID_LEFT AND tgt.ID_RIGHT = src.ID_RIGHT
+        WHEN MATCHED THEN UPDATE SET
+            REVIEWER_DECISION = src.REVIEWER_DECISION,
+            REVIEWER_COMMENT = src.REVIEWER_COMMENT,
+            REVIEWED_BY = src.REVIEWED_BY,
+            REVIEWED_AT = src.REVIEWED_AT
+        WHEN NOT MATCHED THEN INSERT (ID_LEFT, ID_RIGHT, SOURCE_TABLE, REVIEWER_DECISION, REVIEWER_COMMENT, REVIEWED_BY, REVIEWED_AT)
+            VALUES (src.ID_LEFT, src.ID_RIGHT, src.SOURCE_TABLE, src.REVIEWER_DECISION, src.REVIEWER_COMMENT, src.REVIEWED_BY, src.REVIEWED_AT)
+        """,
+        params=[id_left, id_right, SOURCE_TABLE_NAME, decision, comment or ""],
+    ).collect()
+    load_stats.clear()
+    load_unreviewed.clear()
+
+
+# ── Field Pairing ────────────────────────────────────────────────────────────
+
+# (label, source_col, resolved_col, jw_score_col_or_None)
+FIELD_PAIRS = [
+    ("Name",       "SRC_RAW_NAME",    "RES_RAW_NAME",    "NAME_JW"),
+    ("Norm. Name", "SRC_NORM_NAME",   "RES_NORM_NAME",   "NAME_JW"),
+    ("Address",    "SRC_RAW_ADDRESS",  "RES_RAW_ADDRESS",  "STREET_JW"),
+    ("Norm. Street","SRC_NORM_STREET", "RES_NORM_STREET", "STREET_JW"),
+    ("City",       "SRC_NORM_CITY",   "RES_NORM_CITY",   None),
+    ("State",      "SRC_NORM_STATE",  "RES_NORM_STATE",  None),
+    ("ZIP",        "SRC_NORM_ZIP",    "RES_NORM_ZIP",    None),
+    ("NPI",        "SRC_ORIGINAL_NPI","RES_ORIGINAL_NPI",None),
+]
+
+
+# ── Session State ────────────────────────────────────────────────────────────
+
+if "current_index" not in st.session_state:
+    st.session_state.current_index = 0
+
+
+# ── Load Data ────────────────────────────────────────────────────────────────
+
+stats = load_stats()
+df = load_unreviewed()
+
+total = int(stats["TOTAL"])
+unreviewed_count = len(df)
+accepted_count = int(stats["ACCEPTED"])
+rejected_count = int(stats["REJECTED"])
+flagged_count = int(stats["FLAGGED"])
+reviewed_count = total - unreviewed_count
+
+# Clamp index
+idx = st.session_state.current_index
+if idx >= unreviewed_count:
+    idx = 0
+    st.session_state.current_index = 0
+
+
+# ── 1. Compact Header ───────────────────────────────────────────────────────
+
+h1, h2, h3 = st.columns([2, 3, 4])
+with h1:
+    st.markdown("**Entity Resolution Review**")
+with h2:
+    if unreviewed_count > 0:
+        st.markdown(f"Record {idx + 1} of {unreviewed_count} unreviewed")
+    else:
+        st.markdown("All records reviewed")
+with h3:
+    st.markdown(
+        f'<span class="chip-accept">{accepted_count} Accepted</span> '
+        f'<span class="chip-reject">{rejected_count} Rejected</span> '
+        f'<span class="chip-flag">{flagged_count} Flagged</span>',
+        unsafe_allow_html=True,
+    )
+
+# ── Empty State ──────────────────────────────────────────────────────────────
+
+if unreviewed_count == 0:
+    st.info(
+        f"All {total} match records have been reviewed. "
+        f"({accepted_count} accepted, {rejected_count} rejected, {flagged_count} flagged)"
+    )
+    if total > 0:
+        st.progress(1.0, text=f"{total} of {total} reviewed (100%)")
+    st.stop()
+
+row = df.iloc[idx]
+
+
+# ── 2. Side-by-Side Entity Comparison ────────────────────────────────────────
+
+table_html = '<table class="cmp-table"><thead><tr>'
+table_html += '<th>Field</th><th>Source Entity</th><th>Resolved Entity</th><th>Match</th>'
+table_html += '</tr></thead><tbody>'
+
+for label, src_col, res_col, jw_col in FIELD_PAIRS:
+    sv = safe(row.get(src_col))
+    rv = safe(row.get(res_col))
+    jw_val = row.get(jw_col) if jw_col else None
+    chip = match_chip(sv, rv, jw_val)
+    table_html += (
+        f'<tr><td class="field-label">{label}</td>'
+        f'<td>{sv or "--"}</td><td>{rv or "--"}</td><td>{chip}</td></tr>'
+    )
+
+table_html += '</tbody></table>'
+st.markdown(table_html, unsafe_allow_html=True)
+
+
+# ── 3. Signals Bar ──────────────────────────────────────────────────────────
+
+signals = [
+    ("Confidence", row.get("CONFIDENCE"), True),
+    ("Cosine Sim", row.get("COSINE_SIM"), True),
+    ("Name JW", row.get("NAME_JW"), True),
+    ("Street JW", row.get("STREET_JW"), True),
+    ("Method", row.get("MATCH_METHOD"), False),
+    ("Decision", row.get("DECISION"), False),
+]
+
+sig_cols = st.columns(len(signals))
+for i, (label, val, is_numeric) in enumerate(signals):
+    with sig_cols[i]:
+        if is_numeric and val is not None:
+            try:
+                display_val = f"{float(val):.4f}"
+                css_cls = signal_color_class(val)
+            except (TypeError, ValueError):
+                display_val = safe(val)
+                css_cls = "signal-value"
+        else:
+            display_val = safe(val) if val is not None else "N/A"
+            css_cls = "signal-value"
+        st.markdown(
+            f'<div class="signal-card"><span class="signal-label">{label}</span>'
+            f'<span class="{css_cls}">{display_val}</span></div>',
+            unsafe_allow_html=True,
+        )
+
+
+# ── 4. Reasoning Section ────────────────────────────────────────────────────
+
+# Generate reasoning from signals since there's no dedicated reasoning column
+reasoning_parts = []
+name_jw = row.get("NAME_JW")
+street_jw = row.get("STREET_JW")
+cosine = row.get("COSINE_SIM")
+conf = row.get("CONFIDENCE")
+method = safe(row.get("MATCH_METHOD"))
+
+if name_jw is not None:
+    try:
+        njw = float(name_jw)
+        if njw >= 1.0:
+            reasoning_parts.append("Name: exact match")
+        elif njw >= 0.90:
+            reasoning_parts.append(f"Name similarity: {njw:.2f} (Jaro-Winkler, high)")
+        elif njw >= 0.80:
+            reasoning_parts.append(f"Name similarity: {njw:.2f} (Jaro-Winkler, moderate)")
+        else:
+            reasoning_parts.append(f"Name similarity: {njw:.2f} (Jaro-Winkler, low)")
+    except (TypeError, ValueError):
+        pass
+
+if street_jw is not None:
+    try:
+        sjw = float(street_jw)
+        if sjw >= 1.0:
+            reasoning_parts.append("Street: exact match")
+        elif sjw >= 0.90:
+            reasoning_parts.append(f"Street similarity: {sjw:.2f} (Jaro-Winkler, high)")
+        elif sjw >= 0.80:
+            reasoning_parts.append(f"Street similarity: {sjw:.2f} (Jaro-Winkler, moderate)")
+        else:
+            reasoning_parts.append(f"Street similarity: {sjw:.2f} (Jaro-Winkler, low)")
+    except (TypeError, ValueError):
+        pass
+
+# City/State/ZIP exact checks
+for label, sc, rc in [("City", "SRC_NORM_CITY", "RES_NORM_CITY"),
+                       ("State", "SRC_NORM_STATE", "RES_NORM_STATE"),
+                       ("ZIP", "SRC_NORM_ZIP", "RES_NORM_ZIP")]:
+    sv = safe(row.get(sc)).upper()
+    rv = safe(row.get(rc)).upper()
+    if sv and rv:
+        if sv == rv:
+            reasoning_parts.append(f"{label}: exact match")
+        else:
+            reasoning_parts.append(f"{label}: mismatch ({safe(row.get(sc))} vs {safe(row.get(rc))})")
+
+if cosine is not None:
+    try:
+        reasoning_parts.append(f"Overall cosine similarity: {float(cosine):.4f}")
+    except (TypeError, ValueError):
+        pass
+
+if method:
+    reasoning_parts.append(f"Match method: {method}")
+
+reasoning_text = ". ".join(reasoning_parts) + "." if reasoning_parts else "No signal data available."
+
+st.markdown(
+    f'<div class="reasoning-card">'
+    f'<span class="reasoning-label">Match Reasoning</span>'
+    f'<p class="reasoning-text">{reasoning_text}</p>'
+    f'</div>',
+    unsafe_allow_html=True,
+)
+
+
+# ── 5. Action Panel ─────────────────────────────────────────────────────────
+
+current_pk_left = safe(row.get("ID_LEFT"))
+current_pk_right = safe(row.get("ID_RIGHT"))
+
+comment = st.text_input("Optional comment", key=f"comment_{current_pk_left}_{current_pk_right}")
+
+# --- Decision buttons row ---
+dec_cols = st.columns(3)
+
+with dec_cols[0]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(1) .stButton > button {
+            background-color: #A5D6A7 !important;
+            color: #1B5E20 !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    accept_clicked = st.button("ACCEPT (Space)", key="accept_btn", use_container_width=True)
+
+with dec_cols[1]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(2) .stButton > button {
+            background-color: #EF9A9A !important;
+            color: #B71C1C !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    reject_clicked = st.button("REJECT (X)", key="reject_btn", use_container_width=True)
+
+with dec_cols[2]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(3) .stButton > button {
+            background-color: #FFCC80 !important;
+            color: #E65100 !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    flag_clicked = st.button("FLAG (F)", key="flag_btn", use_container_width=True)
+
+# --- Navigation buttons row ---
+nav_cols = st.columns([1, 2, 1])
+
+with nav_cols[0]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(1) .stButton > button {
+            background-color: #90CAF9 !important;
+            color: #0D47A1 !important;
+            border: none !important;
+        }
+    </style>""", unsafe_allow_html=True)
+    prev_clicked = st.button("<< PREVIOUS (P)", key="prev_btn")
+
+with nav_cols[2]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(3) .stButton > button {
+            background-color: #90CAF9 !important;
+            color: #0D47A1 !important;
+            border: none !important;
+        }
+    </style>""", unsafe_allow_html=True)
+    next_clicked = st.button("NEXT (N) >>", key="next_btn")
+
+
+# --- Handle button actions ---
+def _submit(decision):
+    save_decision(current_pk_left, current_pk_right, decision, comment)
+    # Stay at same index since the list shifts after removing the reviewed record
+
+
+def _go_previous():
+    st.session_state.current_index = max(0, st.session_state.current_index - 1)
+
+
+def _go_next():
+    st.session_state.current_index = min(unreviewed_count - 1, st.session_state.current_index + 1)
+
+
+_rerun = st.rerun if hasattr(st, "rerun") else st.experimental_rerun
+
+if accept_clicked:
+    _submit("accept")
+    _rerun()
+if reject_clicked:
+    _submit("reject")
+    _rerun()
+if flag_clicked:
+    _submit("flag")
+    _rerun()
+if prev_clicked:
+    _go_previous()
+    _rerun()
+if next_clicked:
+    _go_next()
+    _rerun()
+
+
+# ── 6. Progress Bar ─────────────────────────────────────────────────────────
+
+if total > 0:
+    progress = reviewed_count / total
+    st.progress(progress, text=f"{reviewed_count} of {total} reviewed ({progress:.0%})")
+
+
+# ── 7. Keyboard Shortcut Hint ───────────────────────────────────────────────
+
+st.markdown(
+    '<div class="shortcut-hint">Space: Accept | X: Reject | F: Flag | N: Next | P: Previous</div>',
+    unsafe_allow_html=True,
+)
+
+# ── Keyboard Shortcuts (hidden component) ────────────────────────────────────
+
+components.html("""
+<script>
+const doc = window.parent.document;
+doc.addEventListener('keydown', function(e) {
+    const active = doc.activeElement;
+    const isInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA');
+    if (isInput) return;
+
+    const keyMap = {
+        ' ': 'accept',
+        'x': 'reject',
+        'f': 'flag',
+        'n': 'next',
+        'p': 'previous'
+    };
+    const target = keyMap[e.key.toLowerCase()];
+    if (target) {
+        e.preventDefault();
+        const allButtons = doc.querySelectorAll('button');
+        for (const btn of allButtons) {
+            if (btn.innerText.toLowerCase().includes(target)) {
+                btn.click();
+                break;
+            }
+        }
+    }
+});
+</script>
+""", height=0)

--- a/skills/entity-resolution/references/hitl-app.md
+++ b/skills/entity-resolution/references/hitl-app.md
@@ -1,0 +1,731 @@
+# HITL Review App -- Streamlit Requirements
+
+Delegate to the `developing-with-streamlit` skill to build this app. This document provides the entity-resolution-specific requirements, UX patterns, and Material Design styling.
+
+> **Note:** The file `er_hitl_review.py` in the skill root is a **reference implementation** built for a specific pharma domain engagement (hardcoded to `ER_SKILL_TEST_DB1.NPI` schema with pharma-specific columns). Do NOT copy it directly — use the generic, table-agnostic patterns described below instead. The reference implementation demonstrates the UX patterns and Material Design styling but must be adapted to the customer's schema and column names using the auto-detection logic in this document.
+
+## Purpose
+
+Allow human reviewers to validate entity resolution results one record at a time. The reviewer sees the source entity fields alongside the resolved/matched entity fields, makes a decision (Accept / Reject / Flag), optionally adds a comment, and advances to the next record.
+
+## Generic Input
+
+The skill starts by discovering available tables:
+
+### Table Selection
+
+1. Detect the user's current database and schema:
+
+```sql
+SELECT CURRENT_DATABASE(), CURRENT_SCHEMA();
+```
+
+2. List tables in the current schema:
+
+```sql
+SHOW TABLES IN SCHEMA <DATABASE>.<SCHEMA>;
+```
+
+3. Present the tables to the user and ask them to pick one. Include row counts if available from the SHOW output. Offer the option to specify a different schema or fully qualified table name if the desired table is not listed:
+
+```
+Tables in TEMP.JJOUBERT:
+
+  1. HITL_ENTITY_RESOLUTION_TEST (12 rows)
+  2. OTHER_TABLE (500 rows)
+  3. ...
+
+Select a table, or provide a fully qualified name (DATABASE.SCHEMA.TABLE) for a different schema.
+```
+
+**MANDATORY STOPPING POINT**: Wait for user to select a table before proceeding.
+
+After the table is selected, run `DESCRIBE TABLE` to retrieve all columns. Then **auto-detect the primary key** and **column groups** by classifying columns using naming patterns.
+
+### Primary Key Auto-Detection
+
+Identify candidate PK columns using these heuristics (ordered by priority):
+
+1. Columns with names ending in `_id` or `_key` that appear first in the table
+2. Columns named exactly `ID`, `PK`, `ROW_ID`, `RECORD_ID`, `ENTITY_ID`, `SUB_ENTITY_ID`
+3. The first VARCHAR or NUMBER column in the table
+
+To validate candidates, run:
+
+```sql
+SELECT COUNT(*) AS total, COUNT(DISTINCT <candidate>) AS distinct_ct
+FROM <TABLE>;
+```
+
+A valid PK has `total = distinct_ct` (all values unique).
+
+Present the top candidate(s) to the user:
+
+```
+I detected these potential primary key columns:
+
+  1. SUB_ENTITY_ID (VARCHAR, 12 unique / 12 total)
+  2. CONSOLIDATED_LOCATION_ID (VARCHAR, 12 unique / 12 total)
+
+Which column should be used as the primary key?
+```
+
+**MANDATORY STOPPING POINT**: Wait for user to confirm or specify the primary key before proceeding.
+
+After the PK is confirmed, **auto-detect column groups** by classifying the remaining columns by naming patterns. Present the proposed grouping to the user for confirmation/editing.
+
+### Column Auto-Detection Logic
+
+Query the table metadata:
+
+```sql
+DESCRIBE TABLE <DATABASE.SCHEMA.TABLE>;
+```
+
+Then classify each column into groups using these heuristics (case-insensitive):
+
+**Source entity columns** (left side of comparison):
+- Columns containing prefixes/infixes like: `raw_`, `source_`, `src_`, `original_`, `input_`
+- Columns containing entity-side identifiers like: `vinemeds_`, `left_`, `entity_a_`, `record_a_`
+- Common entity field names without a resolved-side prefix: `name`, `address`, `street`, `city`, `state`, `zip`
+
+**Resolved entity columns** (right side of comparison):
+- Columns containing prefixes/infixes like: `matched_`, `resolved_`, `npi_`, `target_`, `right_`, `entity_b_`, `record_b_`, `canonical_`, `golden_`
+- Columns that mirror a detected source column but with a different prefix (e.g., `VINEMEDS_RAW_CITY` pairs with `NPI_CITY`)
+
+**Signal columns** (match quality indicators):
+- Columns with names containing: `confidence`, `score`, `sim`, `similarity`, `jw`, `jaro`, `cosine`, `method`, `decision`, `tier`, `match_level`
+- Numeric columns (FLOAT, NUMBER) that are not clearly entity fields
+- Columns with `_exact` suffix (boolean match flags)
+
+**Reasoning columns** (match explanation):
+- Columns with names containing: `reason`, `reasoning`, `explanation`, `rationale`, `justification`, `why`, `notes`, `detail`, `summary`, `narrative`, `logic`
+- Prefer longer VARCHAR/TEXT columns over short ones
+- Typically contains a free-text explanation of why the match was made
+
+**Review columns** (exclude from comparison, already part of REVIEW_DECISIONS):
+- Columns containing: `reviewer_`, `reviewed_`, `review_decision`, `review_comment`
+
+**Unclassified columns:**
+- Primary key column (already identified)
+- Any column not matching the above patterns -- include in a separate "Other" group
+
+### Presenting the Proposed Grouping
+
+After auto-detection, present the results to the user in a clear format:
+
+```
+I analyzed the columns in <TABLE> and propose this grouping:
+
+Source Entity (left side):
+  - SOURCE_RAW_NAME
+  - SOURCE_RAW_ADDRESS
+  - SOURCE_RAW_CITY
+  - SOURCE_RAW_STATE
+  - SOURCE_RAW_ZIP
+
+Resolved Entity (right side):
+  - RESOLVED_NAME
+  - RESOLVED_ADDRESS
+  - RESOLVED_CITY
+  - RESOLVED_STATE
+  - RESOLVED_ZIP
+
+Signals:
+  - CONFIDENCE (FLOAT)
+  - COSINE_SIM (FLOAT)
+  - NAME_JW (FLOAT)
+  - MATCH_METHOD (VARCHAR)
+  - DECISION (VARCHAR)
+
+Reasoning:
+  - MATCH_REASONING (VARCHAR)
+
+Excluded (review/other):
+  - REVIEWER_DECISION
+  - REVIEWER_COMMENT
+  - REVIEWED_BY
+  - REVIEWED_AT
+
+Would you like to adjust any of these groupings?
+```
+
+**MANDATORY STOPPING POINT**: Wait for the user to confirm or modify the column groupings before generating the app. Accept changes like moving columns between groups, removing columns, or adding columns that were misclassified.
+
+### Pairing Source and Resolved Columns
+
+After grouping is confirmed, attempt to pair source columns with their resolved counterparts for the side-by-side comparison. Pair by:
+1. **Suffix matching** -- strip the prefix and match on the remainder (e.g., `VINEMEDS_RAW_CITY` and `NPI_CITY` both end with `CITY`)
+2. **Semantic similarity** -- columns with names like `RAW_NAME` and `MATCHED_NPI_NAME` both contain `NAME`
+3. **Position** -- if source and resolved lists are the same length and ordered similarly, pair by position as fallback
+
+Present the proposed pairing and let the user adjust:
+
+```
+Proposed field pairing for side-by-side comparison:
+
+  VINEMEDS_RAW_NAME    <-->  NPI_NAME
+  VINEMEDS_RAW_ADDRESS <-->  NPI_ADDRESS
+  VINEMEDS_RAW_CITY    <-->  NPI_CITY
+  VINEMEDS_RAW_STATE   <-->  NPI_STATE
+  VINEMEDS_RAW_ZIP     <-->  NPI_ZIP
+
+Adjust if needed.
+```
+
+## Review Decisions Table
+
+Before the app runs, create a review decisions table in the same schema as the source table:
+
+```sql
+CREATE TABLE IF NOT EXISTS <SCHEMA>.REVIEW_DECISIONS (
+    PRIMARY_KEY_VALUE VARCHAR,
+    SOURCE_TABLE VARCHAR,
+    REVIEWER_DECISION VARCHAR,       -- 'accept', 'reject', 'flag'
+    REVIEWER_COMMENT VARCHAR,
+    REVIEWED_BY VARCHAR,
+    REVIEWED_AT TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    CONSTRAINT uq_review UNIQUE (PRIMARY_KEY_VALUE, SOURCE_TABLE)
+);
+```
+
+When a reviewer submits a decision, MERGE into this table using the primary key value and source table name. This allows re-review (latest decision wins).
+
+## App Structure -- Single Page
+
+The app is a single-page Streamlit application. No multi-page navigation. All functionality lives on one screen.
+
+### Eliminating Top Whitespace
+
+Streamlit adds significant top padding by default. Inject this CSS at the very top of the app (before any content) to remove it:
+
+```css
+/* Remove default Streamlit top padding */
+.stApp > header { display: none; }
+div[data-testid="stAppViewContainer"] > div:first-child { padding-top: 0; }
+block-container { padding-top: 1rem; }
+section[data-testid="stSidebar"] { display: none; }
+.stApp { margin-top: -2rem; }
+```
+
+This must be the first `st.markdown(unsafe_allow_html=True)` call in the app.
+
+### Layout (Top to Bottom)
+
+#### 1. Side-by-Side Entity Comparison (FIRST visible element)
+
+The entity mapping is the primary content and must appear immediately with no whitespace above it. Show a compact inline header: app title + record counter + summary chips on the same line, then the comparison table directly below.
+
+**Compact header (single row):**
+```
+Entity Resolution Review  |  Record 3 of 47 unreviewed  |  12 Accepted | 3 Rejected | 2 Flagged
+```
+
+Use `st.columns` for inline layout. Style summary chips with colored backgrounds (green=accepted, red=rejected, amber=flagged).
+
+**Comparison table immediately below the header:**
+
+```
+| FIELD            | SOURCE ENTITY              | RESOLVED ENTITY            |
+|------------------|----------------------------|----------------------------|
+| Name             | WALGREENS PHARMACY         | WALGREENS CO               |
+| Address          | 100 MAIN ST                | 100 MAIN STREET            |
+| City             | MIAMI                      | MIAMI                      |
+| State            | FL                         | FL                         |
+| ZIP              | 33101                      | 33101                      |
+```
+
+Use a three-column layout: field label (narrow), source value, resolved value.
+
+**Field-level match indicators:** After each resolved entity value, show a colored indicator:
+- Green chip "Exact" -- values are identical (case-insensitive, trimmed)
+- Amber chip "Similar" -- values differ but are close (present when a corresponding JW or similarity score column exists and value >= 0.80)
+- Red chip "Different" -- values differ significantly
+
+Implementation: Use `st.columns([1, 2, 2])` per row. Apply CSS classes for the indicator chips.
+
+#### 2. Signals Bar (below the mapping)
+
+A horizontal row of compact metric cards showing match quality signals. All values must use a **uniform small font size (13px)** -- do NOT use `st.metric` (its label/value sizing is too large and inconsistent). Instead, render each signal as a styled HTML snippet inside `st.markdown(unsafe_allow_html=True)`:
+
+```html
+<div class="signal-card">
+  <span class="signal-label">Confidence</span>
+  <span class="signal-value">0.87</span>
+</div>
+```
+
+```css
+.signal-card {
+    display: inline-block;
+    background: #F5F5F5;
+    border-radius: 8px;
+    padding: 6px 14px;
+    margin-right: 8px;
+    text-align: center;
+}
+.signal-label {
+    display: block;
+    font-size: 11px;
+    font-weight: 500;
+    color: #757575;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.signal-value {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: #212121;
+}
+```
+
+Color-code numeric signal values: green >= 0.85, amber >= 0.70, red < 0.70. Categorical values use default dark text. Lay out signals using `st.columns` with one HTML card per column.
+
+#### 3. Reasoning Section
+
+After the signals bar, display the match reasoning/explanation if available.
+
+**Auto-detect reasoning column:** During column classification, identify a reasoning column using these heuristics (case-insensitive):
+- Column names containing: `reason`, `reasoning`, `explanation`, `rationale`, `justification`, `why`, `notes`, `detail`, `summary`, `narrative`, `logic`
+- Prefer longer VARCHAR/TEXT columns over short ones
+
+Classify detected reasoning columns into a new **Reasoning columns** group alongside the existing Source/Resolved/Signal/Review groups.
+
+If a reasoning column is found, display it in a styled container:
+
+```html
+<div class="reasoning-card">
+  <span class="reasoning-label">Match Reasoning</span>
+  <p class="reasoning-text">High confidence fuzzy match. Name similarity 0.86 via Jaro-Winkler. Address normalized to identical street. ZIP exact match.</p>
+</div>
+```
+
+```css
+.reasoning-card {
+    background: #FAFAFA;
+    border-left: 3px solid #1976D2;
+    border-radius: 4px;
+    padding: 10px 16px;
+    margin: 8px 0;
+}
+.reasoning-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: #757575;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: block;
+    margin-bottom: 4px;
+}
+.reasoning-text {
+    font-size: 13px;
+    color: #424242;
+    line-height: 1.5;
+    margin: 0;
+}
+```
+
+**IMPORTANT:** Always display the reasoning section. If no reasoning column is detected in the source table, generate reasoning dynamically by summarizing the signal column values (e.g., "Name similarity: 0.86 (Jaro-Winkler), Address: exact match, ZIP: exact match, Overall confidence: 0.87"). If a reasoning column exists but the value is NULL or empty for the current record, also fall back to the generated summary from signals. Never skip or hide this section.
+
+#### 3b. Additional Context (Expander)
+
+If there are columns classified as "Other" (unclassified columns that are not PK, source, resolved, signal, reasoning, or review), display them inside a collapsed `st.expander` labeled "Additional Context". This keeps the UI clean while making all remaining data accessible.
+
+```python
+other_cols = [c for c in all_columns if c not in used_columns]
+if other_cols:
+    with st.expander("Additional Context"):
+        for col in other_cols:
+            val = current_row[col]
+            if val is not None and str(val).strip():
+                st.markdown(f"**{col}:** {val}")
+```
+
+The expander is collapsed by default. Only show columns that have non-null, non-empty values for the current record.
+
+#### 4. Action Panel
+
+Below the comparison, a panel with the comment input, decision buttons, and navigation buttons. There are exactly 5 buttons: Accept, Reject, Flag, Previous, Next. Do NOT add a Skip button or any other buttons.
+
+**IMPORTANT: Use this exact implementation.** Do not deviate from this pattern -- it is the only reliable way to apply per-button colors in Streamlit.
+
+```python
+comment = st.text_input("Optional comment", key=f"comment_{current_pk}")
+
+# --- Decision buttons row ---
+dec_cols = st.columns(3)
+
+with dec_cols[0]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(1) .stButton > button {
+            background-color: #A5D6A7 !important;
+            color: #1B5E20 !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    accept_clicked = st.button("ACCEPT (Space)", key="accept_btn", use_container_width=True)
+
+with dec_cols[1]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(2) .stButton > button {
+            background-color: #EF9A9A !important;
+            color: #B71C1C !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    reject_clicked = st.button("REJECT (X)", key="reject_btn", use_container_width=True)
+
+with dec_cols[2]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(3) .stButton > button {
+            background-color: #FFCC80 !important;
+            color: #E65100 !important;
+            border: none !important;
+            width: 100%;
+        }
+    </style>""", unsafe_allow_html=True)
+    flag_clicked = st.button("FLAG (F)", key="flag_btn", use_container_width=True)
+
+# --- Navigation buttons row ---
+nav_cols = st.columns([1, 2, 1])
+
+with nav_cols[0]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(1) .stButton > button {
+            background-color: #90CAF9 !important;
+            color: #0D47A1 !important;
+            border: none !important;
+        }
+    </style>""", unsafe_allow_html=True)
+    prev_clicked = st.button("<< PREVIOUS (P)", key="prev_btn")
+
+with nav_cols[2]:
+    st.markdown("""<style>
+        div[data-testid="stColumn"]:nth-child(3) .stButton > button {
+            background-color: #90CAF9 !important;
+            color: #0D47A1 !important;
+            border: none !important;
+        }
+    </style>""", unsafe_allow_html=True)
+    next_clicked = st.button("NEXT (N) >>", key="next_btn")
+
+# --- Handle button actions ---
+if accept_clicked:
+    submit_decision('accept', comment)
+if reject_clicked:
+    submit_decision('reject', comment)
+if flag_clicked:
+    submit_decision('flag', comment)
+if prev_clicked:
+    go_previous()
+if next_clicked:
+    go_next()
+```
+
+On any decision button click (accept/reject/flag):
+1. MERGE the decision into `REVIEW_DECISIONS` table
+2. Advance to the next unreviewed record
+3. Clear the comment field
+
+**CRITICAL:** The CSS selectors above use `nth-child` scoped to each `st.columns` row. Because each row is a separate `st.columns` call, the nth-child numbering resets for each row. This is why the nav buttons also use nth-child(1) and nth-child(3) -- they are in a different `st.columns` context.
+
+**Keyboard shortcuts:**
+Keyboard shortcuts are implemented via a hidden `st.components.v1.html` component placed at the bottom of the page. It listens for `keydown` events on the parent document and programmatically clicks the matching button by searching for the button key text.
+
+Bind these keys (only when no text input/textarea is focused):
+- **Space** -- Accept
+- **X** -- Reject
+- **F** -- Flag for Review
+- **N** -- Next record
+- **P** -- Previous record
+
+```python
+import streamlit.components.v1 as components
+
+components.html("""
+<script>
+const doc = window.parent.document;
+doc.addEventListener('keydown', function(e) {
+    const active = doc.activeElement;
+    const isInput = active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA');
+    if (isInput) return;
+
+    const keyMap = {
+        ' ': 'accept',
+        'x': 'reject',
+        'f': 'flag',
+        'n': 'next',
+        'p': 'previous'
+    };
+    const target = keyMap[e.key.toLowerCase()];
+    if (target) {
+        e.preventDefault();
+        const allButtons = doc.querySelectorAll('button');
+        for (const btn of allButtons) {
+            if (btn.innerText.toLowerCase().includes(target)) {
+                btn.click();
+                break;
+            }
+        }
+    }
+});
+</script>
+""", height=0)
+```
+
+This works in SiS because `st.components.v1.html` is supported. The JS matches buttons by their label text (e.g., "ACCEPT (Space)" contains "accept"), so button labels must include the keywords shown above.
+
+#### 5. Progress Bar
+
+A thin progress bar at the bottom: `reviewed / total` records.
+
+#### 6. Keyboard Shortcut Hint
+
+At the very bottom, display a subtle hint bar:
+
+```html
+<div class="shortcut-hint">
+  Space: Accept | X: Reject | F: Flag | N: Next | P: Previous
+</div>
+```
+
+```css
+.shortcut-hint {
+    text-align: center;
+    font-size: 11px;
+    color: #9E9E9E;
+    padding: 8px 0;
+    letter-spacing: 0.3px;
+}
+```
+
+## Material Design Styling
+
+Use custom CSS injected via `st.markdown(unsafe_allow_html=True)` to achieve Material Design appearance. Do NOT use third-party MUI libraries.
+
+### Required CSS
+
+```css
+/* Remove default Streamlit top padding */
+.stApp > header { display: none; }
+div[data-testid="stAppViewContainer"] > div:first-child { padding-top: 0; }
+.block-container { padding-top: 1rem !important; }
+.stApp { margin-top: -2rem; }
+
+/* Material Design elevation and typography */
+.stApp {
+    font-family: 'Roboto', 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* Card elevation */
+div[data-testid="stVerticalBlock"] > div[data-testid="stHorizontalBlock"] {
+    background: white;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    padding: 16px;
+    margin-bottom: 12px;
+}
+
+/* Material chip styles */
+.chip-accept {
+    background-color: #C8E6C9;
+    color: #2E7D32;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 13px;
+    font-weight: 500;
+    display: inline-block;
+}
+.chip-reject {
+    background-color: #FFCDD2;
+    color: #C62828;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 13px;
+    font-weight: 500;
+    display: inline-block;
+}
+.chip-flag {
+    background-color: #FFE0B2;
+    color: #E65100;
+    padding: 4px 12px;
+    border-radius: 16px;
+    font-size: 13px;
+    font-weight: 500;
+    display: inline-block;
+}
+.chip-exact {
+    background-color: #C8E6C9;
+    color: #2E7D32;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+}
+.chip-similar {
+    background-color: #FFE0B2;
+    color: #E65100;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+}
+.chip-different {
+    background-color: #FFCDD2;
+    color: #C62828;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+}
+
+/* Signal card styles (uniform small font) */
+.signal-card {
+    display: inline-block;
+    background: #F5F5F5;
+    border-radius: 8px;
+    padding: 6px 14px;
+    margin-right: 8px;
+    text-align: center;
+}
+.signal-label {
+    display: block;
+    font-size: 11px;
+    font-weight: 500;
+    color: #757575;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+.signal-value {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: #212121;
+}
+
+/* Reasoning card */
+.reasoning-card {
+    background: #FAFAFA;
+    border-left: 3px solid #1976D2;
+    border-radius: 4px;
+    padding: 10px 16px;
+    margin: 8px 0;
+}
+.reasoning-label {
+    font-size: 11px;
+    font-weight: 500;
+    color: #757575;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    display: block;
+    margin-bottom: 4px;
+}
+.reasoning-text {
+    font-size: 13px;
+    color: #424242;
+    line-height: 1.5;
+    margin: 0;
+}
+
+/* Shortcut hint */
+.shortcut-hint {
+    text-align: center;
+    font-size: 11px;
+    color: #9E9E9E;
+    padding: 8px 0;
+    letter-spacing: 0.3px;
+}
+
+/* Material button overrides */
+.stButton > button {
+    border-radius: 4px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-size: 13px;
+    padding: 8px 24px;
+    transition: box-shadow 0.2s;
+}
+.stButton > button:hover {
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+```
+
+### Button Styling
+
+Button colors are applied inline within the Action Panel code above (Section 4). Do NOT use `type="primary"` for any button. Do NOT add a Skip button. The exact 5 buttons are: Accept, Reject, Flag, Previous, Next.
+
+Color reference:
+- **Accept**: `#A5D6A7` background, `#1B5E20` text (pastel green)
+- **Reject**: `#EF9A9A` background, `#B71C1C` text (pastel red)
+- **Flag**: `#FFCC80` background, `#E65100` text (pastel orange)
+- **Previous / Next**: `#90CAF9` background, `#0D47A1` text (blue)
+
+## State Management
+
+Use `st.session_state` to track:
+- `current_index` -- index into the list of unreviewed primary keys
+- `reviewed_pks` -- set of primary keys already reviewed this session
+- `stats` -- dict with accept/reject/flag counts
+
+On app load:
+1. Query the source table for all primary keys
+2. LEFT JOIN to `REVIEW_DECISIONS` to identify already-reviewed records
+3. Default to showing the first unreviewed record
+
+## Data Access Pattern
+
+```python
+# Load unreviewed records
+# NOTE: source_table, schema, and pk_column are table/column identifiers derived
+# from app configuration (not user input). Snowflake bind parameters (?) only work
+# for literal values, not object identifiers, so f-string interpolation is correct here.
+unreviewed = session.sql(f"""
+    SELECT s.*
+    FROM {source_table} s
+    LEFT JOIN {schema}.REVIEW_DECISIONS r
+        ON r.PRIMARY_KEY_VALUE = s.{pk_column}::VARCHAR
+        AND r.SOURCE_TABLE = '{source_table}'
+    WHERE r.PRIMARY_KEY_VALUE IS NULL
+    ORDER BY s.{pk_column}
+""").to_pandas()
+
+# Submit a decision (use parameterized queries to prevent SQL injection)
+session.sql(
+    f"""
+    MERGE INTO {schema}.REVIEW_DECISIONS tgt
+    USING (SELECT
+        ? AS PRIMARY_KEY_VALUE,
+        ? AS SOURCE_TABLE,
+        ? AS REVIEWER_DECISION,
+        ? AS REVIEWER_COMMENT,
+        CURRENT_USER() AS REVIEWED_BY,
+        CURRENT_TIMESTAMP() AS REVIEWED_AT
+    ) src
+    ON tgt.PRIMARY_KEY_VALUE = src.PRIMARY_KEY_VALUE
+       AND tgt.SOURCE_TABLE = src.SOURCE_TABLE
+    WHEN MATCHED THEN UPDATE SET
+        REVIEWER_DECISION = src.REVIEWER_DECISION,
+        REVIEWER_COMMENT = src.REVIEWER_COMMENT,
+        REVIEWED_BY = src.REVIEWED_BY,
+        REVIEWED_AT = src.REVIEWED_AT
+    WHEN NOT MATCHED THEN INSERT VALUES (
+        src.PRIMARY_KEY_VALUE, src.SOURCE_TABLE,
+        src.REVIEWER_DECISION, src.REVIEWER_COMMENT,
+        src.REVIEWED_BY, src.REVIEWED_AT
+    )
+    """,
+    params=[pk_value, source_table, decision, comment or ""],
+).collect()
+```
+
+## Constraints
+
+- No emojis anywhere in the UI. Use text labels and Material Design icons via CSS/HTML only.
+- No third-party MUI Python libraries. Use native Streamlit components with custom CSS.
+- The app must work with ANY table structure. Column names come from user input at skill invocation time.
+- The app should be deployable to Snowflake via Streamlit in Snowflake (SiS).
+- Use `FROM` syntax (not `ROOT_LOCATION`) when creating the Streamlit object.

--- a/skills/entity-resolution/references/operationalize.md
+++ b/skills/entity-resolution/references/operationalize.md
@@ -1,0 +1,221 @@
+# Operationalize — Pipeline and Extensions
+
+Make entity resolution an ongoing, incremental process rather than a one-time batch job.
+
+## Dynamic Tables Pipeline (Path A — Pair-Based)
+
+**Delegate to:** `dynamic-tables` skill with the following ER-specific pipeline topology.
+
+### Pipeline DAG
+
+```
+source_entities (base tables)
+  └─> dt_normalized_entities (dynamic table, TARGET_LAG = '1 hour')
+        └─> dt_candidate_pairs (dynamic table, TARGET_LAG = DOWNSTREAM)
+              ├─> dt_tier1_results (dynamic table, TARGET_LAG = DOWNSTREAM)
+              ├─> dt_tier2_results (dynamic table, TARGET_LAG = DOWNSTREAM)
+              └─> dt_match_results (dynamic table, TARGET_LAG = DOWNSTREAM)
+                    └─> dt_entity_groups (dynamic table, TARGET_LAG = DOWNSTREAM)
+                          └─> dt_entity_master (dynamic table, TARGET_LAG = DOWNSTREAM)
+```
+
+### Key Configuration
+
+- **Root lag:** Set `TARGET_LAG` on `dt_normalized_entities` based on how fresh match results need to be. Typical values: `'1 hour'` for operational matching, `'24 hours'` for batch.
+- **Downstream lag:** All downstream tables use `TARGET_LAG = DOWNSTREAM` to cascade from the root.
+- **Warehouse sizing:** Tier 2 (embedding) and Tier 3 (LLM) steps are the most expensive. Size the warehouse based on the expected volume of new/changed records per refresh cycle, not total table size. Dynamic tables refresh incrementally.
+
+### Incremental Considerations
+
+- **New records:** Automatically processed through the pipeline when source tables change.
+- **Changed records:** Handled by dynamic table refresh if the source table updates in place. If the source appends new versions, add a deduplication step in `dt_normalized_entities`.
+- **Deleted records:** Dynamic tables handle this naturally. Entity groups will be recalculated.
+- **Threshold changes:** After HITL review and threshold tuning, update the matching dynamic table definition. This triggers a full refresh of downstream tables.
+
+> **For stream + task based incremental pipelines** (higher control over refresh timing and cost), see `references/templates/incremental.md` which covers change detection via streams, incremental MERGE normalization, delta candidate pair generation, and task DAG orchestration with `SYSTEM$STREAM_HAS_DATA()` guards.
+
+## Entity Master Table
+
+The golden record view aggregating the best values per entity group:
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE dt_entity_master
+    TARGET_LAG = DOWNSTREAM
+    WAREHOUSE = <warehouse_name>
+AS
+SELECT
+    eg.entity_group_id,
+    -- Best name: pick the most complete/recent
+    FIRST_VALUE(ne.normalized_name) OVER (
+        PARTITION BY eg.entity_group_id
+        ORDER BY LENGTH(ne.normalized_name) DESC  -- Longest (most complete) name
+    ) AS master_name,
+    -- Best address: pick the most complete
+    FIRST_VALUE(ne.normalized_street) OVER (
+        PARTITION BY eg.entity_group_id
+        ORDER BY CASE WHEN ne.normalized_street IS NOT NULL THEN 1 ELSE 0 END DESC
+    ) AS master_street,
+    -- Aggregate all source IDs
+    ARRAY_AGG(DISTINCT ne.source_id) AS source_ids,
+    ARRAY_AGG(DISTINCT ne.source_table) AS source_tables,
+    COUNT(DISTINCT ne.source_id) AS record_count
+FROM entity_groups eg
+JOIN normalized_entities ne ON eg.entity_id = ne.source_id
+GROUP BY eg.entity_group_id;
+```
+
+**Note:** The "best value" selection strategy (longest name, most complete address) is a starting point. Customize based on the customer's data quality priorities. Some may prefer the most recent record, or a specific source as the system of record.
+
+## Monitoring
+
+**Delegate to:** `data-quality` skill for source data quality monitoring.
+
+Key metrics to monitor:
+- **Source data freshness** — are source tables being updated on schedule?
+- **Match rate trends** — is the percentage of matches stable over time? A sudden drop may indicate source data quality issues.
+- **Entity group growth** — are entity groups growing too large? Groups >10 records may indicate over-matching.
+- **Pipeline lag** — are dynamic tables refreshing within their target lag?
+
+## Agentic Pipeline (Path B — Entity Linking)
+
+When using the agentic matching workflow (Phase 4b), operationalize the 3-tier escalation pipeline.
+
+### Pipeline DAG
+
+```
+source_entities (base tables)
+  └─> dt_normalized_entities (dynamic table, TARGET_LAG = '1 hour')
+        └─> dt_entity_embeddings (dynamic table, TARGET_LAG = DOWNSTREAM)
+              └─> dt_match_candidates (dynamic table, TARGET_LAG = DOWNSTREAM)
+                    └─> dt_highconf_matches (dynamic table, TARGET_LAG = DOWNSTREAM)
+                          └─> [Tier 1.5 + Tier 2 triggered via Task DAG]
+                                └─> dt_crosswalk (view, UNION ALL of all tiers)
+                                      └─> dt_entity_master (dynamic table, TARGET_LAG = DOWNSTREAM)
+```
+
+**Key difference from Path A:** Tier 1.5 (batch search + classify) and Tier 2 (agent) cannot be fully expressed as dynamic tables because they involve stored procedure calls (Cortex Search, AI_COMPLETE, DATA_AGENT_RUN). Instead:
+
+1. **Dynamic tables handle:** normalization, embedding, match candidates, high-confidence triage, crosswalk assembly, and entity master
+2. **Task DAG handles:** batch search + classify (Tier 1.5) and agent resolution (Tier 2)
+3. **Trigger:** When `dt_highconf_matches` refreshes and new unresolved entities appear, trigger the Task DAG to process them through Tier 1.5 and Tier 2
+
+### State-Based Pipeline Controller
+
+For large reference corpora spanning multiple partitions (e.g., US states), process one partition at a time using a controller pattern:
+
+```sql
+-- State queue tracks which partitions have been processed
+CREATE OR REPLACE TABLE state_batch_queue (
+    state_code    STRING PRIMARY KEY,
+    entity_count  INT,
+    status        STRING DEFAULT 'PENDING',  -- PENDING | ACTIVE | COMPLETED
+    started_at    TIMESTAMP_NTZ,
+    completed_at  TIMESTAMP_NTZ
+);
+```
+
+The Task DAG finalizer calls a controller SP that checks backlog and auto-feeds the next partition. See `templates/orchestration.md` for the controller pattern.
+
+### Agent Reasoning Search Corpus
+
+For operational intelligence, maintain a searchable corpus of agent reasoning across all resolution runs:
+
+```sql
+CREATE OR REPLACE TABLE agent_reasoning_corpus (
+    source_id               INT,
+    reasoning_text           STRING,    -- Concatenated: decision + reasoning + entity context
+    agent_reasoning          STRING,
+    source_entity_id         STRING,
+    decision                 STRING,
+    confidence               FLOAT,
+    state_code               STRING,
+    entity_name              STRING,
+    matched_reference_name   STRING,
+    web_search_used          BOOLEAN,
+    created_at               TIMESTAMP_NTZ
+);
+```
+
+Build a Cortex Search Service over this corpus to enable natural-language queries like "show me entities where the agent found a closure" or "which pharmacies had name mismatches resolved by web search." Refreshed incrementally by the finalizer after each pipeline cycle.
+
+### Quality Loop — LLM-as-a-Judge
+
+For ongoing quality assurance, add an automated judge layer that evaluates a sample of agent decisions after each pipeline cycle:
+
+1. **Sample:** Stratified sample of agent results (by decision type, confidence range)
+2. **Judge prompt:** Provide entity details, agent decision, reasoning, and reference match — ask the judge to evaluate correctness
+3. **Output:** Quality metrics per tier, per decision type, and actionable improvement findings
+4. **Feedback:** Findings feed into threshold tuning and agent prompt refinement
+
+This can be scheduled as a post-pipeline task that runs after the finalizer.
+
+## Contrastive Embeddings Pipeline (Phase 4c)
+
+When contrastive embeddings are used (standalone or as a Tier 2 replacement), the operationalization differs from the standard pipeline because embedding generation requires a GPU training step that cannot be expressed as a dynamic table.
+
+### Standalone Pipeline DAG
+
+```
+source_entities (base tables)
+  └─> dt_normalized_entities (dynamic table, TARGET_LAG = '1 hour')
+        └─> dt_serialized_entities (dynamic table, TARGET_LAG = DOWNSTREAM)
+              └─> [GPU training job triggered manually or via Task]
+                    └─> contrastive_embeddings (base table, written by training job)
+                          └─> dt_blocking_candidates (dynamic table, TARGET_LAG = DOWNSTREAM)
+                                └─> dt_predicted_matches (dynamic table, TARGET_LAG = DOWNSTREAM)
+                                      └─> dt_entity_groups (dynamic table, TARGET_LAG = DOWNSTREAM)
+                                            └─> dt_entity_master (dynamic table, TARGET_LAG = DOWNSTREAM)
+```
+
+### Add-On Pipeline DAG (replaces AI_EMBED in Path A)
+
+```
+source_entities (base tables)
+  └─> dt_normalized_entities (dynamic table, TARGET_LAG = '1 hour')
+        ├─> dt_candidate_pairs (dynamic table, TARGET_LAG = DOWNSTREAM)
+        │     ├─> dt_tier1_results (dynamic table, TARGET_LAG = DOWNSTREAM)
+        │     ├─> dt_tier2_contrastive_results (dynamic table, reads from contrastive_embeddings)
+        │     └─> dt_match_results (dynamic table, TARGET_LAG = DOWNSTREAM)
+        │           └─> dt_entity_groups → dt_entity_master
+        └─> dt_serialized_entities (dynamic table, TARGET_LAG = DOWNSTREAM)
+              └─> [GPU training job — manual or scheduled retrain]
+                    └─> contrastive_embeddings (base table)
+```
+
+### Retraining Strategy
+
+Contrastive embeddings are not automatically refreshed like dynamic tables. Retrain when:
+- **New entity types appear** that were not in the original training data
+- **Data distribution shifts** (e.g., new product categories, geographic expansion)
+- **HITL review reveals systematic errors** that better embeddings could fix
+- **Periodic schedule** — retrain monthly or quarterly as new ground truth accumulates from HITL reviews
+
+Retraining workflow:
+1. Collect new ground truth from HITL review decisions (Phase 5 outputs)
+2. Merge with original training data
+3. Re-run GPU training job with updated `pretrain_entities` table
+4. Verify new embeddings improve F1 on a held-out validation set
+5. Replace `contrastive_embeddings` table (downstream dynamic tables auto-refresh)
+
+**Note:** Retraining is fast (~5-30 min on GPU_NV_S) and cheap (~1-5 credits). The cost of not retraining is potential F1 degradation as entity data evolves.
+
+## Extension: Cortex Agent
+
+**Delegate to:** `cortex-agent` skill to build an agent for querying match results.
+
+Agent instructions should include:
+- Access to `entity_master`, `match_results`, `entity_groups` tables
+- Sample questions: "Find all records for entity X", "Show match history for record Y", "Which entities have the most source records?", "Show unresolved probable matches"
+- Tool mapping to a semantic view over the entity resolution tables
+
+## Extension: Custom ML Model
+
+**Delegate to:** `machine-learning` skill when the customer wants to go beyond Cortex AI functions.
+
+Use cases:
+- **Training a matching model:** Use HITL review decisions as labeled training data (accepted pairs = positive, rejected pairs = negative). Train a binary classifier or learn-to-rank model.
+- **Feature engineering:** Use cosine_sim, name_jw, street_jw, and domain-specific signals as features.
+- **Model registry:** Register the trained model in Snowflake Model Registry for version tracking.
+- **Replacing Tier 2/3:** A well-trained custom model can replace both Tier 2 and Tier 3 with a single inference call, reducing cost and latency.
+
+**Minimum training data:** 500+ labeled pairs (250+ positive, 250+ negative) for a reasonable model. Collect through HITL review.

--- a/skills/entity-resolution/references/profiles/financial-services.md
+++ b/skills/entity-resolution/references/profiles/financial-services.md
@@ -1,0 +1,102 @@
+# Financial Services Domain Profile
+
+## Tier 1 Authoritative Identifiers
+
+| Identifier | Format | Description | Priority |
+|-----------|--------|-------------|----------|
+| LEI | 20 alphanumeric (ISO 17442) | Legal Entity Identifier — global standard | 1 |
+| DUNS | 9 digits | Dun & Bradstreet Universal Numbering System | 2 |
+| Tax ID / EIN | 9 digits (XX-XXXXXXX) | US Employer Identification Number | 3 |
+| CRD | Up to 7 digits | Central Registration Depository (broker-dealers, advisors) | 4 |
+| SWIFT/BIC | 8 or 11 alphanumeric | Bank Identifier Code | 5 |
+| RSSD ID | Up to 7 digits | Federal Reserve identifier for banking institutions | 6 |
+
+**Cascade order:** LEI -> DUNS -> Tax ID -> CRD -> SWIFT -> RSSD. LEI is the gold standard for legal entity identification.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, PLC, LP, LLP, NA, N.A.,
+BANK, BANKING, TRUST, TRUST CO, TRUST COMPANY,
+FINANCIAL, FINANCE, CAPITAL, ADVISORS, ADVISORY, ADVISERS,
+SECURITIES, INVESTMENTS, INVESTMENT, ASSET MANAGEMENT, WEALTH MANAGEMENT,
+PARTNERS, GROUP, HOLDINGS, HOLDING, CO, COMPANY,
+FSB, SSB, SB, FCU, CU
+```
+
+### Abbreviations to expand
+```
+NATL -> NATIONAL
+INTL -> INTERNATIONAL
+FED -> FEDERAL
+AMER -> AMERICAN
+ASSOC -> ASSOCIATION
+MGMT -> MANAGEMENT
+INS -> INSURANCE
+SVCS -> SERVICES
+```
+
+### When to use AI_COMPLETE for name normalization
+- Entity names with multiple DBAs or subsidiary references
+- Foreign entity names requiring transliteration (common in KYC/AML)
+- Names with complex legal structure suffixes in non-English jurisdictions
+
+## Address Schema
+
+Use the standard address schema for `AI_EXTRACT`:
+
+```json
+{
+  "street": "Full street address including number and suite/unit",
+  "city": "City name",
+  "state": "State or province abbreviation",
+  "zip": "ZIP or postal code",
+  "country": "Country name or ISO 3166-1 alpha-2 code"
+}
+```
+
+**Country is critical** — financial entities are global. Always extract and normalize country.
+
+## Blocking Strategy
+
+Recommended blocking keys:
+
+1. **`country + LEFT(UPPER(normalized_name), 4)`** — Primary block. Financial entities are global; name prefix partitions effectively.
+2. **`state + LEFT(zip, 3)`** — Secondary for US-only datasets.
+3. **`entity_type + country`** — When entity type classification is available (bank, broker-dealer, fund, etc.).
+
+Expected block sizes: 200-2,000 entities per block for country+name_prefix in global datasets.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.93 | Higher than generic — financial entity names are more unique |
+| `probable_match` | >= 0.82 | |
+| `no_match` | < 0.82 | |
+
+**Subsidiary/parent caveat:** "JPMorgan Chase Bank, N.A." and "JPMorgan Chase & Co." are **different legal entities** (subsidiary vs parent). They should be linked but not merged unless the use case explicitly requires corporate hierarchy flattening. Flag these as `probable_match` for human review.
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+```
+Additional context: These are financial services entities (banks, broker-dealers, funds,
+insurance companies, advisors). Two records may represent a parent company and its subsidiary —
+these are DIFFERENT legal entities unless the user explicitly wants corporate hierarchy matching.
+Focus on: (1) Do LEI/DUNS/Tax IDs match? (2) Is the legal name substantively the same or
+does it indicate parent vs subsidiary? (3) Are they in the same jurisdiction?
+```
+
+## Entity Types
+
+| Type | Distinguishing Fields | Notes |
+|------|----------------------|-------|
+| Bank / Depository | RSSD, SWIFT, FDIC cert | Regulated entity with charter |
+| Broker-Dealer | CRD | SEC/FINRA registered |
+| Investment Advisor | CRD (IA series) | SEC or state registered |
+| Insurance Company | NAIC code | State-regulated |
+| Fund / Vehicle | LEI, fund ticker | Investment product entity |
+| Corporate (non-financial) | DUNS, EIN | Counterparty to financial entities |
+
+**KYC/AML context:** If the use case is sanctions screening or KYC, match thresholds should be **lower** (more aggressive matching) to minimize false negatives. Flag this during profiling and adjust Tier 2 thresholds: `probable_match` >= 0.75.

--- a/skills/entity-resolution/references/profiles/generic.md
+++ b/skills/entity-resolution/references/profiles/generic.md
@@ -1,0 +1,100 @@
+# Generic Domain Profile (Name + Address)
+
+This profile applies when no industry-specific identifiers are available. Matching relies entirely on name and address similarity.
+
+## Tier 1 Authoritative Identifiers
+
+**None.** Skip Tier 1 (deterministic matching) entirely. Proceed directly to Tier 2 (fuzzy matching).
+
+If the user identifies any domain-specific IDs during profiling, switch to the appropriate domain profile.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, PLC, LP, LLP,
+CO, COMPANY, GROUP, HOLDINGS, ENTERPRISES,
+DBA, D/B/A, FORMERLY, FKA, AKA,
+THE, AND, OF, AT
+```
+
+### Abbreviations to expand
+```
+ST -> STREET
+AVE -> AVENUE
+BLVD -> BOULEVARD
+DR -> DRIVE
+RD -> ROAD
+CT -> COURT
+PL -> PLACE
+LN -> LANE
+DEPT -> DEPARTMENT
+NATL -> NATIONAL
+INTL -> INTERNATIONAL
+```
+
+### When to use AI_COMPLETE for name normalization
+- Names with embedded location references ("ABC Company - New York Office")
+- Names in mixed languages or scripts
+- Names with heavy abbreviation that regex cannot reliably expand
+
+## Address Schema
+
+Use the standard address schema for `AI_EXTRACT`:
+
+```json
+{
+  "street": "Full street address including number and suite/unit",
+  "city": "City name",
+  "state": "State or province abbreviation",
+  "zip": "ZIP or postal code",
+  "country": "Country name or ISO code if present"
+}
+```
+
+## Blocking Strategy
+
+Recommended blocking keys:
+
+1. **`state + LEFT(zip, 3)`** — Primary for US entities with addresses.
+2. **`SOUNDEX(normalized_name) + state`** — Secondary when names are the primary signal.
+3. **`LEFT(UPPER(normalized_name), 4) + LEFT(zip, 3)`** — Tighter blocking for large datasets.
+
+For datasets without addresses (name-only):
+- **`SOUNDEX(normalized_name)`** — Primary.
+- **`LEFT(UPPER(normalized_name), 3)`** — Secondary prefix block.
+
+Expected block sizes vary widely. Run blocking diagnostics and adjust.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.92 | Standard threshold |
+| `probable_match` | >= 0.80 | |
+| `no_match` | < 0.80 | |
+
+**Without authoritative IDs, more pairs will land in `probable_match`.** Budget for a larger Tier 3 volume and more HITL review.
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+Use the base prompt without domain-specific additions:
+
+```
+Record A: Name="[name_left]", Address="[address_left]"
+Record B: Name="[name_right]", Address="[address_right]"
+
+Are these the same real-world entity? Consider:
+1. Are the names substantively the same (accounting for abbreviations, typos, formatting)?
+2. Are the addresses the same location (accounting for formatting differences)?
+3. Could these be different branches/locations of the same organization?
+
+Categories: match, probable_match, no_match
+```
+
+## Tips for Generic Matching
+
+- **Weight address heavily** — without authoritative IDs, address is the strongest signal after name.
+- **Use JAROWINKLER_SIMILARITY** on both name and street fields as supplemental signals. Threshold >= 0.85 for name, >= 0.80 for street.
+- **Consider phone/email** if available — exact match on phone or email is a strong confirmation signal even without formal IDs.
+- **Expect more HITL review** — generic matching produces more ambiguous results than ID-based matching. Set expectations with the customer early.

--- a/skills/entity-resolution/references/profiles/healthcare-provider.md
+++ b/skills/entity-resolution/references/profiles/healthcare-provider.md
@@ -1,0 +1,121 @@
+# Healthcare Provider Domain Profile
+
+## Tier 1 Authoritative Identifiers
+
+| Identifier | Format | Description | Priority |
+|-----------|--------|-------------|----------|
+| NPI | 10 digits | National Provider Identifier | 1 |
+| Taxonomy Code | 10 alphanumeric (X+9 chars) | Healthcare Provider Taxonomy (specialty classification) | Supplemental |
+| Medicare ID / PTAN | Variable | Provider Transaction Access Number | 2 |
+| State License | Variable by state | State medical/professional license | 3 |
+| Tax ID / EIN | 9 digits | Employer Identification Number (for organizations) | 4 |
+
+**NPI types:** Type 1 = individual provider, Type 2 = organizational provider. Do not match Type 1 against Type 2 unless explicitly linking individuals to their organizations.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, PC, PLLC, PA, SC,
+MD, DO, DDS, DMD, DPM, DC, OD, PHD, PHARMD, NP, RN, ARNP, CRNA, CNM,
+DR, DOCTOR, PROF, PROFESSOR,
+MEDICAL, MED, MEDICINE, HEALTH, HEALTHCARE,
+GROUP, PRACTICE, ASSOCIATES, ASSOC, CLINIC, CLINICS,
+CENTER, CENTRE, HOSPITAL, HOSP, SYSTEM, SYSTEMS, NETWORK,
+OF, THE, AND, AT
+```
+
+### Person name handling (Type 1 NPI)
+For individual providers:
+1. Parse into LAST, FIRST, MIDDLE, SUFFIX using `AI_EXTRACT`:
+   ```json
+   {
+     "last_name": "Family/surname",
+     "first_name": "Given name",
+     "middle_name": "Middle name or initial",
+     "suffix": "Generational suffix (Jr, Sr, III, etc.)",
+     "credential": "Professional credential (MD, DO, NP, etc.)"
+   }
+   ```
+2. Normalize to `LAST, FIRST` format for matching
+3. Strip credentials — they are classification metadata, not identity
+
+### Organization name handling (Type 2 NPI)
+Apply standard business name normalization (strip legal suffixes, expand abbreviations).
+
+### Abbreviations to expand
+```
+HOSP -> HOSPITAL
+MED -> MEDICAL
+CTR -> CENTER
+UNIV -> UNIVERSITY
+COMM -> COMMUNITY
+REHAB -> REHABILITATION
+ORTHO -> ORTHOPEDIC
+PEDS -> PEDIATRIC
+OB/GYN -> OBSTETRICS AND GYNECOLOGY
+```
+
+## Address Schema (Detailed)
+
+Healthcare providers frequently share buildings. Use the detailed schema:
+
+```json
+{
+  "street_number": "Street number only",
+  "street_name": "Street name without number",
+  "suite_unit": "Suite, unit, floor, building, or room identifier",
+  "city": "City name",
+  "state": "2-letter state abbreviation (US)",
+  "zip": "5-digit ZIP code (US)",
+  "zip4": "ZIP+4 extension if present"
+}
+```
+
+**Suite/unit is critical** — a medical office building at one address may house 20+ separate provider practices.
+
+## Blocking Strategy
+
+Recommended blocking keys:
+
+1. **`state + LEFT(zip, 3)`** — Primary. Providers are location-bound.
+2. **`SOUNDEX(last_name) + state`** — For individual provider (Type 1) deduplication.
+3. **`taxonomy_prefix + state`** — Group by specialty and state (taxonomy_prefix = first 3 chars).
+
+Expected block sizes: 500-5,000 per block for state+zip3.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.91 | |
+| `probable_match` | >= 0.80 | |
+| `no_match` | < 0.80 | |
+
+**Group practice caveat:** A provider may appear individually (Type 1 NPI) and as part of a group (Type 2 NPI). These are **different entities** — one is a person, the other is an organization. The individual is a *member of* the group, not a duplicate.
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+```
+Additional context: These are healthcare providers (doctors, nurses, clinics, hospitals,
+group practices). NPI Type 1 (individual) and Type 2 (organization) are DIFFERENT entity
+types — do not match across types. Providers at the same address but different suites
+are DIFFERENT entities. A provider may practice at multiple locations — match by NPI
+not by address alone.
+Focus on: (1) Do NPIs match? (2) Is this the same NPI type? (3) For individuals,
+do last name + first name match (credentials and middle initials may vary)?
+(4) For organizations, is it the same practice or a different practice at the same address?
+```
+
+## Entity Types
+
+| Type | Distinguishing Fields | Notes |
+|------|----------------------|-------|
+| Individual Provider | NPI Type 1, credential | Person-level entity |
+| Group Practice | NPI Type 2, Tax ID | Organization of providers |
+| Hospital / Facility | NPI Type 2, facility code | Institutional provider |
+| Health System | Tax ID, system affiliation | Parent organization (multiple facilities) |
+
+## Multi-Location Providers
+
+Individual providers may practice at 2+ locations. In NPPES data, each practice location gets a separate record but the **same NPI**. These are the same entity with multiple addresses — deduplicate by NPI, retain all addresses as attributes.

--- a/skills/entity-resolution/references/profiles/insurance-payer.md
+++ b/skills/entity-resolution/references/profiles/insurance-payer.md
@@ -1,0 +1,113 @@
+# Insurance / Payer Domain Profile
+
+## Tier 1 Authoritative Identifiers
+
+| Identifier | Format | Description | Priority |
+|-----------|--------|-------------|----------|
+| NAIC Code | 5 digits | National Association of Insurance Commissioners identifier | 1 |
+| CMS Payer ID | 5 alphanumeric | Centers for Medicare & Medicaid Services payer identifier | 2 |
+| Plan ID (HIOS) | 14-16 alphanumeric | Health Insurance Oversight System plan identifier (ACA marketplace) | 3 |
+| Tax ID / EIN | 9 digits (XX-XXXXXXX) | Employer Identification Number | 4 |
+| DUNS | 9 digits | Dun & Bradstreet Universal Numbering System | 5 |
+| AM Best ID | Variable | AM Best Company Number (rating agency identifier) | 6 |
+
+**Cascade order:** NAIC -> CMS Payer ID -> Plan ID -> Tax ID -> DUNS -> AM Best. NAIC is the gold standard for US-domiciled insurance carriers.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, CO, COMPANY,
+INSURANCE, INS, ASSURANCE, INDEMNITY,
+HEALTH, HEALTHCARE, HEALTH CARE,
+PLAN, PLANS, HMO, PPO, EPO, POS, HDHP,
+MUTUAL, GROUP, BENEFITS, BENEFIT,
+LIFE, CASUALTY, PROPERTY, FIRE,
+OF, THE, AND, AT,
+UNDERWRITERS, UNDERWRITING
+```
+
+### Abbreviations to expand
+```
+INS -> INSURANCE
+NATL -> NATIONAL
+AMER -> AMERICAN
+ASSOC -> ASSOCIATION
+MGMT -> MANAGEMENT
+GRP -> GROUP
+HLTH -> HEALTH
+BC -> BLUE CROSS
+BS -> BLUE SHIELD
+BCBS -> BLUE CROSS BLUE SHIELD
+```
+
+### When to use AI_COMPLETE for name normalization
+- Plans with parent company references embedded ("Anthem Blue Cross - California Individual & Family Plans")
+- DBA/trade name vs legal entity name (e.g., "Wellpoint Inc" dba "Anthem Blue Cross")
+- Regional Blue Cross Blue Shield licensees with complex naming
+
+## Address Schema
+
+Standard schema (same as financial services — use country field since some reinsurers are international):
+
+```json
+{
+  "street": "Full street address including number and suite/unit",
+  "city": "City name",
+  "state": "State or province abbreviation",
+  "zip": "ZIP or postal code",
+  "country": "Country name or ISO 3166-1 alpha-2 code"
+}
+```
+
+**Note:** State of domicile is critical — an insurance company is chartered in one state but may operate in many. Use domicile state as the primary geographic attribute, not mailing address state.
+
+## Blocking Strategy
+
+Recommended blocking keys:
+
+1. **`state_of_domicile + LEFT(UPPER(normalized_name), 4)`** — Primary. Insurers are state-regulated.
+2. **`line_of_business + state_of_domicile`** — When line-of-business classification is available (life, P&C, health).
+3. **`LEFT(UPPER(normalized_name), 5) + country`** — For international reinsurers.
+
+Expected block sizes: 100-1,000 per block for state+name_prefix.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.93 | Higher — insurance entity names are relatively unique |
+| `probable_match` | >= 0.82 | |
+| `no_match` | < 0.82 | |
+
+**Subsidiary/parent caveat:** Same as financial services — "Anthem, Inc." and "Anthem Blue Cross Life and Health Insurance Company" are different legal entities (parent vs subsidiary). They should be linked but not merged unless explicitly requested. Also: a plan product ("Anthem Gold 80 HMO") is NOT the same entity as the issuing company ("Anthem Blue Cross").
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+```
+Additional context: These are insurance/payer entities (health insurers, P&C carriers,
+life insurers, reinsurers, managed care organizations). A parent company and its subsidiary
+are DIFFERENT legal entities. A plan product name is NOT the same entity as the issuing
+company. Blue Cross Blue Shield licensees in different states are DIFFERENT entities even
+though they share the BCBS brand. Focus on: (1) Do NAIC codes or CMS Payer IDs match?
+(2) Is this the same legal entity or parent vs subsidiary? (3) Are they in the same
+state of domicile? (4) Is one a plan product name and the other the issuing company?
+```
+
+## Entity Types
+
+| Type | Distinguishing Fields | Notes |
+|------|----------------------|-------|
+| Health Insurer (commercial) | NAIC, CMS Payer ID | State-regulated, may operate multi-state |
+| Medicare Advantage Plan | CMS Payer ID, Plan ID (H-number) | CMS-contracted |
+| Medicaid MCO | CMS Payer ID, state contract | State-contracted managed care |
+| P&C Carrier | NAIC, AM Best | Property and casualty insurer |
+| Life Insurer | NAIC, AM Best | Life and annuity products |
+| Reinsurer | NAIC (if US), AM Best, LEI | May be international |
+| TPA (Third-Party Administrator) | Tax ID | Administers plans but does not bear risk |
+
+When matching, **do not match across entity types** unless explicitly requested. A TPA and a health insurer at the same address are different entities.
+
+## Multi-State Operations
+
+Insurance companies are domiciled in one state but licensed in many. In NAIC data, the company has ONE NAIC code regardless of operating states. Do not create separate entities per operating state — deduplicate by NAIC code. However, Blue Cross Blue Shield licensees ARE separate legal entities per state/region.

--- a/skills/entity-resolution/references/profiles/pharma.md
+++ b/skills/entity-resolution/references/profiles/pharma.md
@@ -1,0 +1,108 @@
+# Pharma Domain Profile
+
+## Tier 1 Authoritative Identifiers
+
+| Identifier | Format | Description | Priority |
+|-----------|--------|-------------|----------|
+| NPI | 10 digits | National Provider Identifier (prescribers, pharmacies) | 1 |
+| DEA | 2 letters + 7 digits | Drug Enforcement Administration registration | 2 |
+| NCPDP | 7 digits | National Council for Prescription Drug Programs (pharmacies) | 3 |
+| HIN | Variable | Health Industry Number (distributors) | 4 |
+| NDC | 10-11 digits (5-4-2 or 5-4-1) | National Drug Code (products, not entities — use for product matching only) | N/A |
+
+**Cascade order:** NPI -> DEA -> NCPDP -> HIN. Match on the highest-priority ID available.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, LP, LLP,
+PHARMACY, PHCY, PHARMA, PHARMACEUTICAL, PHARMACEUTICALS,
+DRUG, DRUGS, DRUGSTORE, RX, APOTHECARY,
+STORE, SHOP, CENTER, CENTRE, CLINIC,
+DBA, D/B/A, FORMERLY, FKA, AKA
+```
+
+### Abbreviations to expand
+```
+PHCY -> PHARMACY
+HOSP -> HOSPITAL
+MED -> MEDICAL
+CTR -> CENTER
+SVC -> SERVICE
+SVCS -> SERVICES
+HLTH -> HEALTH
+NATL -> NATIONAL
+INTL -> INTERNATIONAL
+```
+
+### When to use AI_COMPLETE for name normalization
+- Names containing store numbers (e.g., "CVS #12345" vs "CVS PHARMACY 12345") — AI can normalize the store number format
+- Names with parenthetical DBA references (e.g., "ABC Corp (dba XYZ Pharmacy)")
+- Names in non-English characters requiring transliteration
+
+## Address Schema (Detailed)
+
+Pharma entities often share buildings. Use the detailed address schema for `AI_EXTRACT`:
+
+```json
+{
+  "street_number": "Street number only",
+  "street_name": "Street name without number",
+  "suite_unit": "Suite, unit, floor, room, or building identifier",
+  "city": "City name",
+  "state": "2-letter state abbreviation (US)",
+  "zip": "5-digit ZIP code (US)",
+  "zip4": "ZIP+4 extension if present",
+  "country": "Country ISO code if present"
+}
+```
+
+**Suite/unit is critical** — multiple pharmacies or prescriber offices may share one street address. Do NOT merge entities that differ only by suite/unit.
+
+## Blocking Strategy
+
+Recommended blocking keys (in priority order):
+
+1. **`state + LEFT(zip, 3)`** — Primary block. Pharmacies and prescribers are location-bound.
+2. **`SOUNDEX(normalized_name) + state`** — Secondary block for chains with spelling variations.
+3. **`LEFT(npi, 6)`** — If NPI is present, prefix blocking catches transposed-digit errors.
+
+Expected block sizes: 500-5,000 entities per block for state+zip3 in typical pharma datasets.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.90 | Lower than generic — pharma names are highly formulaic ("CVS Pharmacy" appears thousands of times) |
+| `probable_match` | >= 0.78 | Wider band — chain pharmacies have many near-duplicates |
+| `no_match` | < 0.78 | |
+
+**Chain pharmacy deduplication caveat:** Two CVS locations at different addresses are **different entities**. Cosine similarity on name alone will be very high. Always weight address fields heavily. Consider adding `JAROWINKLER_SIMILARITY` on street address as a tiebreaker with threshold >= 0.85.
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+Add to the base Tier 3 prompt for pharma:
+
+```
+Additional context: These are pharmaceutical entities (pharmacies, prescribers, distributors).
+Two records at the same address but different suite/unit numbers are DIFFERENT entities.
+Two records with the same name but different addresses are DIFFERENT entities (chain locations).
+Focus on: (1) Do the identifiers (NPI/DEA) match or are they absent? (2) Is the address
+including suite/unit the same? (3) Are name differences just formatting or do they indicate
+different business entities?
+```
+
+## Entity Types
+
+Pharma datasets typically contain mixed entity types:
+
+| Type | Distinguishing Fields | Notes |
+|------|----------------------|-------|
+| Pharmacy (retail) | NCPDP, store number | Chain pharmacies are separate entities per location |
+| Pharmacy (mail-order) | NCPDP, no physical storefront | May share corporate address |
+| Prescriber (individual) | NPI (Type 1), DEA | Person-level entity |
+| Prescriber (organization) | NPI (Type 2) | Group practice, hospital |
+| Distributor | HIN, DEA | Wholesale drug distributors |
+
+When matching, **do not match across entity types** unless explicitly requested. A pharmacy and a prescriber at the same address are different entities.

--- a/skills/entity-resolution/references/profiles/retail-cpg.md
+++ b/skills/entity-resolution/references/profiles/retail-cpg.md
@@ -1,0 +1,106 @@
+# Retail / CPG Domain Profile
+
+## Tier 1 Authoritative Identifiers
+
+| Identifier | Format | Description | Priority |
+|-----------|--------|-------------|----------|
+| GTIN/UPC | 8, 12, 13, or 14 digits | Global Trade Item Number (product-level) | 1 (products) |
+| GLN | 13 digits | Global Location Number (location-level) | 1 (locations) |
+| Supplier ID | Vendor-specific | Internal supplier/vendor number | 2 |
+| DUNS | 9 digits | Dun & Bradstreet (corporate-level) | 3 |
+
+**Entity vs product distinction:** GTIN/UPC identifies *products*, not *entities*. For supplier/vendor matching, use GLN or DUNS. For product matching (deduplication across catalogs), use GTIN/UPC.
+
+## Name Normalization Rules
+
+### Terms to strip (case-insensitive)
+```
+LLC, INC, INCORPORATED, CORP, CORPORATION, LTD, LIMITED, CO, COMPANY,
+STORES, STORE, SHOP, SHOPS, MARKET, MARKETS, SUPERMARKET, GROCERY,
+FOODS, FOOD, BRANDS, BRAND, PRODUCTS, PRODUCT,
+WHOLESALE, DISTRIBUTION, DISTRIBUTING, SUPPLY, SUPPLIES,
+DBA, D/B/A, FORMERLY, FKA, AKA,
+GROUP, HOLDINGS, ENTERPRISES, INTERNATIONAL, GLOBAL
+```
+
+### Abbreviations to expand
+```
+INTL -> INTERNATIONAL
+NATL -> NATIONAL
+DIST -> DISTRIBUTION
+MFG -> MANUFACTURING
+PKG -> PACKAGING
+WHSE -> WAREHOUSE
+```
+
+### Store number handling
+Retail entities frequently include store numbers: "WALMART #4523", "TARGET T-1892". Normalize by:
+1. Extract store number to a separate field
+2. Strip from entity name for matching purposes
+3. Use store number as a supplemental match signal (exact match = strong confirmation)
+
+### When to use AI_COMPLETE for name normalization
+- Private label brands with variable naming ("Great Value" vs "GV" vs store brand references)
+- Supplier names with plant/facility codes embedded
+
+## Address Schema
+
+Use the standard address schema:
+
+```json
+{
+  "street": "Full street address including number and suite/unit",
+  "city": "City name",
+  "state": "State or province abbreviation",
+  "zip": "ZIP or postal code",
+  "country": "Country name or ISO code if present"
+}
+```
+
+## Blocking Strategy
+
+Recommended blocking keys:
+
+1. **`state + LEFT(zip, 3)`** — Primary for location-based entities (stores, warehouses).
+2. **`LEFT(UPPER(normalized_name), 5) + state`** — For supplier/vendor matching where names are more distinctive.
+3. **`category_code + country`** — If product category or NAICS code is available.
+
+Expected block sizes: 1,000-10,000 for state+zip3 in national retail datasets.
+
+## Match Threshold Starting Points
+
+| Decision | Cosine Similarity | Notes |
+|----------|------------------|-------|
+| `match` | >= 0.91 | |
+| `probable_match` | >= 0.79 | |
+| `no_match` | < 0.79 | |
+
+**Franchise caveat:** Franchise locations (e.g., McDonald's) may have different legal entity names (the franchisee) but the same trade name. Clarify during profiling whether the goal is to match by **trade name** (brand) or **legal entity** (franchise owner).
+
+## Tier 3 AI_CLASSIFY Prompt Enhancement
+
+```
+Additional context: These are retail/CPG entities (retailers, suppliers, distributors,
+manufacturers). Different store locations of the same chain are DIFFERENT entities.
+A franchise location owned by a different legal entity is a DIFFERENT entity from
+corporate-owned locations unless matching by trade name only.
+Focus on: (1) Do GLN/DUNS/Supplier IDs match? (2) Is this the same physical location
+or a different branch? (3) Are name differences due to DBA/trade name vs legal name?
+```
+
+## Entity Types
+
+| Type | Distinguishing Fields | Notes |
+|------|----------------------|-------|
+| Retailer (store) | GLN, store number | Each location is a separate entity |
+| Supplier / Vendor | Supplier ID, DUNS | Corporate-level entity |
+| Manufacturer | DUNS, plant code | May have multiple facilities |
+| Distributor | GLN, warehouse code | Logistics entity |
+| Product | GTIN/UPC | Not an entity — match separately if needed |
+
+## Product Matching (Supplemental)
+
+If the engagement includes product deduplication across catalogs:
+- Match on GTIN/UPC as Tier 1 (deterministic)
+- Embed product description + brand + category for Tier 2
+- Be cautious with pack-size variants (12-pack vs 24-pack have different GTINs but similar descriptions)

--- a/skills/entity-resolution/references/templates/agent-definition.md
+++ b/skills/entity-resolution/references/templates/agent-definition.md
@@ -1,0 +1,324 @@
+# Agent Definition — Cortex Agent for Entity Resolution
+
+Template for defining a Cortex Agent that resolves entities using multi-tool search with reasoning. Used in Tier 2 of the agentic matching workflow (see `agentic-matching.md`).
+
+## Agent Specification
+
+**Delegate to:** `cortex-agent` skill to create the agent. Provide this specification as the ER-specific configuration.
+
+```sql
+CREATE OR REPLACE AGENT <schema>.entity_resolution_agent
+    COMMENT = 'Matches source entities to reference records via search, SQL, and web search'
+    FROM SPECIFICATION
+$$
+models:
+  orchestration: claude-haiku-4-5
+
+orchestration:
+  budget:
+    seconds: 90
+    tokens: 16000
+
+instructions:
+  system: |
+    Match source entity records to reference records.
+
+    <DOMAIN_ABBREVIATION_MAP>
+
+    RULES:
+    - Same name + same address = match
+    - Same name + different address (minor formatting differences OK) = probable_match
+    - Different name + same address = investigate (check DBA names)
+    - Different suite/unit numbers at same street address = DIFFERENT entities
+    - <DOMAIN_SPECIFIC_RULES>
+
+    DECISIONS (use exactly one):
+    - "match": High confidence the entity matches this reference record.
+    - "probable_match": Likely match but some ambiguity.
+    - "no_match": Exhausted all search strategies, no match found.
+    - "investigate": Ambiguous, requires human review.
+    - "location_closed": Entity identified but confirmed permanently closed.
+    - "new_record_needed": Entity confirmed active (via web search) but missing from reference corpus.
+
+  orchestration: |
+    BUDGET: Make a decision within 6 tool calls total. Do NOT keep searching
+    after 6 calls — use the best evidence and decide.
+
+    TOOL PRIORITY ORDER:
+    1. Corpus_Search (PRIMARY): Search by expanded name + geographic filter.
+       If a clear match appears, decide immediately.
+       Maximum 3 Corpus_Search calls per entity.
+    2. Corpus_Query (FALLBACK): SQL query if search returned zero or ambiguous results.
+       Maximum 1 Corpus_Query call per entity.
+    3. Web_Search (LAST RESORT): Only after BOTH internal tools failed.
+       Maximum 1 Web_Search call per entity.
+       Useful for: confirming closures, finding rebrands/acquisitions, verifying existence.
+
+    GEOGRAPHIC FILTERING:
+    Always include a state filter when using Corpus_Search if the entity has a known state.
+    Use: {"filter": {"@eq": {"state": "<entity_state>"}}}
+    If state is unknown or the filtered search returns zero results, retry WITHOUT
+    the state filter — but evaluate cross-state results with extra skepticism.
+    Same-state matches are strongly preferred over cross-state matches.
+
+    WHEN USING WEB SEARCH:
+    Populate "web_sources" with URLs, titles, and snippets consulted.
+    If web search confirms the entity exists, populate "web_validated_entity".
+
+  response: |
+    Return ONLY JSON:
+    {
+      "decision": "match|probable_match|no_match|investigate|location_closed|new_record_needed",
+      "matched_reference_id": "ID or null",
+      "matched_name": "name or null",
+      "matched_address": "address or null",
+      "matched_city": "city or null",
+      "matched_state": "state or null",
+      "matched_zip": "ZIP or null",
+      "confidence": 0.0-1.0,
+      "reasoning": "brief explanation",
+      "web_search_used": true/false,
+      "web_sources": [{"url":"...","title":"...","snippet":"..."}],
+      "web_validated_entity": {"name":"...","address":"...","city":"...","state":"...","zip":"...","source_type":"...","validation_confidence":0.0-1.0},
+      "discovered_name": "name confirmed via web or null",
+      "discovered_address": "address or null",
+      "discovered_city": "city or null",
+      "discovered_zip": "ZIP or null",
+      "discovery_reasoning": "why this entity is missing from reference or null"
+    }
+
+tools:
+  - tool_spec:
+      type: "cortex_search"
+      name: "Corpus_Search"
+      description: "Fuzzy search reference entity records. Search by name, address, city, keywords. PRIMARY tool — always try first."
+
+  - tool_spec:
+      type: "cortex_analyst_text_to_sql"
+      name: "Corpus_Query"
+      description: "SQL queries on reference entity table. FALLBACK — use only when Corpus_Search returns no results."
+
+  - tool_spec:
+      type: "web_search"
+      name: "Web_Search"
+      description: "Search the public web. LAST RESORT — use only after both internal tools fail."
+
+tool_resources:
+  Corpus_Search:
+    name: "<database>.<schema>.reference_search_svc"
+    max_results: "5"
+    id_column: "ENTITY_ID"
+    columns_and_descriptions:
+      SEARCH_TEXT:
+        description: "Name+address combined text"
+        type: "string"
+        searchable: true
+        filterable: false
+      ENTITY_NAME:
+        description: "Entity name, UPPERCASE"
+        type: "string"
+        searchable: true
+        filterable: false
+      DBA_NAME:
+        description: "DBA / trade name if any"
+        type: "string"
+        searchable: true
+        filterable: false
+      CITY:
+        description: "City, UPPERCASE"
+        type: "string"
+        searchable: false
+        filterable: true
+      ZIP5:
+        description: "5-digit ZIP"
+        type: "string"
+        searchable: false
+        filterable: true
+      ENTITY_ID:
+        description: "Unique reference entity identifier"
+        type: "string"
+        searchable: false
+        filterable: true
+
+  Corpus_Query:
+    semantic_model_file: "@<database>.<schema>.<stage>/semantic_model.yaml"
+    execution_environment:
+      type: "warehouse"
+      warehouse: "<warehouse_name>"
+$$;
+```
+
+## Placeholders to Replace
+
+| Placeholder | Description | Example |
+|-------------|-------------|---------|
+| `<schema>` | Fully qualified schema | `MY_DB.ER_SCHEMA` |
+| `<database>.<schema>.reference_search_svc` | Cortex Search Service (from `search-service.md`) | `MY_DB.ER_SCHEMA.REFERENCE_SEARCH_SVC` |
+| `<database>.<schema>.<stage>` | Stage containing the semantic model YAML | `MY_DB.ER_SCHEMA.ER_ASSETS` |
+| `<warehouse_name>` | Warehouse for SQL execution | `ER_WH` |
+| `<DOMAIN_ABBREVIATION_MAP>` | Domain-specific abbreviation mappings from the loaded profile | See below |
+| `<DOMAIN_SPECIFIC_RULES>` | Domain-specific matching rules from the loaded profile | See below |
+
+## Domain-Specific Prompt Sections
+
+### Abbreviation Map
+
+Build from the loaded domain profile's normalization rules. Example for healthcare/pharma:
+
+```
+ABBREVIATION MAP:
+Medical: HSP/HOSP=Hospital, PHCY/PHMY=Pharmacy, HLTH=Health, CTR=Center, MED=Medical,
+  DLYS=Dialysis, INF=Infusion, ONC=Oncology, COMM=Community, REHAB=Rehabilitation
+Geography: FT=Fort, ST=Saint, MT=Mount, SPGS=Springs, HTS=Heights
+Chains: WALGREENS #NNNNN, CVS PHARMACY NNNN, PUBLIX PHARMACY #NNNN
+Suffixes to STRIP: LLC, INC, PA, DBA, D/B/A, <domain_strip_terms>
+```
+
+### Domain-Specific Rules
+
+Append rules from the loaded profile. Examples:
+
+- **Healthcare:** Different Class of Trade (IP vs OP vs Retail) at the same address = DIFFERENT entities
+- **Financial services:** Subsidiaries sharing a parent address may be different entities — check legal entity names
+- **Retail/CPG:** Chain stores with same brand + same address but different store numbers may be the same entity (renumbering)
+
+## Semantic Model YAML
+
+The agent's `Corpus_Query` tool requires a semantic model YAML file describing the reference table. Create this and upload to a stage.
+
+```yaml
+name: reference_entity_model
+description: Reference entity records for entity resolution queries.
+tables:
+  - name: <schema>.search_corpus
+    description: Denormalized reference entity records.
+    columns:
+      - name: ENTITY_ID
+        description: Unique entity identifier.
+        data_type: VARCHAR
+      - name: ENTITY_NAME
+        description: Entity name (uppercase).
+        data_type: VARCHAR
+      - name: DBA_NAME
+        description: DBA or trade name (may be NULL).
+        data_type: VARCHAR
+      - name: ADDRESS_LINE_1
+        description: Street address (uppercase).
+        data_type: VARCHAR
+      - name: CITY
+        description: City (uppercase).
+        data_type: VARCHAR
+      - name: STATE
+        description: 2-letter state code.
+        data_type: VARCHAR
+      - name: ZIP5
+        description: 5-digit ZIP code.
+        data_type: VARCHAR
+      # Add domain-specific columns:
+      # - name: TAXONOMY_CODE
+      #   description: Provider taxonomy code.
+      #   data_type: VARCHAR
+```
+
+Upload to stage:
+```bash
+snow stage copy semantic_model.yaml @<database>.<schema>.<stage>/ -c <connection>
+```
+
+## Agent Invocation
+
+Call the agent from a stored procedure using `SNOWFLAKE.CORTEX.DATA_AGENT_RUN`:
+
+```python
+import json
+
+AGENT_NAME = '<database>.<schema>.entity_resolution_agent'
+
+request_body = json.dumps({
+    "messages": [{
+        "role": "user",
+        "content": [{"type": "text", "text": prompt}]
+    }]
+})
+safe_json = request_body.replace("\\", "\\\\").replace("'", "''")
+
+rows = session.sql(
+    f"SELECT TRY_PARSE_JSON("
+    f"SNOWFLAKE.CORTEX.DATA_AGENT_RUN("
+    f"'{AGENT_NAME}', "
+    f"'{safe_json}'"
+    f")) AS result"
+).collect()
+```
+
+## Response Parsing
+
+Agent responses are wrapped in an envelope. Extract the text content:
+
+```python
+def parse_agent_response(raw):
+    """Extract structured decision from agent response envelope."""
+    VALID_DECISIONS = {
+        'match', 'probable_match', 'no_match',
+        'investigate', 'location_closed', 'new_record_needed'
+    }
+
+    default = {
+        "decision": "no_match",
+        "matched_reference_id": None,
+        "matched_name": None,
+        "matched_address": None,
+        "confidence": 0.0,
+        "reasoning": "",
+        "web_search_used": False,
+        "web_sources": [],
+        "web_validated_entity": None,
+    }
+
+    # 1. Unwrap envelope → extract text block
+    envelope = raw if isinstance(raw, dict) else json.loads(raw)
+    text = ""
+    for block in reversed(envelope.get("content", [])):
+        if isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text", "")
+            break
+    if not text:
+        text = str(raw)
+
+    # 2. Try parsing: code-fence JSON → direct JSON → first {...} block
+    import re
+    # Code fence
+    m = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', text, re.DOTALL)
+    if m:
+        result = {**default, **json.loads(m.group(1))}
+        if result["decision"] not in VALID_DECISIONS:
+            result["decision"] = "no_match"
+        return result
+
+    # Direct parse
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict) and "decision" in parsed:
+            result = {**default, **parsed}
+            if result["decision"] not in VALID_DECISIONS:
+                result["decision"] = "no_match"
+            return result
+    except Exception:
+        pass
+
+    # First JSON object with "decision" key
+    for m in re.finditer(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', text, re.DOTALL):
+        try:
+            candidate = json.loads(m.group(0))
+            if isinstance(candidate, dict) and "decision" in candidate:
+                result = {**default, **candidate}
+                if result["decision"] not in VALID_DECISIONS:
+                    result["decision"] = "no_match"
+                return result
+        except Exception:
+            continue
+
+    # Fallback
+    default["reasoning"] = text[:2000]
+    return default
+```

--- a/skills/entity-resolution/references/templates/agentic-matching.md
+++ b/skills/entity-resolution/references/templates/agentic-matching.md
@@ -1,0 +1,502 @@
+# Agentic Matching — 3-Tier Entity Linking Workflow
+
+Resolve source entities against a reference corpus using a progressive escalation funnel. Each tier is more capable and more expensive than the previous. Only unresolved entities escalate to the next tier.
+
+**Use this workflow when:**
+- Matching source records against a known reference corpus (entity linking), not comparing records within/across datasets (deduplication)
+- The reference corpus is available as a Cortex Search Service
+- Entities may require web validation (closures, rebrands, acquisitions)
+- The domain includes abbreviations, name variants, or Class of Trade distinctions that require reasoning
+
+**Do NOT use when:**
+- Performing symmetric deduplication (no "reference side") — use `matching.md` instead
+- The reference corpus is small enough to compare all pairs directly (<10K records)
+
+## Architecture Overview
+
+```
+Source Entities (normalized, embedded)
+  │
+  ├─── Tier 1: High-Confidence Triage (pure SQL)
+  │     ├── RESOLVED ──→ highconf_matches
+  │     └── UNRESOLVED ──↓
+  │
+  ├─── Tier 1.5: Batch Search + Classify (Cortex Search + AI_COMPLETE)
+  │     ├── RESOLVED ──→ batch_classify_matches
+  │     └── UNRESOLVED ──↓
+  │
+  └─── Tier 2: Agentic Search (Cortex Agent with tools + web search)
+        ├── RESOLVED ──→ agent_results
+        └── UNRESOLVED ──→ no_match / investigate / new_record_needed
+                              │
+                              ↓
+                    Crosswalk (UNION ALL of all tiers)
+```
+
+**Expected volume reduction:**
+- Tier 1 resolves ~60-80% of entities (high-confidence embedding + JW matches)
+- Tier 1.5 resolves ~10-20% (medium-confidence, search-assisted)
+- Tier 2 resolves the remaining ~5-20% (hardest cases requiring reasoning/web search)
+
+## Prerequisites
+
+Before starting the agentic matching workflow:
+
+1. **Normalized entities** — Source entities must be normalized (Phase 2 output)
+2. **Embeddings** — Both source and reference entities must have embeddings (`AI_EMBED` with `snowflake-arctic-embed-l-v2.0`)
+3. **Match candidates** — Top-N embedding matches per source entity (from Phase 3 blocking or direct vector search)
+4. **Cortex Search Service** — Over the reference corpus (see `search-service.md`)
+5. **Semantic model** — YAML file for the reference corpus (for the agent's SQL fallback tool)
+
+---
+
+## Tier 1: High-Confidence Triage
+
+**Goal:** Resolve entities where embedding similarity + string similarity scores exceed tight thresholds. Pure SQL, zero AI cost.
+
+**Delegate to:** Standard SQL execution. No bundled skill needed.
+
+### Match Rules
+
+Apply these rules to the top-1 embedding candidate per source entity:
+
+```sql
+CREATE OR REPLACE TABLE highconf_matches AS
+WITH top1 AS (
+    SELECT *
+    FROM match_candidates
+    WHERE rn = 1
+)
+SELECT
+    t.id_left       AS source_entity_id,
+    t.id_right      AS reference_entity_id,
+    t.cosine_sim,
+    t.name_jw,
+    t.street_jw,
+    t.zip_exact,
+    t.composite_score AS confidence,
+    'tier1_highconf' AS match_method,
+    'match'          AS decision
+FROM top1 t
+WHERE
+    -- Path 1: Strong embedding + strong name
+    (
+        (cosine_sim >= 0.92 AND name_jw >= 0.85)
+        OR (cosine_sim >= 0.90 AND name_jw >= 0.80
+            AND street_jw >= 0.90 AND zip_exact = 1)
+    )
+    -- Address floor guard: require some address alignment
+    AND (street_jw >= 0.70 OR zip_exact = 1);
+```
+
+### Domain-Specific Guard Rails
+
+Add guard rails based on the loaded domain profile. Common patterns:
+
+**Chain-store guard** (retail, pharma): If both entities match a known chain brand, require store number match:
+```sql
+-- Add to the WHERE clause:
+AND (both_are_chains = 0 OR store_num_match = 1)
+```
+
+**Multi-tenant building guard** (healthcare, office buildings): At addresses with 4+ reference entities, require tighter name match to prevent wrong-tenant matches:
+```sql
+-- Add to the WHERE clause:
+AND (
+    is_multi_tenant = 0           -- standard addresses: normal thresholds
+    OR name_jw >= 0.92            -- high-density: very strong name match
+    OR zip4_exact = 1             -- high-density: ZIP+4 confirms same suite
+)
+```
+
+**Chain-brand consolidation** (optional): Same chain brand + strong address match can override store number mismatch (e.g., store renumbering during remodeling). Flag for human review:
+```sql
+-- Additional OR path in WHERE clause:
+OR (
+    chain_brand_match = 1
+    AND street_jw >= 0.90
+    AND zip_exact = 1
+    AND name_jw >= 0.75
+    AND cosine_sim >= 0.80
+)
+```
+
+### Threshold Starting Points
+
+These are starting points. Tune based on manual review of results.
+
+| Parameter | Starting Value | Notes |
+|-----------|---------------|-------|
+| `cosine_sim` (primary path) | >= 0.92 | Tighten to 0.94 if over-matching |
+| `name_jw` (primary path) | >= 0.85 | Core name similarity |
+| `cosine_sim` (address-confirmed path) | >= 0.90 | Lower cosine OK if address is strong |
+| `name_jw` (address-confirmed path) | >= 0.80 | |
+| `street_jw` (address-confirmed path) | >= 0.90 | |
+| `street_jw` (address floor) | >= 0.70 | Prevents wrong-location matches |
+| `name_jw` (multi-tenant override) | >= 0.92 | Only for buildings with 4+ tenants |
+
+**MANDATORY STOPPING POINT**: Present Tier 1 match counts and sample matches for user review before proceeding.
+
+---
+
+## Tier 1.5: Batch Search + Classify
+
+**Goal:** Resolve medium-confidence entities using Cortex Search retrieval + LLM classification. ~10-50x cheaper than a full agent call.
+
+**Delegate to:** `cortex-ai-functions` for `AI_COMPLETE` calls. Cortex Search is called via `SNOWFLAKE.CORTEX.SEARCH_PREVIEW`.
+
+### Step 1: Batch Search
+
+For each unresolved entity, query the Cortex Search Service with the entity's name + address as the search query. Retrieve top-N results (typically 10).
+
+```sql
+-- Search query construction per entity:
+-- CONCAT(expanded_name, ' ', normalized_street, ' ', city, ' ', state, ' ', zip)
+
+-- Filter by state if the reference corpus is nationwide
+-- {"filter": {"@eq": {"state": "<entity_state>"}}}
+```
+
+See `search-service.md` for the search SP template (`RUN_BATCH_SEARCH`). The SP:
+1. Iterates over unresolved entities
+2. Calls `SNOWFLAKE.CORTEX.SEARCH_PREVIEW` per entity
+3. Bulk-inserts results with set-based JW scoring (name_jw, street_jw, zip_exact, composite_score)
+
+### Step 2: Classify Top Candidate
+
+For each entity's top search result (by composite score), use `AI_COMPLETE` to classify whether it's the same entity.
+
+```sql
+-- Classification prompt template:
+SNOWFLAKE.CORTEX.COMPLETE(
+    '<model>',  -- Use a cost-effective model: 'claude-haiku-4-5' or 'mistral-large2'
+    CONCAT(
+        'You are an entity resolution expert. Determine if these two records '
+        'refer to the same entity.\n\n',
+        'ENTITY A (Source record):\n',
+        '  Name: ', COALESCE(source_name, 'N/A'), '\n',
+        '  Address: ', COALESCE(source_street, 'N/A'), '\n',
+        '  City: ', COALESCE(source_city, 'N/A'), '\n',
+        '  State: ', COALESCE(source_state, 'N/A'), '\n',
+        '  ZIP: ', COALESCE(source_zip, 'N/A'), '\n\n',
+        'ENTITY B (Reference record):\n',
+        '  Name: ', COALESCE(ref_name, 'N/A'), '\n',
+        '  Address: ', COALESCE(ref_address, 'N/A'), '\n',
+        '  City: ', COALESCE(ref_city, 'N/A'), '\n',
+        '  State: ', COALESCE(ref_state, 'N/A'), '\n',
+        '  ZIP: ', COALESCE(ref_zip, 'N/A'), '\n\n',
+        'SCORING CONTEXT:\n',
+        '  Name similarity (Jaro-Winkler): ', name_jw, '\n',
+        '  Address similarity (Jaro-Winkler): ', street_jw, '\n',
+        '  ZIP exact match: ', CASE WHEN zip_exact = 1 THEN 'Yes' ELSE 'No' END, '\n\n',
+        '<DOMAIN_SPECIFIC_RULES>\n\n',  -- Insert domain profile rules here
+        'Respond with ONLY a JSON object:\n',
+        '{"decision": "match|no_match|uncertain", "confidence": 0.0-1.0, "reasoning": "brief explanation"}'
+    )
+)
+```
+
+**Domain-specific rules:** Insert the domain profile's abbreviation mappings, entity type distinctions (e.g., different Class of Trade = different entity), and chain-store rules into the `<DOMAIN_SPECIFIC_RULES>` placeholder.
+
+### Step 3: Accept Matches with Guard Rails
+
+Accept classified matches only if guard rails pass:
+
+```sql
+INSERT INTO batch_classify_matches
+SELECT ...
+FROM batch_classify_results
+WHERE decision = 'match'
+  AND confidence >= 0.80
+  -- Guard rails: require minimum name OR address alignment
+  AND (name_jw >= 0.70 OR street_jw >= 0.85)
+  AND (street_jw >= 0.60 OR zip_exact = 1);
+```
+
+### Model Selection
+
+| Model | Cost | Use When |
+|-------|------|----------|
+| `claude-haiku-4-5` | Low | Default for batch classify — fast, cheap, good at structured JSON |
+| `mistral-large2` | Low | Alternative if Claude is unavailable |
+| `claude-sonnet-4` | Medium | Use if haiku produces too many `uncertain` results |
+
+### Composite Score Formula
+
+Weight name similarity, address similarity, and ZIP match:
+
+```sql
+ROUND(0.40 * name_jw + 0.35 * street_jw + 0.25 * zip_exact, 4) AS composite_search_score
+```
+
+Adjust weights based on domain. Address-heavy domains (retail pharmacies) may increase street_jw weight. Name-heavy domains (financial services) may increase name_jw weight.
+
+**MANDATORY STOPPING POINT**: Present Tier 1.5 results (classified count, match count, sample matches) for user review.
+
+---
+
+## Tier 2: Agentic Search
+
+**Goal:** Resolve the hardest cases using a Cortex Agent with multi-tool access and reasoning capabilities.
+
+**Delegate to:** `cortex-agent` skill for agent definition. This section provides the ER-specific agent configuration.
+
+### Agent Design
+
+The agent has three tools, in strict priority order:
+
+1. **Corpus_Search** (`cortex_search`): Fuzzy search against the reference Cortex Search Service. PRIMARY — always try first.
+2. **Corpus_Query** (`cortex_analyst_text_to_sql`): SQL queries against the reference table via semantic model. FALLBACK — use when search returns no results.
+3. **Web_Search** (`web_search`): Public web search. LAST RESORT — use only after both internal tools fail. Useful for confirming closures, rebrands, acquisitions.
+
+See `agent-definition.md` for the full agent specification template.
+
+### Decision Types
+
+The agent must use one of these decisions:
+
+| Decision | When | Confidence |
+|----------|------|-----------|
+| `match` | Same entity confirmed (name + address align) | 0.80-1.0 |
+| `probable_match` | Likely same but some ambiguity (minor discrepancy) | 0.60-0.80 |
+| `no_match` | Exhausted all search strategies, no match found | 0.0-0.50 |
+| `investigate` | Ambiguous, requires human review | 0.40-0.70 |
+| `location_closed` | Entity identified but confirmed permanently closed | 0.70-1.0 |
+| `new_record_needed` | Entity confirmed active but missing from reference corpus | 0.70-1.0 |
+
+### Budget Constraints
+
+Configure the agent with strict budget limits to control cost:
+
+```yaml
+orchestration:
+  budget:
+    seconds: 90       # Wall-clock limit per entity
+    tokens: 16000     # Token limit per entity
+```
+
+Additionally, enforce tool call limits in the orchestration instructions:
+- Maximum 3 Corpus_Search calls per entity
+- Maximum 1 Corpus_Query call per entity
+- Maximum 1 Web_Search call per entity
+- Total maximum 6 tool calls — decide with best evidence after limit reached
+
+### Work Queue
+
+Create a work queue table to track agent processing:
+
+```sql
+CREATE OR REPLACE TABLE agent_work_queue (
+    queue_id                INT AUTOINCREMENT,
+    source_entity_id        STRING NOT NULL,
+    batch_id                INT,
+    -- Entity details (for prompt building)
+    entity_name             STRING,
+    entity_address          STRING,
+    entity_city             STRING,
+    entity_state            STRING,
+    entity_zip              STRING,
+    -- Context
+    name_variants           VARIANT,     -- JSON array of name variants
+    match_candidates        VARIANT,     -- JSON array of top embedding candidates
+    domain_context          VARIANT,     -- Domain-specific context (class of trade, etc.)
+    -- Processing state
+    status                  STRING DEFAULT 'PENDING',
+    worker_id               STRING,
+    started_at              TIMESTAMP_NTZ,
+    completed_at            TIMESTAMP_NTZ,
+    error_message           STRING,
+    retry_count             INT DEFAULT 0,
+    PRIMARY KEY (queue_id)
+);
+```
+
+Populate with entities not resolved by Tier 1 or Tier 1.5:
+```sql
+INSERT INTO agent_work_queue (source_entity_id, ...)
+SELECT ...
+FROM source_entities
+WHERE source_entity_id NOT IN (SELECT source_entity_id FROM highconf_matches)
+  AND source_entity_id NOT IN (SELECT source_entity_id FROM batch_classify_matches);
+```
+
+Assign balanced batches using `NTILE(<num_workers>)` for parallel processing.
+
+### Orchestration
+
+See `orchestration.md` for the full orchestration SP template. Key components:
+
+1. **Prompt builder** — Constructs per-entity prompt with: entity details, name variants, embedding candidates, domain context, search strategies, and response format
+2. **Agent caller** — Invokes `SNOWFLAKE.CORTEX.DATA_AGENT_RUN` with the built prompt
+3. **Response parser** — Extracts structured JSON from agent response (handles code fences, partial JSON, fallback)
+4. **Validation scorer** — Computes JW scores between matched entity and original for audit
+5. **Entity discovery recorder** — When the agent discovers entities missing from the reference corpus, records them for future enrichment
+6. **Retry logic** — Exponential backoff for rate limits, configurable max retries
+
+### Parallel Execution
+
+Use a Snowflake Task DAG for parallel processing:
+```
+root_task → N worker tasks (one per batch) → finalizer_task
+```
+
+Worker count: Use `NTILE(N)` where N is under 100 (Snowflake child task limit is 100). Typical: 50-98 workers depending on volume.
+
+See `orchestration.md` for the Task DAG DDL template.
+
+### Entity Discovery
+
+When the agent uses web search and confirms an entity exists but the reference corpus lacks it, record the discovery:
+
+```sql
+CREATE OR REPLACE TABLE discovered_entities (
+    discovery_id            INT AUTOINCREMENT,
+    source_entity_id        STRING NOT NULL,
+    discovered_name         STRING NOT NULL,
+    discovered_address      STRING,
+    discovered_city         STRING,
+    discovered_state        STRING,
+    discovered_zip          STRING,
+    discovery_source        STRING,       -- 'web_search' | 'agent_inference'
+    discovery_reasoning     STRING,
+    confidence              FLOAT,
+    web_sources             VARIANT,      -- Array of {url, title, snippet}
+    verified                BOOLEAN DEFAULT FALSE,
+    created_at              TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (discovery_id)
+);
+```
+
+These discoveries feed back into the reference corpus after human verification, improving future match rates.
+
+**MANDATORY STOPPING POINT**: Present Tier 2 agent results summary (decision distribution, web search usage, sample matches/non-matches/closures) for user review.
+
+---
+
+## Crosswalk Assembly
+
+Combine all tiers into a unified crosswalk with a uniform schema:
+
+```sql
+CREATE OR REPLACE VIEW crosswalk AS
+
+-- Tier 1: High-confidence matches
+SELECT
+    source_entity_id,
+    reference_entity_id,
+    decision,
+    confidence,
+    match_method,
+    NULL AS agent_reasoning,
+    NULL AS web_sources
+FROM highconf_matches
+
+UNION ALL
+
+-- Tier 1.5: Batch classify matches
+SELECT
+    source_entity_id,
+    reference_entity_id,
+    decision,
+    confidence,
+    'tier15_batch_classify' AS match_method,
+    classify_reasoning AS agent_reasoning,
+    NULL AS web_sources
+FROM batch_classify_matches
+
+UNION ALL
+
+-- Tier 2: Agent matches (match and probable_match)
+SELECT
+    source_entity_id,
+    matched_reference_id AS reference_entity_id,
+    decision,
+    confidence,
+    'tier2_agent' AS match_method,
+    agent_reasoning,
+    web_sources
+FROM agent_results
+WHERE decision IN ('match', 'probable_match')
+  -- Guard rails for agent probable_match:
+  AND (decision = 'match'
+       OR (confidence >= 0.70 AND (zip_exact = 1 OR address_jw >= 0.80)))
+
+UNION ALL
+
+-- Tier 2: Location closed (no reference match, but entity identified)
+SELECT
+    source_entity_id,
+    matched_reference_id AS reference_entity_id,
+    decision,
+    confidence,
+    'tier2_agent_closed' AS match_method,
+    agent_reasoning,
+    web_sources
+FROM agent_results
+WHERE decision = 'location_closed'
+
+UNION ALL
+
+-- Tier 2: New record needed (entity exists but not in reference)
+SELECT
+    source_entity_id,
+    NULL AS reference_entity_id,
+    decision,
+    confidence,
+    'tier2_agent_new_record' AS match_method,
+    agent_reasoning,
+    web_sources
+FROM agent_results
+WHERE decision = 'new_record_needed';
+```
+
+---
+
+## Cost Control
+
+### Model Selection by Tier
+
+| Tier | Model | Cost per Entity | Notes |
+|------|-------|----------------|-------|
+| 1 | N/A (SQL only) | ~$0 | Pure SQL, no LLM |
+| 1.5 | `claude-haiku-4-5` | ~$0.001-0.005 | Single AI_COMPLETE call |
+| 2 | `claude-haiku-4-5` (orchestration) | ~$0.05-0.20 | Multi-tool agent, 2-6 calls |
+
+### Volume Planning
+
+For a dataset of N source entities:
+- Tier 1 processes all N, resolves ~0.6N-0.8N — cost: ~$0
+- Tier 1.5 processes ~0.2N-0.4N, resolves ~0.05N-0.15N — cost: ~$0.001 * 0.3N
+- Tier 2 processes ~0.05N-0.2N — cost: ~$0.10 * 0.1N
+
+**Example:** 10,000 entities → Tier 1 resolves ~7,000, Tier 1.5 resolves ~1,500, Tier 2 processes ~1,500 → total LLM cost ~$150-300.
+
+### Cost Monitoring
+
+Track cost per tier and per entity using execution metadata (tokens_used, processing_time_seconds, model_used) stored in agent_results.
+
+---
+
+## Threshold Tuning
+
+### Manual Review Approach
+
+1. Sample 50-100 entities from each tier's output
+2. Human-verify each match as correct/incorrect
+3. Compute precision per tier
+4. Adjust thresholds:
+   - If Tier 1 precision < 95%: tighten cosine_sim or name_jw thresholds by 0.02
+   - If Tier 1 recall is too low (too many entities going to Tier 1.5): loosen thresholds by 0.01-0.02
+   - If Tier 1.5 `uncertain` rate > 30%: upgrade model from haiku to a more capable model
+   - If Tier 2 `no_match` rate > 40%: review whether the reference corpus is comprehensive enough
+
+### LLM-as-a-Judge (Automated Quality)
+
+For ongoing quality monitoring, use an LLM judge to evaluate a sample of decisions:
+
+1. Sample N agent results (stratified by decision type)
+2. Provide the judge with: entity details, agent decision, agent reasoning, reference match details
+3. Judge evaluates: decision correctness, reasoning quality, whether web search was appropriately used
+4. Aggregate findings into quality metrics and improvement recommendations
+
+This can be operationalized as a post-pipeline quality gate. See `operationalize.md` for the quality loop pattern.

--- a/skills/entity-resolution/references/templates/blocking.md
+++ b/skills/entity-resolution/references/templates/blocking.md
@@ -1,0 +1,226 @@
+# Blocking SQL Templates
+
+Reduce the comparison space from O(n^2) to manageable partitions. Without blocking, matching 1M records requires 500B comparisons.
+
+## Section 1: Blocking Key Assignment
+
+### Geographic blocking (state + zip prefix)
+
+```sql
+UPDATE normalized_entities
+SET blocking_key = normalized_state || '-' || LEFT(normalized_zip, 3)
+WHERE normalized_state IS NOT NULL AND normalized_zip IS NOT NULL;
+```
+
+### Phonetic blocking (SOUNDEX + state)
+
+```sql
+UPDATE normalized_entities
+SET blocking_key = SOUNDEX(normalized_name) || '-' || normalized_state
+WHERE normalized_name IS NOT NULL AND normalized_state IS NOT NULL;
+```
+
+### Name prefix blocking (for large datasets or name-only matching)
+
+```sql
+UPDATE normalized_entities
+SET blocking_key = LEFT(UPPER(normalized_name), 4) || '-' || LEFT(normalized_zip, 3)
+WHERE normalized_name IS NOT NULL AND normalized_zip IS NOT NULL;
+```
+
+### Identifier prefix blocking (when authoritative IDs present)
+
+```sql
+-- Example for NPI
+UPDATE normalized_entities
+SET blocking_key = LEFT(normalized_npi, 6)
+WHERE normalized_npi IS NOT NULL;
+```
+
+### Compound blocking (multiple strategies via UNION)
+
+For better recall at the cost of more pairs, use multiple blocking keys:
+
+```sql
+CREATE OR REPLACE TABLE blocking_assignments AS
+-- Strategy 1: Geographic
+SELECT source_id, normalized_state || '-' || LEFT(normalized_zip, 3) AS block_key, 'geo' AS strategy
+FROM normalized_entities
+WHERE normalized_state IS NOT NULL AND normalized_zip IS NOT NULL
+UNION ALL
+-- Strategy 2: Phonetic
+SELECT source_id, SOUNDEX(normalized_name) || '-' || normalized_state AS block_key, 'phonetic' AS strategy
+FROM normalized_entities
+WHERE normalized_name IS NOT NULL AND normalized_state IS NOT NULL;
+```
+
+## Section 2: Candidate Pair Generation
+
+### Cross-source matching (different source tables)
+
+```sql
+CREATE OR REPLACE TABLE candidate_pairs AS
+SELECT
+    a.source_id AS id_left,
+    b.source_id AS id_right,
+    a.blocking_key,
+    a.source_table AS source_left,
+    b.source_table AS source_right
+FROM normalized_entities a
+JOIN normalized_entities b
+    ON a.blocking_key = b.blocking_key
+    AND a.source_table != b.source_table
+    AND a.source_id < b.source_id;  -- Avoid duplicates and self-matches
+```
+
+### Deduplication (same source table)
+
+```sql
+CREATE OR REPLACE TABLE candidate_pairs AS
+SELECT
+    a.source_id AS id_left,
+    b.source_id AS id_right,
+    a.blocking_key
+FROM normalized_entities a
+JOIN normalized_entities b
+    ON a.blocking_key = b.blocking_key
+    AND a.source_id < b.source_id;  -- Allow same-source pairs
+```
+
+### With compound blocking (multiple strategies)
+
+```sql
+CREATE OR REPLACE TABLE candidate_pairs AS
+SELECT DISTINCT
+    a.source_id AS id_left,
+    b.source_id AS id_right
+FROM blocking_assignments a
+JOIN blocking_assignments b
+    ON a.block_key = b.block_key
+    AND a.source_id < b.source_id;
+```
+
+### Multi-Pass Deduplication Cost
+
+When using compound blocking (multiple strategies via UNION ALL + DISTINCT), the DISTINCT operation can become expensive at scale. Diagnostic query to measure duplicate pair rate:
+
+```sql
+-- Measure how many duplicate pairs compound blocking produces
+WITH raw_pairs AS (
+    SELECT a.source_id AS id_left, b.source_id AS id_right
+    FROM blocking_assignments a
+    JOIN blocking_assignments b
+        ON a.block_key = b.block_key
+        AND a.source_id < b.source_id
+)
+SELECT
+    COUNT(*) AS raw_pair_count,
+    COUNT(DISTINCT id_left || '-' || id_right) AS unique_pair_count,
+    ROUND(1.0 - COUNT(DISTINCT id_left || '-' || id_right) / NULLIF(COUNT(*), 0), 4) AS duplicate_rate
+FROM raw_pairs;
+```
+
+**Guidance by scale:**
+
+| Unique Pairs | DISTINCT Cost | Recommendation |
+|-------------|---------------|----------------|
+| <10M | Low | Use `SELECT DISTINCT` — straightforward and fast |
+| 10M-50M | Moderate | Use `SELECT DISTINCT` but monitor query profile for spilling |
+| >50M | High | Consider single-strategy blocking or sorted-neighborhood (below) |
+
+### Sorted-Neighborhood Blocking (Large Datasets)
+
+For datasets >5M records where compound blocking produces too many pairs, sorted-neighborhood blocking is an alternative that avoids the O(n²) pair explosion:
+
+```sql
+-- Sort entities by a composite key, then compare only within a sliding window
+CREATE OR REPLACE TABLE candidate_pairs AS
+WITH sorted AS (
+    SELECT
+        source_id,
+        blocking_key,
+        normalized_name,
+        ROW_NUMBER() OVER (
+            PARTITION BY blocking_key
+            ORDER BY normalized_name
+        ) AS sort_pos
+    FROM normalized_entities
+)
+SELECT
+    a.source_id AS id_left,
+    b.source_id AS id_right,
+    a.blocking_key
+FROM sorted a
+JOIN sorted b
+    ON a.blocking_key = b.blocking_key
+    AND b.sort_pos BETWEEN a.sort_pos + 1 AND a.sort_pos + 10  -- Window size = 10
+    AND a.source_id < b.source_id;
+```
+
+**Window size tuning:** Start with 10. Increase to 20 if recall is too low (missing known matches). Decrease to 5 if pair volume is still too high. Validate by checking whether known match pairs appear in the candidate set.
+
+## Section 3: Blocking Diagnostics
+
+### Block size distribution
+
+```sql
+SELECT
+    blocking_key,
+    COUNT(*) AS entities_in_block,
+    (COUNT(*) * (COUNT(*) - 1)) / 2 AS potential_pairs
+FROM normalized_entities
+GROUP BY blocking_key
+ORDER BY potential_pairs DESC
+LIMIT 20;
+```
+
+### Aggregate statistics
+
+```sql
+SELECT
+    COUNT(DISTINCT blocking_key) AS total_blocks,
+    SUM(entity_count) AS total_entities,
+    SUM(pair_count) AS total_candidate_pairs,
+    MAX(pair_count) AS largest_block_pairs,
+    AVG(pair_count) AS avg_block_pairs,
+    -- Reduction ratio: candidate_pairs / total_possible_pairs
+    ROUND(SUM(pair_count) / (SUM(entity_count) * (SUM(entity_count) - 1) / 2) * 100, 4) AS reduction_ratio_pct
+FROM (
+    SELECT
+        blocking_key,
+        COUNT(*) AS entity_count,
+        (COUNT(*) * (COUNT(*) - 1)) / 2 AS pair_count
+    FROM normalized_entities
+    GROUP BY blocking_key
+);
+```
+
+### Red flag checks
+
+```sql
+-- Check 1: Any block with >100K pairs (too coarse)
+SELECT blocking_key, COUNT(*) AS entity_count, (COUNT(*) * (COUNT(*) - 1)) / 2 AS pairs
+FROM normalized_entities
+GROUP BY blocking_key
+HAVING pairs > 100000
+ORDER BY pairs DESC;
+
+-- Check 2: Total candidate pairs
+SELECT COUNT(*) AS total_pairs FROM candidate_pairs;
+-- If >10M: add second blocking pass or tighten criteria
+
+-- Check 3: Entities not assigned to any block (lost records)
+SELECT COUNT(*) AS unblocked_entities
+FROM normalized_entities
+WHERE blocking_key IS NULL;
+```
+
+### Red flag thresholds
+
+| Metric | Threshold | Action |
+|--------|-----------|--------|
+| Largest block pairs | >100K | Refine blocking key (add more fields) |
+| Total pairs | >10M | Add second blocking pass |
+| Total pairs | Very few | Loosen blocking key |
+| Reduction ratio | >10% | Blocking is too loose |
+| Unblocked entities | >5% of total | Fix NULL blocking keys or add fallback strategy |

--- a/skills/entity-resolution/references/templates/contrastive-embeddings.md
+++ b/skills/entity-resolution/references/templates/contrastive-embeddings.md
@@ -1,0 +1,503 @@
+# Contrastive Embeddings for Entity Resolution
+
+Fine-tune a transformer encoder via supervised contrastive learning (SupConLoss) to produce domain-adapted embeddings for entity matching. Replaces or supplements `AI_EMBED`-based Tier 2 fuzzy matching with embeddings trained specifically on the customer's entity data.
+
+## When to Use
+
+| Condition | Use Contrastive | Use `AI_EMBED` |
+|-----------|----------------|----------------|
+| Labeled clusters or ground truth pairs available (500+) | Yes | Fallback |
+| GPU compute pool available | Yes | N/A (serverless) |
+| High-stakes matching (medical, financial, legal) | Recommended | Acceptable |
+| Quick prototype or <500 labeled pairs | No | Yes |
+| Multilingual entity data | Yes (with NER) | Acceptable |
+| Need per-record cost = $0 at inference time | Yes (one-time training cost) | No ($0.0001/record) |
+
+**Standalone mode:** Contrastive embeddings can be used as the sole matching approach — the trained encoder produces embeddings, cosine similarity does blocking, and a threshold sweep finds the optimal decision boundary. No Tier 1 (deterministic) or Tier 3 (AI-judged) tiers are required, though both can be layered on top.
+
+**Add-on mode:** Contrastive embeddings replace the `AI_EMBED` call in Tier 2 of Path A (or the embedding step of Path B). The rest of the pipeline (Tier 1 deterministic, Tier 3 AI-judged, blocking, HITL review) remains unchanged. This improves cosine similarity quality, which means fewer pairs need Tier 3 escalation — reducing both cost and latency.
+
+## Prerequisites
+
+1. **Ground truth** — Either:
+   - Existing labeled match/non-match pairs (from a prior HITL review cycle or external source)
+   - Cluster assignments (records grouped by known entity identity)
+   - Minimum: ~500 entities across ~200+ clusters for reasonable training
+2. **GPU compute pool** — `GPU_NV_S` (NVIDIA T4, 16 GB VRAM) is sufficient for all three recommended models
+3. **External access integrations:**
+   - `PYPI_EAI` — pip package installation (transformers, torch, sentencepiece)
+   - `HF_EAI` — HuggingFace model download + GitHub access (for spaCy NER models when NER enabled)
+4. **Network rule** — Must include HuggingFace and (when NER is enabled) GitHub domains:
+
+```sql
+CREATE OR REPLACE NETWORK RULE <database>.<schema>.HF_RULE
+    MODE = EGRESS
+    TYPE = HOST_PORT
+    VALUE_LIST = (
+        'huggingface.co', 'hf.co',
+        'cdn-lfs.huggingface.co', 'cdn-lfs.hf.co',
+        'cdn-lfs-us-1.huggingface.co', 'cdn-lfs-us-1.hf.co',
+        'data.hub.huggingface.co', 'hub-ci.huggingface.co',
+        'cas-bridge.xethub.hf.co',
+        -- GitHub domains (required for spaCy NER model download)
+        'github.com',
+        'raw.githubusercontent.com',
+        'objects.githubusercontent.com',
+        'release-assets.githubusercontent.com'
+    );
+```
+
+**Note:** The GitHub domains are required when NER is enabled — spaCy's `en_core_web_sm` model is hosted on GitHub, not PyPI. The download chain involves redirects through `raw.githubusercontent.com` (compatibility check), `github.com` (release page), and `release-assets.githubusercontent.com` (actual wheel).
+
+## Model Selection
+
+Based on a 10-experiment ablation study across two benchmark datasets (DBLP-ACM bibliographic matching, Walmart-Amazon product matching):
+
+| Model | Params | Dim | Best For | DBLP-ACM F1 | Walmart-Amazon F1 |
+|-------|--------|-----|----------|-------------|-------------------|
+| `roberta-base` | 125M | 768 | English-only ER | **0.9904** | **0.8701** |
+| `xlm-roberta-base` | 278M | 768 | Multilingual ER | 0.9646 (0.9818 w/ NER) | 0.8472 (0.8556 w/ NER) |
+| `sentence-transformers/all-MiniLM-L6-v2` | 33M | 384 | Latency-critical / resource-constrained | 0.9797 | 0.7706 |
+
+**Recommendation logic:**
+
+```
+IF data is English-only:
+    Use roberta-base (best F1, NER disabled)
+ELSE IF data is multilingual or mixed-language:
+    Use xlm-roberta-base (enable NER)
+ELSE IF GPU memory is severely constrained OR latency is critical:
+    Use all-MiniLM-L6-v2 (smallest, fastest)
+```
+
+**Key finding:** `roberta-base` (125M params) outperforms `xlm-roberta-base` (278M params) on English ER because it dedicates all capacity to English. Bigger is not always better — language-specific capacity matters more than raw parameter count.
+
+## NER Mode Selection
+
+DITTO-style NER tag injection (Li et al., VLDB 2021) inserts entity-type tags from spaCy NER into serialized record text within `[VAL]` regions.
+
+| Data Characteristics | Model | NER Mode | Rationale |
+|---------------------|-------|----------|-----------|
+| English structured data (databases, academic records) | roberta-base | `none` | RoBERTa already encodes English entity types from pretraining |
+| English product/e-commerce data | roberta-base | `none` | NER is neutral (-0.23pp F1 on Walmart-Amazon) |
+| English data + multilingual model | xlm-roberta-base | `ditto-general` or `ditto-product` | NER compensates for XLM-R's diluted English capacity (+1.7pp on DBLP-ACM) |
+| Multilingual data | xlm-roberta-base | `ditto-general` | NER provides explicit entity-type signals across languages |
+
+**NER modes:**
+
+- `ditto-general` — Preserves fine-grained entity labels. Use for structured/bibliographic data.
+  - PERSON, ORG, PRODUCT, NUM, ID tags
+- `ditto-product` — Collapses to coarser categories. Use for e-commerce/product data.
+  - PRODUCT (absorbs PERSON, GPE, LOC, NORP), NUM, ID tags
+- `none` — No NER preprocessing. Use with English-specialized encoders.
+
+**NER special tokens** (added to tokenizer alongside `[COL]`, `[VAL]`):
+`[PERSON]`, `[ORG]`, `[PRODUCT]`, `[NUM]`, `[ID]`
+
+The `[ID]` tag is also applied via regex to alphanumeric strings of 7+ characters (model numbers, SKUs) regardless of spaCy NER output.
+
+## Section 1: Data Preparation
+
+### Record serialization with [COL]/[VAL] tokens
+
+Serialize each entity record into a flat text string. Adapt the column list to the customer's schema.
+
+```sql
+-- Example for name+address entities
+CREATE OR REPLACE TABLE serialized_entities AS
+SELECT
+    source_id,
+    source_table,
+    '[COL] name [VAL] ' || COALESCE(normalized_name, '') ||
+    ' [COL] street [VAL] ' || COALESCE(normalized_street, '') ||
+    ' [COL] city [VAL] ' || COALESCE(normalized_city, '') ||
+    ' [COL] state [VAL] ' || COALESCE(normalized_state, '') ||
+    ' [COL] zip [VAL] ' || COALESCE(normalized_zip, '') AS serialized_text
+FROM normalized_entities;
+```
+
+```sql
+-- Example for product entities
+CREATE OR REPLACE TABLE serialized_entities AS
+SELECT
+    source_id,
+    source_table,
+    '[COL] brand [VAL] ' || COALESCE(brand, '') ||
+    ' [COL] title [VAL] ' || COALESCE(title, '') ||
+    ' [COL] modelno [VAL] ' || COALESCE(model_number, '') ||
+    ' [COL] category [VAL] ' || COALESCE(category, '') ||
+    ' [COL] price [VAL] ' || COALESCE(price::STRING, '') AS serialized_text
+FROM normalized_entities;
+```
+
+**Adapt columns** to the customer's entity schema. Every attribute that could help disambiguate entities should be included. Column names in `[COL]` tokens should be short, lowercase descriptors.
+
+### Cluster assignment for training
+
+Contrastive learning requires cluster labels (which records refer to the same entity). Derive from ground truth pairs:
+
+```sql
+-- From ground truth match pairs, assign cluster IDs via iterative Union-Find
+-- (see matching.md Section 4 for the full iterative Union-Find pattern)
+
+-- Step 1: Initialize each entity as its own cluster
+CREATE OR REPLACE TABLE entity_clusters AS
+SELECT DISTINCT source_id AS entity_id, source_id AS cluster_id
+FROM (
+    SELECT source_id_left AS source_id FROM ground_truth
+    UNION
+    SELECT source_id_right AS source_id FROM ground_truth
+);
+
+-- Step 2: Propagate smallest cluster_id across ground truth edges
+-- (iterate until convergence — typically 3-10 iterations)
+DECLARE changes INT DEFAULT 1;
+BEGIN
+    WHILE (changes > 0) DO
+        UPDATE entity_clusters ec
+        SET cluster_id = sub.min_cluster
+        FROM (
+            SELECT ec2.entity_id,
+                   LEAST(ec2.cluster_id, MIN(ec_linked.cluster_id)) AS min_cluster
+            FROM entity_clusters ec2
+            JOIN ground_truth gt
+                ON ec2.entity_id = gt.source_id_left OR ec2.entity_id = gt.source_id_right
+            JOIN entity_clusters ec_linked
+                ON ec_linked.entity_id = CASE
+                    WHEN ec2.entity_id = gt.source_id_left THEN gt.source_id_right
+                    ELSE gt.source_id_left
+                END
+            GROUP BY ec2.entity_id, ec2.cluster_id
+            HAVING LEAST(ec2.cluster_id, MIN(ec_linked.cluster_id)) < ec2.cluster_id
+        ) sub
+        WHERE ec.entity_id = sub.entity_id;
+        changes := SQLROWCOUNT;
+    END WHILE;
+END;
+
+-- Step 3: Include singleton entities (entities with no ground truth pairs)
+INSERT INTO entity_clusters (entity_id, cluster_id)
+SELECT source_id, source_id
+FROM serialized_entities
+WHERE source_id NOT IN (SELECT entity_id FROM entity_clusters);
+```
+
+### Pretrain entities (training-ready table)
+
+```sql
+CREATE OR REPLACE TABLE pretrain_entities AS
+SELECT
+    s.source_id,
+    s.source_table,
+    s.serialized_text,
+    ec.cluster_id
+FROM serialized_entities s
+JOIN entity_clusters ec ON s.source_id = ec.entity_id;
+```
+
+## Section 2: Training Job Submission
+
+### Stored procedure template
+
+Create a stored procedure that submits the contrastive training job to the GPU compute pool:
+
+```sql
+CREATE OR REPLACE PROCEDURE submit_contrastive_training_job()
+RETURNS STRING
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('snowflake-ml-python')
+HANDLER = 'run'
+AS
+$$
+def run(session):
+    from snowflake.ml.jobs import submit_file
+
+    job = submit_file(
+        file="train_contrastive_ner.py",       -- Training script (upload to stage first)
+        compute_pool="<COMPUTE_POOL_NAME>",     -- GPU_NV_S or GPU_NV_M
+        stage_name="<SCHEMA>.ML_JOB_STAGE",
+        pip_requirements=[
+            "transformers>=4.30.0",
+            "torch>=2.0.0",
+            "sentencepiece",
+            "spacy>=3.5.0,<3.8",               -- Only needed if NER enabled
+        ],
+        external_access_integrations=["PYPI_EAI", "HF_EAI"],
+        env_vars={
+            "ER_DATABASE": "<DATABASE>",
+            "ER_SCHEMA": "<SCHEMA>",
+            "ER_HF_MODEL_NAME": "roberta-base",         -- or xlm-roberta-base, all-MiniLM-L6-v2
+            "ER_NER_MODE": "none",                       -- or ditto-general, ditto-product
+            "ER_EMBEDDING_DIM": "768",                   -- 768 for roberta/xlm-r, 384 for minilm
+            "ER_NUM_EPOCHS": "10",
+            "ER_BATCH_SIZE": "64",                       -- 32 for xlm-roberta-base (larger model)
+            "ER_LEARNING_RATE": "2e-5",
+            "ER_TEMPERATURE": "0.07",
+            "ER_WARMUP_RATIO": "0.05",
+            "ER_WEIGHT_DECAY": "0.01",
+        },
+        session=session,
+    )
+    return f"Submitted job: {job.id}"
+$$;
+```
+
+**Replace** all `<PLACEHOLDER>` values with the customer's database, schema, compute pool, and model choices from discovery.
+
+### Training hyperparameters
+
+| Parameter | Default | Notes |
+|-----------|---------|-------|
+| Epochs | 10 | Sufficient for convergence on most ER datasets |
+| Batch size | 64 | Use 32 for XLM-RoBERTa-base (278M params, higher memory) |
+| Learning rate | 2e-5 | Standard for transformer fine-tuning |
+| Temperature (tau) | 0.07 | Controls sharpness of contrastive similarity distribution |
+| Warmup ratio | 0.05 | 5% of training steps for learning rate warmup |
+| Weight decay | 0.01 | AdamW regularization |
+| Gradient clipping | 1.0 | Max gradient norm |
+
+### Training script overview
+
+The training script (`train_contrastive_ner.py`) implements:
+
+1. **SupConLoss** (Khosla et al., 2020) — pulls same-cluster embeddings together, pushes different-cluster embeddings apart
+2. **[COL]/[VAL] special tokens** — registered in tokenizer so the model learns attribute structure
+3. **NER tag injection** (optional) — spaCy `en_core_web_sm` tags inserted within `[VAL]` spans at training time and embedding time
+4. **Mean pooling + L2 normalization** — attention-weighted mean pool over token hidden states, normalized to unit hypersphere
+5. **Embedding upload** — batch-encodes all entities post-training, uploads as `VECTOR(FLOAT, n)` via Snowpark
+
+**Delegate to:** `machine-learning` skill for compute pool setup, stage management, and job monitoring.
+
+## Section 3: Post-Training Embedding Table
+
+After the training job completes, the `CONTRASTIVE_EMBEDDINGS` table is populated:
+
+```sql
+-- Schema of the output table (created by training script)
+-- CONTRASTIVE_EMBEDDINGS (
+--     SOURCE_ID     STRING,
+--     SOURCE_TABLE  STRING,
+--     EMBEDDING     VECTOR(FLOAT, 768)   -- or 384 for MiniLM
+-- )
+
+-- Verify embeddings were generated
+SELECT COUNT(*) AS embedding_count FROM contrastive_embeddings;
+SELECT SOURCE_TABLE, COUNT(*) FROM contrastive_embeddings GROUP BY SOURCE_TABLE;
+```
+
+## Section 4: Blocking via Cosine Similarity
+
+Contrastive embeddings replace traditional blocking + Tier 2 fuzzy matching with a single cosine similarity computation. The trained embeddings produce much tighter clusters than `AI_EMBED`, so cosine similarity alone is highly discriminative.
+
+### Cross-source blocking (matching across datasets)
+
+```sql
+CREATE OR REPLACE TABLE blocking_candidates AS
+SELECT
+    e1.SOURCE_ID AS ID_LEFT,
+    e2.SOURCE_ID AS ID_RIGHT,
+    e1.SOURCE_TABLE AS SOURCE_LEFT,
+    e2.SOURCE_TABLE AS SOURCE_RIGHT,
+    VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) AS COSINE_SIM
+FROM contrastive_embeddings e1
+JOIN contrastive_embeddings e2
+    ON e1.SOURCE_TABLE != e2.SOURCE_TABLE
+    AND e1.SOURCE_ID < e2.SOURCE_ID
+WHERE VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) > 0.50;
+```
+
+### Deduplication blocking (within same dataset)
+
+```sql
+CREATE OR REPLACE TABLE blocking_candidates AS
+SELECT
+    e1.SOURCE_ID AS ID_LEFT,
+    e2.SOURCE_ID AS ID_RIGHT,
+    VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) AS COSINE_SIM
+FROM contrastive_embeddings e1
+JOIN contrastive_embeddings e2
+    ON e1.SOURCE_ID < e2.SOURCE_ID
+WHERE VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) > 0.50;
+```
+
+**Threshold 0.50** is deliberately low for blocking — it captures all plausible candidates. The actual match/no-match decision is made during the threshold sweep below.
+
+**Scaling note:** For large datasets (>100K entities), the cross-join becomes expensive. Use a pre-filter (e.g., geographic blocking key) to partition entities before computing cosine similarity within partitions:
+
+```sql
+-- Partitioned blocking for large datasets
+CREATE OR REPLACE TABLE blocking_candidates AS
+SELECT
+    e1.SOURCE_ID AS ID_LEFT,
+    e2.SOURCE_ID AS ID_RIGHT,
+    VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) AS COSINE_SIM
+FROM contrastive_embeddings e1
+JOIN normalized_entities n1 ON e1.SOURCE_ID = n1.SOURCE_ID
+JOIN contrastive_embeddings e2
+    ON e1.SOURCE_TABLE != e2.SOURCE_TABLE
+    AND e1.SOURCE_ID < e2.SOURCE_ID
+JOIN normalized_entities n2 ON e2.SOURCE_ID = n2.SOURCE_ID
+WHERE n1.NORMALIZED_STATE = n2.NORMALIZED_STATE     -- Geographic partition
+    AND VECTOR_COSINE_SIMILARITY(e1.EMBEDDING, e2.EMBEDDING) > 0.50;
+```
+
+## Section 5: Threshold Sweep
+
+Evaluate precision, recall, and F1 at multiple cosine similarity thresholds to find the optimal decision boundary.
+
+```sql
+CREATE OR REPLACE TABLE threshold_results AS
+WITH thresholds AS (
+    SELECT column1 AS threshold FROM VALUES
+        (0.50),(0.55),(0.60),(0.65),(0.70),(0.72),(0.74),(0.76),
+        (0.78),(0.80),(0.82),(0.84),(0.86),(0.88),(0.90),(0.92),(0.94),(0.96)
+),
+predictions AS (
+    SELECT
+        t.threshold,
+        bc.ID_LEFT,
+        bc.ID_RIGHT,
+        bc.COSINE_SIM
+    FROM thresholds t
+    CROSS JOIN blocking_candidates bc
+    WHERE bc.COSINE_SIM >= t.threshold
+),
+metrics AS (
+    SELECT
+        p.threshold,
+        COUNT(DISTINCT CASE WHEN gt.SOURCE_ID_LEFT IS NOT NULL
+              THEN p.ID_LEFT || '-' || p.ID_RIGHT END) AS tp,
+        COUNT(DISTINCT CASE WHEN gt.SOURCE_ID_LEFT IS NULL
+              THEN p.ID_LEFT || '-' || p.ID_RIGHT END) AS fp,
+        (SELECT COUNT(*) FROM ground_truth)
+            - COUNT(DISTINCT CASE WHEN gt.SOURCE_ID_LEFT IS NOT NULL
+              THEN p.ID_LEFT || '-' || p.ID_RIGHT END) AS fn
+    FROM predictions p
+    LEFT JOIN ground_truth gt
+        ON (p.ID_LEFT = gt.SOURCE_ID_LEFT AND p.ID_RIGHT = gt.SOURCE_ID_RIGHT)
+        OR (p.ID_LEFT = gt.SOURCE_ID_RIGHT AND p.ID_RIGHT = gt.SOURCE_ID_LEFT)
+    GROUP BY p.threshold
+)
+SELECT
+    threshold,
+    tp, fp, fn,
+    ROUND(tp / NULLIF(tp + fp, 0), 4) AS precision,
+    ROUND(tp / NULLIF(tp + fn, 0), 4) AS recall,
+    ROUND(2.0 * (tp / NULLIF(tp + fp, 0)) * (tp / NULLIF(tp + fn, 0))
+        / NULLIF((tp / NULLIF(tp + fp, 0)) + (tp / NULLIF(tp + fn, 0)), 0), 4) AS f1
+FROM metrics
+ORDER BY threshold;
+```
+
+### Optimal threshold selection
+
+```sql
+-- Select the threshold that maximizes F1
+SELECT * FROM threshold_results ORDER BY f1 DESC LIMIT 1;
+```
+
+### Materialize final matches
+
+```sql
+CREATE OR REPLACE TABLE predicted_matches AS
+SELECT
+    ID_LEFT, ID_RIGHT, SOURCE_LEFT, SOURCE_RIGHT, COSINE_SIM,
+    'match' AS decision,
+    COSINE_SIM AS confidence,
+    'contrastive_embedding' AS match_method
+FROM blocking_candidates
+WHERE COSINE_SIM >= <optimal_threshold>;   -- Replace with threshold from sweep
+```
+
+## Section 6: Integration with Existing Tiers
+
+When used as an add-on to the standard Path A pipeline, contrastive embeddings replace the `AI_EMBED` step in Tier 2. This improves similarity quality and reduces the number of pairs that need expensive Tier 3 (AI-judged) escalation.
+
+### Replace Tier 2 embedding generation
+
+Instead of:
+```sql
+-- Old: AI_EMBED (general-purpose, per-record cost)
+AI_EMBED('snowflake-arctic-embed-l-v2.0', concatenated_text) AS embedding
+```
+
+Use the contrastive embeddings table directly:
+```sql
+-- New: Pre-computed contrastive embeddings (zero marginal cost)
+SELECT source_id, embedding FROM contrastive_embeddings
+```
+
+### Layer with Tier 1 and Tier 3
+
+```sql
+-- Score consolidation: Tier 1 (exact ID) + Contrastive (replaces Tier 2) + Tier 3 (AI-judged)
+CREATE OR REPLACE TABLE match_results AS
+-- Tier 1: Deterministic
+SELECT id_left, id_right, decision, confidence, match_method, matched_on
+FROM tier1_results
+UNION ALL
+-- Contrastive: High-confidence matches (above match threshold)
+SELECT id_left, id_right, 'match' AS decision, cosine_sim AS confidence,
+       'contrastive_embedding' AS match_method, NULL AS matched_on
+FROM blocking_candidates
+WHERE cosine_sim >= <match_threshold>
+    AND (id_left, id_right) NOT IN (SELECT id_left, id_right FROM tier1_results)
+UNION ALL
+-- Contrastive: Clear non-matches (below no_match threshold)
+SELECT id_left, id_right, 'no_match' AS decision, cosine_sim AS confidence,
+       'contrastive_embedding' AS match_method, NULL AS matched_on
+FROM blocking_candidates
+WHERE cosine_sim < <no_match_threshold>
+    AND (id_left, id_right) NOT IN (SELECT id_left, id_right FROM tier1_results)
+UNION ALL
+-- Tier 3: AI-judged on probable matches (between thresholds)
+SELECT id_left, id_right, ai_decision:label::STRING AS decision,
+       ai_decision:score::FLOAT AS confidence, 'tier3_ai_judged' AS match_method, NULL
+FROM tier3_results;
+```
+
+## Expected Performance Benchmarks
+
+Results from the 10-experiment ablation study (for reference when discussing with customers):
+
+| Dataset | Model | NER | F1 | Precision | Recall |
+|---------|-------|-----|-----|-----------|--------|
+| DBLP-ACM (bibliographic) | RoBERTa-base | none | **0.9904** | 98.2% | 99.9% |
+| DBLP-ACM | RoBERTa-base | ditto-general | 0.9895 | 98.4% | 99.6% |
+| DBLP-ACM | XLM-RoBERTa-base | ditto-general | 0.9818 | 97.0% | 99.4% |
+| DBLP-ACM | MiniLM-L6-v2 | none | 0.9797 | 97.0% | 99.0% |
+| DBLP-ACM | XLM-RoBERTa-base | none | 0.9646 | 94.4% | 98.6% |
+| Walmart-Amazon (product) | RoBERTa-base | none | **0.8701** | 79.5% | 96.1% |
+| Walmart-Amazon | RoBERTa-base | ditto-product | 0.8678 | 82.7% | 91.3% |
+| Walmart-Amazon | XLM-RoBERTa-base | ditto-product | 0.8556 | 83.0% | 88.3% |
+| Walmart-Amazon | XLM-RoBERTa-base | none | 0.8472 | 81.1% | 88.7% |
+| Walmart-Amazon | MiniLM-L6-v2 | none | 0.7706 | 69.2% | 75.2% |
+
+**Key observations for customer conversations:**
+1. Model capacity matters most on noisy data (MiniLM-to-RoBERTa gap: +1.1pp on clean DBLP-ACM vs +10.0pp on noisy Walmart-Amazon)
+2. NER helps multilingual models but not English-specialized ones
+3. Clean, structured data reaches F1 > 0.98 even with the smallest model
+4. Noisy, heterogeneous data benefits most from larger English-specialized encoders
+
+## Cost Model
+
+| Component | Cost Driver | Estimate |
+|-----------|------------|----------|
+| GPU training (one-time) | Compute pool credits, ~5-30 min on GPU_NV_S (T4) | ~1-5 credits per training run |
+| Embedding generation | Included in training job (runs on same GPU) | $0 marginal |
+| Blocking + threshold sweep | Warehouse compute (XS-MEDIUM) | ~0.5-2 credits |
+| NER preprocessing | CPU within GPU container, adds ~10-17% to training time | Included in GPU cost |
+| Retraining (periodic) | Same as initial training | ~1-5 credits per retrain |
+
+**Comparison with `AI_EMBED` approach:**
+
+| Metric | Contrastive | `AI_EMBED` |
+|--------|------------|------------|
+| Per-record embedding cost | $0 (pre-computed) | ~$0.0001/record |
+| Training cost | ~1-5 credits (one-time) | $0 (no training) |
+| F1 quality | Higher (domain-adapted) | Lower (general-purpose) |
+| Setup complexity | Higher (GPU pool, EAIs, training script) | Lower (single SQL call) |
+| Time to first result | ~30 min (training + embedding) | ~seconds (immediate) |
+| Retraining needed? | Yes, when entity types or data distribution shift | No |
+| Break-even volume | ~50K records (contrastive cheaper above this) | Below ~50K records |

--- a/skills/entity-resolution/references/templates/cost-estimator.md
+++ b/skills/entity-resolution/references/templates/cost-estimator.md
@@ -1,0 +1,100 @@
+# Cost Estimator — Entity Resolution Pipeline
+
+Use this template after Phase 1 profiling to estimate costs before proceeding. Present the estimate to the user and wait for explicit acknowledgment before continuing with implementation.
+
+## Input Parameters
+
+- **N** = total source entity count (from profiling output)
+- **R** = reference corpus size (Path B only)
+- **Tier distribution** = expected % of records reaching each tier (use defaults below if unknown)
+
+## Path A Cost Model (Pair-Based Deduplication)
+
+| Component | Driver | Unit Cost | Formula |
+|-----------|--------|-----------|---------|
+| Embedding generation | N records | ~$0.0001/record (`snowflake-arctic-embed-l-v2.0`) | `N × $0.0001` |
+| Tier 3 AI classify | Probable-match pairs (~5–15% of candidates) | ~$0.001–0.003/pair | `probable_pairs × $0.002` |
+| Warehouse compute | Size by volume | MEDIUM (<1M records), LARGE (>1M) | ~2–10 credits/run |
+
+**Estimated candidate pairs** (after blocking): typically `N × 10–50` pairs reviewed, of which 5–15% reach Tier 3.
+
+```
+total_cost_a ≈ (N × $0.0001) + (probable_match_pairs × $0.002) + warehouse_credits
+```
+
+## Path B Cost Model (Agentic Entity Linking)
+
+| Tier | Records Processed | Cost per Entity | Subtotal Formula |
+|------|-------------------|-----------------|------------------|
+| 1 — Deterministic SQL triage | N (all) | ~$0 (SQL only) | $0 |
+| 1.5 — Batch search + classify | ~20–40% of N | ~$0.001–0.005 | `0.3N × $0.003` |
+| 2 — Agent with tools | ~5–20% of N | ~$0.05–0.20 | `0.1N × $0.10` |
+
+**Additional costs:**
+
+| Component | Notes |
+|-----------|-------|
+| Cortex Search Service | Index build + incremental refresh credits (varies by corpus size) |
+| Embedding generation | Corpus indexing: `R × $0.0001`; source records: `N × $0.0001` |
+| Semantic model | Minimal — one-time YAML upload, no ongoing cost |
+| Warehouse | Task DAG workers × runtime; typically MEDIUM warehouse |
+
+```
+total_cost_b ≈ (0.3N × $0.003) + (0.1N × $0.10) + (N × $0.0001) + (R × $0.0001) + warehouse_credits
+```
+
+## Contrastive Embeddings Cost Model (Phase 4c — Standalone or Add-On)
+
+| Component | Driver | Unit Cost | Formula |
+|-----------|--------|-----------|---------|
+| GPU training (one-time) | Compute pool credits, ~5-30 min on GPU_NV_S (T4) | ~1-5 credits/run | Fixed per training run |
+| Embedding generation | Included in GPU training job | $0 marginal | Included |
+| Blocking + threshold sweep | Warehouse compute (XS-MEDIUM) | ~0.5-2 credits | Warehouse runtime |
+| NER preprocessing (optional) | CPU within GPU container | +10-17% training time | Included in GPU cost |
+| Retraining (periodic) | Same as initial training | ~1-5 credits/retrain | As needed |
+
+**Break-even vs `AI_EMBED`:** Contrastive embeddings have a fixed training cost (~1-5 credits) but $0 per-record embedding cost. `AI_EMBED` costs ~$0.0001/record with no training. Break-even is at ~50K records — above that, contrastive is cheaper.
+
+```
+total_cost_contrastive ≈ training_credits + warehouse_credits
+                       ≈ 1-5 credits + 0.5-2 credits
+                       ≈ 1.5-7 credits (one-time, plus retraining as needed)
+```
+
+**Add-on mode savings:** When contrastive embeddings replace `AI_EMBED` in Tier 2, the cost savings come from:
+1. Eliminating per-record embedding cost (`N × $0.0001` saved)
+2. Reducing Tier 3 escalation (higher-quality embeddings produce fewer `probable_match` results needing LLM classification)
+
+## Volume-Based Path Recommendation
+
+| Source Records | Reference Corpus | Recommended Path | Estimated Cost Range |
+|----------------|-----------------|-----------------|---------------------|
+| <10K | None | Path A | $1–10 |
+| <10K | Available | Path B | $5–50 |
+| 10K–100K | None | Path A | $10–100 |
+| 10K–100K | Available | Path B | $30–500 |
+| 100K–1M | None | Path A | $100–1,000 |
+| 100K–1M | Available | Path B | $300–5,000 |
+| >1M | Any | Either (discuss with customer) | $1,000+ |
+| Any (with ground truth + GPU) | Any | Contrastive (standalone or add-on) | $3-15 (one-time training + warehouse) |
+
+## Presenting the Estimate
+
+Use this template when surfacing the cost estimate to the user:
+
+```
+Estimated pipeline cost for [N] source entities using Path [A/B]:
+
+- Embedding generation:          ~$X
+- Tier [1.5 / 3] LLM classify:  ~$Y
+- Tier [2 / 3] agent/classify:  ~$Z
+- Warehouse compute:             ~$W credits (~$W_dollars at standard rates)
+- Total estimated:               ~$TOTAL
+
+These are estimates based on typical tier distributions. Actual costs depend on
+data quality (cleaner data = more Tier 1 matches = lower LLM cost).
+```
+
+## MANDATORY STOPPING POINT
+
+Present the cost estimate to the user. **Do NOT proceed to any implementation phase until the user explicitly acknowledges and accepts the estimated cost.**

--- a/skills/entity-resolution/references/templates/incremental.md
+++ b/skills/entity-resolution/references/templates/incremental.md
@@ -1,0 +1,315 @@
+# Incremental Processing — Delta Entity Resolution
+
+Use incremental processing when the cost of a full pipeline refresh outweighs the overhead of change tracking. Rule of thumb:
+
+| Scenario | Approach |
+|----------|----------|
+| < 500K source records | Full refresh (simpler, no stream management) |
+| > 500K records, < 5% change rate per cycle | Incremental (streams + tasks) |
+| > 20% of records change per cycle | Full refresh (delta overhead exceeds savings) |
+| Schema change or blocking strategy change | Full refresh (required) |
+
+The full-refresh pipeline uses dynamic tables. Incremental processing uses **Snowflake Streams + Tasks** because streams are consumed on read — dynamic tables cannot drive stream-based incrementals.
+
+---
+
+## Change Detection via Streams
+
+Create a stream on the source table. Set `APPEND_ONLY = FALSE` to capture updates and deletes, not just inserts:
+
+```sql
+CREATE OR REPLACE STREAM source_entity_stream
+    ON TABLE source_entities
+    APPEND_ONLY = FALSE;
+```
+
+Check the stream to understand what changed before processing:
+
+```sql
+SELECT
+    METADATA$ACTION,       -- 'INSERT' or 'DELETE' (updates appear as DELETE + INSERT pair)
+    METADATA$ISUPDATE,     -- TRUE if this row is part of an update operation
+    METADATA$ROW_ID,       -- Stable row identifier across the stream's lifetime
+    *
+FROM source_entity_stream
+LIMIT 100;
+```
+
+**Important:** Querying the stream without consuming it (e.g., a bare `SELECT`) does not advance the stream offset. Only DML operations that read from the stream inside a transaction advance the offset.
+
+---
+
+## Incremental Normalization
+
+Normalize only new/changed source records and MERGE them into `normalized_entities`. This avoids re-running AI_EXTRACT and name normalization on unchanged rows.
+
+```sql
+-- Normalize new/changed records from stream
+CREATE OR REPLACE TEMPORARY TABLE new_normalized AS
+SELECT
+    s.METADATA$ROW_ID                          AS row_id,
+    s.source_id,
+    UPPER(TRIM(s.raw_name))                    AS normalized_name,
+    s.blocking_key_field                       AS blocking_key,
+    -- Apply same normalization logic as normalization.md
+    ai_parsed:street::STRING                   AS normalized_street,
+    ai_parsed:city::STRING                     AS normalized_city,
+    UPPER(TRIM(ai_parsed:state::STRING))       AS normalized_state,
+    LEFT(REGEXP_REPLACE(ai_parsed:zip::STRING, '[^0-9]', ''), 5) AS normalized_zip
+FROM source_entity_stream s,
+     LATERAL FLATTEN(INPUT => ARRAY_CONSTRUCT(
+         AI_EXTRACT(s.raw_address, '{"street":"...","city":"...","state":"...","zip":"..."}')
+     )) f
+WHERE s.METADATA$ACTION = 'INSERT';
+
+-- Merge into normalized_entities
+MERGE INTO normalized_entities tgt
+USING new_normalized src
+ON tgt.source_id = src.source_id
+WHEN MATCHED THEN UPDATE SET
+    tgt.normalized_name   = src.normalized_name,
+    tgt.normalized_street = src.normalized_street,
+    tgt.normalized_city   = src.normalized_city,
+    tgt.normalized_state  = src.normalized_state,
+    tgt.normalized_zip    = src.normalized_zip,
+    tgt.blocking_key      = src.blocking_key,
+    tgt.updated_at        = CURRENT_TIMESTAMP()
+WHEN NOT MATCHED THEN INSERT (
+    source_id, normalized_name, normalized_street,
+    normalized_city, normalized_state, normalized_zip,
+    blocking_key, updated_at
+) VALUES (
+    src.source_id, src.normalized_name, src.normalized_street,
+    src.normalized_city, src.normalized_state, src.normalized_zip,
+    src.blocking_key, CURRENT_TIMESTAMP()
+);
+```
+
+Handle deletes — remove records from `normalized_entities` when the source row is deleted:
+
+```sql
+DELETE FROM normalized_entities
+WHERE source_id IN (
+    SELECT source_id
+    FROM source_entity_stream
+    WHERE METADATA$ACTION = 'DELETE'
+      AND METADATA$ISUPDATE = FALSE  -- True deletes only, not the DELETE half of an update
+);
+```
+
+---
+
+## Incremental Candidate Pair Generation
+
+Key insight: when a new record arrives, it only needs to be paired with **existing records in the same block** — not re-paired with each other. Pairs among pre-existing records are already in `candidate_pairs`.
+
+```sql
+-- Only generate pairs involving new/changed records
+INSERT INTO candidate_pairs (id_left, id_right, blocking_key)
+SELECT
+    new.source_id    AS id_left,
+    existing.source_id AS id_right,
+    new.blocking_key
+FROM new_normalized new
+JOIN normalized_entities existing
+    ON  new.blocking_key  = existing.blocking_key
+    AND new.source_id    != existing.source_id
+WHERE NOT EXISTS (
+    SELECT 1 FROM candidate_pairs cp
+    WHERE (cp.id_left = new.source_id AND cp.id_right = existing.source_id)
+       OR (cp.id_left = existing.source_id AND cp.id_right = new.source_id)
+);
+```
+
+Also clean up pairs for deleted records:
+
+```sql
+DELETE FROM candidate_pairs
+WHERE id_left  IN (SELECT source_id FROM source_entity_stream WHERE METADATA$ACTION = 'DELETE' AND METADATA$ISUPDATE = FALSE)
+   OR id_right IN (SELECT source_id FROM source_entity_stream WHERE METADATA$ACTION = 'DELETE' AND METADATA$ISUPDATE = FALSE);
+```
+
+---
+
+## Incremental Matching
+
+Run matching tiers only on new candidate pairs (those without an existing entry in `match_results`):
+
+```sql
+-- Identify new pairs not yet scored
+CREATE OR REPLACE TEMPORARY TABLE new_candidate_pairs AS
+SELECT cp.*
+FROM candidate_pairs cp
+WHERE NOT EXISTS (
+    SELECT 1 FROM match_results mr
+    WHERE mr.id_left = cp.id_left AND mr.id_right = cp.id_right
+);
+
+-- Score new pairs and merge into match_results
+MERGE INTO match_results tgt
+USING (
+    SELECT
+        cp.id_left,
+        cp.id_right,
+        cp.blocking_key,
+        JAROWINKLER_SIMILARITY(l.normalized_name, r.normalized_name) / 100.0   AS name_jw,
+        JAROWINKLER_SIMILARITY(l.normalized_street, r.normalized_street) / 100.0 AS street_jw,
+        IFF(l.normalized_zip = r.normalized_zip, 1.0, 0.0)                     AS zip_exact,
+        -- Composite score — adapt weights from matching.md
+        (0.6 * JAROWINKLER_SIMILARITY(l.normalized_name, r.normalized_name) / 100.0
+         + 0.25 * JAROWINKLER_SIMILARITY(l.normalized_street, r.normalized_street) / 100.0
+         + 0.15 * IFF(l.normalized_zip = r.normalized_zip, 1.0, 0.0))          AS composite_score
+    FROM new_candidate_pairs cp
+    JOIN normalized_entities l ON cp.id_left  = l.source_id
+    JOIN normalized_entities r ON cp.id_right = r.source_id
+) src
+ON tgt.id_left = src.id_left AND tgt.id_right = src.id_right
+WHEN NOT MATCHED THEN INSERT (
+    id_left, id_right, blocking_key,
+    name_jw, street_jw, zip_exact, composite_score,
+    tier, created_at
+) VALUES (
+    src.id_left, src.id_right, src.blocking_key,
+    src.name_jw, src.street_jw, src.zip_exact, src.composite_score,
+    'tier1', CURRENT_TIMESTAMP()
+);
+```
+
+---
+
+## Entity Group Recalculation
+
+A new match can bridge two previously separate entity groups, so group membership cannot be updated incrementally in a simple way. Two options:
+
+### Option 1: Full Recalculation (recommended for < 100K confirmed matches)
+
+Simpler and less error-prone. Re-run the connected-components query over all confirmed matches:
+
+```sql
+-- See blocking.md for the full connected-components pattern.
+-- Truncate and rebuild entity_groups from match_results where composite_score >= threshold.
+CREATE OR REPLACE TABLE entity_groups AS
+WITH confirmed_matches AS (
+    SELECT id_left, id_right
+    FROM match_results
+    WHERE composite_score >= <match_threshold>
+),
+-- ... (connected components logic from blocking.md)
+```
+
+### Option 2: Incremental Union-Find (for > 100K matches)
+
+Only re-traverse graph components that include at least one newly added match edge. Requires tracking which `entity_id` values appear in new matches:
+
+```sql
+-- Step 1: Identify affected entity IDs
+CREATE OR REPLACE TEMPORARY TABLE affected_ids AS
+SELECT DISTINCT id_left AS entity_id FROM new_match_results
+UNION
+SELECT DISTINCT id_right FROM new_match_results;
+
+-- Step 2: Find all group_ids that contain any affected entity
+CREATE OR REPLACE TEMPORARY TABLE affected_groups AS
+SELECT DISTINCT group_id
+FROM entity_groups
+WHERE entity_id IN (SELECT entity_id FROM affected_ids);
+
+-- Step 3: Delete stale group assignments for affected components
+DELETE FROM entity_groups
+WHERE group_id IN (SELECT group_id FROM affected_groups);
+
+-- Step 4: Re-run connected components for affected entities only
+-- (Use the same union-find or graph traversal as the full recalc,
+--  scoped to entities whose group_id was in affected_groups)
+INSERT INTO entity_groups (entity_id, group_id, canonical_id)
+-- ... scoped connected-components query ...
+```
+
+> **Trade-off:** Option 2 avoids re-processing unaffected components but is significantly more complex to implement and test. Only use it if full recalculation is too slow in practice.
+
+---
+
+## Incremental Pipeline DAG
+
+Use Snowflake Tasks (not dynamic tables) for incremental processing. Streams are consumed on read — each task in the chain must read from the stream exactly once per cycle.
+
+```
+source_entity_stream
+  └─> task_incremental_normalize        (scheduled, e.g. EVERY 1 HOUR)
+        └─> task_incremental_block_and_pair
+              └─> task_incremental_match
+                    └─> task_recalc_groups
+                          └─> task_refresh_entity_master
+```
+
+Example task definitions:
+
+```sql
+-- Root task: normalize new/changed records
+CREATE OR REPLACE TASK task_incremental_normalize
+    WAREHOUSE = <warehouse_name>
+    SCHEDULE  = 'USING CRON 0 * * * * UTC'  -- every hour
+    WHEN SYSTEM$STREAM_HAS_DATA('source_entity_stream')  -- skip if no changes
+AS
+    CALL sp_incremental_normalize();
+
+-- Downstream tasks chain via AFTER
+CREATE OR REPLACE TASK task_incremental_block_and_pair
+    WAREHOUSE = <warehouse_name>
+    AFTER     task_incremental_normalize
+AS
+    CALL sp_incremental_block_and_pair();
+
+CREATE OR REPLACE TASK task_incremental_match
+    WAREHOUSE = <warehouse_name>
+    AFTER     task_incremental_block_and_pair
+AS
+    CALL sp_incremental_match();
+
+CREATE OR REPLACE TASK task_recalc_groups
+    WAREHOUSE = <warehouse_name>
+    AFTER     task_incremental_match
+AS
+    CALL sp_recalc_entity_groups();
+
+CREATE OR REPLACE TASK task_refresh_entity_master
+    WAREHOUSE = <warehouse_name>
+    AFTER     task_recalc_groups
+AS
+    CALL sp_refresh_entity_master();
+
+-- Resume all tasks (tasks are suspended by default after CREATE)
+ALTER TASK task_refresh_entity_master  RESUME;
+ALTER TASK task_recalc_groups          RESUME;
+ALTER TASK task_incremental_match      RESUME;
+ALTER TASK task_incremental_block_and_pair RESUME;
+ALTER TASK task_incremental_normalize  RESUME;
+```
+
+`SYSTEM$STREAM_HAS_DATA()` on the root task prevents the entire DAG from firing when there are no new records, saving compute costs.
+
+---
+
+## When to Fall Back to Full Refresh
+
+Abandon the incremental path and run a full refresh when any of the following are true:
+
+| Condition | Reason |
+|-----------|--------|
+| Source table schema changed | Stream may be invalidated or blocking keys affected |
+| Blocking strategy changed | All pairs must be re-generated from scratch |
+| Match thresholds tuned | Historical match decisions may flip; full re-score required |
+| Stream staleness > 14 days | Standard retention expires; stream becomes invalid |
+| Source change rate > 20% per cycle | Incremental overhead exceeds full-refresh cost |
+| `SYSTEM$STREAM_BACKLOG_BYTES` very large | Accumulated lag; a single cycle may overwhelm task compute |
+
+Check stream health before each scheduled cycle:
+
+```sql
+SELECT
+    SYSTEM$STREAM_HAS_DATA('source_entity_stream')   AS has_data,
+    -- Stale streams return an error on consumption; check with:
+    SHOW STREAMS LIKE 'source_entity_stream';
+-- Look for STALE = TRUE in results; if stale, drop/recreate the stream
+-- and trigger a full refresh before resuming incremental cycles.
+```

--- a/skills/entity-resolution/references/templates/matching.md
+++ b/skills/entity-resolution/references/templates/matching.md
@@ -1,0 +1,294 @@
+# Matching SQL Templates
+
+Multi-tier matching cascade: deterministic (Tier 1) -> fuzzy (Tier 2) -> AI-judged (Tier 3). Each tier is progressively more expensive. Only escalate unresolved pairs.
+
+## Section 1: Tier 1 — Deterministic Matching (Exact ID Match)
+
+### Single identifier match
+
+```sql
+CREATE OR REPLACE TABLE tier1_results AS
+SELECT
+    cp.id_left,
+    cp.id_right,
+    'match' AS decision,
+    1.0 AS confidence,
+    'tier1_exact_id' AS match_method,
+    '<identifier_name>' AS matched_on
+FROM candidate_pairs cp
+JOIN normalized_entities a ON cp.id_left = a.source_id
+JOIN normalized_entities b ON cp.id_right = b.source_id
+WHERE a.<normalized_id> = b.<normalized_id>
+    AND a.<normalized_id> IS NOT NULL;
+```
+
+Replace `<normalized_id>` and `<identifier_name>` with the domain profile's Tier 1 identifiers (e.g., `normalized_npi`, `normalized_lei`).
+
+### Cascading identifier match (multiple ID types)
+
+```sql
+CREATE OR REPLACE TABLE tier1_results AS
+SELECT
+    cp.id_left,
+    cp.id_right,
+    'match' AS decision,
+    1.0 AS confidence,
+    'tier1_exact_id' AS match_method,
+    CASE
+        WHEN a.normalized_id_1 = b.normalized_id_1 AND a.normalized_id_1 IS NOT NULL THEN '<id_1_name>'
+        WHEN a.normalized_id_2 = b.normalized_id_2 AND a.normalized_id_2 IS NOT NULL THEN '<id_2_name>'
+        WHEN a.normalized_id_3 = b.normalized_id_3 AND a.normalized_id_3 IS NOT NULL THEN '<id_3_name>'
+    END AS matched_on
+FROM candidate_pairs cp
+JOIN normalized_entities a ON cp.id_left = a.source_id
+JOIN normalized_entities b ON cp.id_right = b.source_id
+WHERE (a.normalized_id_1 = b.normalized_id_1 AND a.normalized_id_1 IS NOT NULL)
+   OR (a.normalized_id_2 = b.normalized_id_2 AND a.normalized_id_2 IS NOT NULL)
+   OR (a.normalized_id_3 = b.normalized_id_3 AND a.normalized_id_3 IS NOT NULL);
+```
+
+Replace placeholder identifiers with the domain profile's cascade order.
+
+### Remaining pairs for Tier 2
+
+```sql
+CREATE OR REPLACE TABLE tier2_input AS
+SELECT cp.*
+FROM candidate_pairs cp
+LEFT JOIN tier1_results t1 ON cp.id_left = t1.id_left AND cp.id_right = t1.id_right
+WHERE t1.id_left IS NULL;  -- Not resolved in Tier 1
+```
+
+## Section 2: Tier 2 — Fuzzy Matching (Vector Similarity)
+
+### Embedding generation
+
+> **Higher-quality alternative:** If contrastive embeddings are available (Phase 4c), use the pre-computed `CONTRASTIVE_EMBEDDINGS` table instead of `AI_EMBED`. Contrastive embeddings are domain-adapted and produce tighter clusters (F1 up to 0.99 vs ~0.83-0.89 for general-purpose embeddings), at zero per-record marginal cost. See `references/templates/contrastive-embeddings.md` Section 6 for the integration pattern.
+
+Delegate to `cortex-ai-functions` skill. Embed concatenated entity text:
+
+```sql
+CREATE OR REPLACE TABLE entity_embeddings AS
+SELECT
+    source_id,
+    AI_EMBED(
+        'snowflake-arctic-embed-l-v2.0',
+        normalized_name || ' ' ||
+        COALESCE(normalized_street, '') || ' ' ||
+        COALESCE(normalized_city, '') || ' ' ||
+        COALESCE(normalized_state, '') || ' ' ||
+        COALESCE(normalized_zip, '')
+    ) AS embedding
+FROM normalized_entities;
+```
+
+### Similarity computation
+
+```sql
+CREATE OR REPLACE TABLE tier2_results AS
+SELECT
+    t2.id_left,
+    t2.id_right,
+    VECTOR_COSINE_SIMILARITY(el.embedding, er.embedding) AS cosine_sim,
+    JAROWINKLER_SIMILARITY(nl.normalized_name, nr.normalized_name) / 100.0 AS name_jw,
+    JAROWINKLER_SIMILARITY(
+        COALESCE(nl.normalized_street, ''),
+        COALESCE(nr.normalized_street, '')
+    ) / 100.0 AS street_jw,
+    -- Classification
+    CASE
+        WHEN VECTOR_COSINE_SIMILARITY(el.embedding, er.embedding) >= 0.92 THEN 'match'
+        WHEN VECTOR_COSINE_SIMILARITY(el.embedding, er.embedding) >= 0.80 THEN 'probable_match'
+        ELSE 'no_match'
+    END AS decision,
+    VECTOR_COSINE_SIMILARITY(el.embedding, er.embedding) AS confidence,
+    'tier2_fuzzy' AS match_method
+FROM tier2_input t2
+JOIN entity_embeddings el ON t2.id_left = el.source_id
+JOIN entity_embeddings er ON t2.id_right = er.source_id
+JOIN normalized_entities nl ON t2.id_left = nl.source_id
+JOIN normalized_entities nr ON t2.id_right = nr.source_id;
+```
+
+**Threshold adjustment:** Replace 0.92 and 0.80 with the loaded domain profile's starting thresholds. Tune in 0.02-0.03 increments based on manual review.
+
+### Remaining pairs for Tier 3
+
+```sql
+CREATE OR REPLACE TABLE tier3_input AS
+SELECT *
+FROM tier2_results
+WHERE decision = 'probable_match';
+```
+
+## Section 3: Tier 3 — AI-Judged Matching (LLM Classification)
+
+**Only process Tier 2 `probable_match` results.** This is the most expensive tier.
+
+```sql
+CREATE OR REPLACE TABLE tier3_results AS
+SELECT
+    t3.id_left,
+    t3.id_right,
+    t3.cosine_sim,
+    t3.name_jw,
+    t3.street_jw,
+    AI_CLASSIFY(
+        'Record A: Name="' || nl.normalized_name || '", Address="' ||
+            COALESCE(nl.normalized_street, '') || ', ' ||
+            COALESCE(nl.normalized_city, '') || ', ' ||
+            COALESCE(nl.normalized_state, '') || ' ' ||
+            COALESCE(nl.normalized_zip, '') || '"' ||
+        '\nRecord B: Name="' || nr.normalized_name || '", Address="' ||
+            COALESCE(nr.normalized_street, '') || ', ' ||
+            COALESCE(nr.normalized_city, '') || ', ' ||
+            COALESCE(nr.normalized_state, '') || ' ' ||
+            COALESCE(nr.normalized_zip, '') || '"' ||
+        '\nAre these the same real-world entity?',
+        ARRAY_CONSTRUCT('match', 'probable_match', 'no_match')
+    ) AS ai_decision,
+    'tier3_ai_judged' AS match_method
+FROM tier3_input t3
+JOIN normalized_entities nl ON t3.id_left = nl.source_id
+JOIN normalized_entities nr ON t3.id_right = nr.source_id;
+```
+
+**Domain-specific prompt enhancement:** Append the domain profile's Tier 3 prompt addition before the `AI_CLASSIFY` call. Build the prompt string dynamically.
+
+## Section 4: Score Consolidation
+
+### Combine all tier results
+
+```sql
+CREATE OR REPLACE TABLE match_results AS
+-- Tier 1 matches
+SELECT id_left, id_right, decision, confidence, match_method, matched_on
+FROM tier1_results
+UNION ALL
+-- Tier 2 definitive results (match or no_match)
+SELECT id_left, id_right, decision, confidence, match_method, NULL AS matched_on
+FROM tier2_results
+WHERE decision IN ('match', 'no_match')
+UNION ALL
+-- Tier 3 results (overrides Tier 2 probable_match)
+SELECT id_left, id_right, ai_decision:label::STRING AS decision,
+       ai_decision:score::FLOAT AS confidence, match_method, NULL AS matched_on
+FROM tier3_results;
+```
+
+### Transitivity resolution (entity group assignment)
+
+Connected components: if A=B and B=C, then A=B=C belong to the same entity group.
+
+```sql
+-- Iterative transitive closure using a recursive CTE
+CREATE OR REPLACE TABLE entity_groups AS
+WITH RECURSIVE edges AS (
+    SELECT id_left AS entity_id, id_right AS linked_to FROM match_results WHERE decision = 'match'
+    UNION ALL
+    SELECT id_right AS entity_id, id_left AS linked_to FROM match_results WHERE decision = 'match'
+),
+closure AS (
+    SELECT entity_id, entity_id AS group_root FROM edges
+    UNION ALL
+    SELECT e.entity_id, LEAST(c.group_root, e.linked_to) AS group_root
+    FROM edges e
+    JOIN closure c ON e.linked_to = c.entity_id
+    WHERE LEAST(c.group_root, e.linked_to) < c.group_root
+)
+SELECT entity_id, MIN(group_root) AS entity_group_id
+FROM closure
+GROUP BY entity_id;
+```
+
+**Note:** For very large match sets (>1M matches), the recursive CTE may be slow. Consider an iterative approach using a WHILE loop with convergence check, or use the `machine-learning` skill to implement Union-Find.
+
+### Iterative Union-Find (for >100K matches)
+
+When the recursive CTE is too slow or hits Snowflake recursion limits, use an iterative convergence approach:
+
+```sql
+-- Step 1: Initialize — each entity is its own group root
+CREATE OR REPLACE TABLE entity_groups AS
+SELECT DISTINCT entity_id, entity_id AS entity_group_id
+FROM (
+    SELECT id_left AS entity_id FROM match_results WHERE decision = 'match'
+    UNION
+    SELECT id_right AS entity_id FROM match_results WHERE decision = 'match'
+);
+
+-- Step 2: Iterate until convergence
+DECLARE
+    changes INT DEFAULT 1;
+    iteration INT DEFAULT 0;
+BEGIN
+    WHILE (changes > 0 AND iteration < 50) DO
+        -- Propagate the smallest group_id across edges
+        UPDATE entity_groups eg
+        SET entity_group_id = new_groups.min_group
+        FROM (
+            SELECT
+                eg2.entity_id,
+                LEAST(
+                    eg2.entity_group_id,
+                    MIN(eg_linked.entity_group_id)
+                ) AS min_group
+            FROM entity_groups eg2
+            JOIN match_results mr
+                ON eg2.entity_id = mr.id_left OR eg2.entity_id = mr.id_right
+            JOIN entity_groups eg_linked
+                ON eg_linked.entity_id = CASE
+                    WHEN eg2.entity_id = mr.id_left THEN mr.id_right
+                    ELSE mr.id_left
+                END
+            WHERE mr.decision = 'match'
+            GROUP BY eg2.entity_id, eg2.entity_group_id
+            HAVING LEAST(eg2.entity_group_id, MIN(eg_linked.entity_group_id)) < eg2.entity_group_id
+        ) new_groups
+        WHERE eg.entity_id = new_groups.entity_id;
+
+        changes := SQLROWCOUNT;
+        iteration := iteration + 1;
+    END WHILE;
+
+    RETURN 'Converged in ' || iteration || ' iterations, last changes: ' || changes;
+END;
+```
+
+**Expected behavior:** Real-world entity graphs converge in 5-15 iterations (the diameter of the match graph). If iteration hits 50, the match graph may have pathological chains — investigate whether thresholds are too loose.
+
+**When to use which approach:**
+
+| Match Count | Approach | Notes |
+|-------------|----------|-------|
+| <100K | Recursive CTE | Simpler, single statement |
+| 100K-10M | Iterative Union-Find | Reliable convergence, predictable cost |
+| >10M | Iterative + partitioned | Partition by blocking_key first, then merge cross-partition groups |
+
+## Section 5: Match Summary Statistics
+
+Present these to the user at the Phase 4 stopping point:
+
+```sql
+-- Decision counts by tier
+SELECT match_method, decision, COUNT(*) AS pair_count
+FROM match_results
+GROUP BY match_method, decision
+ORDER BY match_method, decision;
+
+-- Entity group sizes
+SELECT entity_group_id, COUNT(*) AS group_size
+FROM entity_groups
+GROUP BY entity_group_id
+ORDER BY group_size DESC
+LIMIT 20;
+
+-- Confidence distribution for Tier 2
+SELECT
+    FLOOR(confidence * 20) / 20 AS confidence_bucket,  -- 0.05 buckets
+    decision,
+    COUNT(*) AS pair_count
+FROM tier2_results
+GROUP BY confidence_bucket, decision
+ORDER BY confidence_bucket;
+```

--- a/skills/entity-resolution/references/templates/normalization.md
+++ b/skills/entity-resolution/references/templates/normalization.md
@@ -1,0 +1,190 @@
+# Normalization SQL Templates
+
+Entity-resolution-specific normalization patterns. These compose Snowflake SQL and Cortex AI function calls. Delegate actual AI function invocation to the `cortex-ai-functions` skill.
+
+## Section 1: Address Parsing via AI_EXTRACT
+
+### Standard address extraction (freeform to structured)
+
+```sql
+CREATE OR REPLACE TABLE normalized_addresses AS
+SELECT
+    source_id,
+    raw_address,
+    AI_EXTRACT(
+        raw_address,
+        '{
+            "street": "Full street address including number and suite/unit",
+            "city": "City name",
+            "state": "State or province abbreviation",
+            "zip": "ZIP or postal code",
+            "country": "Country name or ISO code if present"
+        }'
+    ) AS parsed,
+    parsed:street::STRING AS street,
+    parsed:city::STRING AS city,
+    UPPER(TRIM(parsed:state::STRING)) AS state,
+    LEFT(REGEXP_REPLACE(parsed:zip::STRING, '[^0-9]', ''), 5) AS zip,
+    UPPER(TRIM(COALESCE(parsed:country::STRING, 'US'))) AS country
+FROM source_entities
+WHERE raw_address IS NOT NULL;
+```
+
+### Detailed address extraction (suite/unit matters — pharma, healthcare)
+
+Use the detailed schema from the loaded domain profile. Replace the extraction schema above with the profile's detailed schema that separates `street_number`, `street_name`, `suite_unit`.
+
+## Section 2: Name Normalization
+
+### Standard name cleanup (SQL)
+
+```sql
+-- Step 1: Uppercase and trim
+-- Step 2: Remove legal suffixes (from domain profile's terms-to-strip list)
+-- Step 3: Remove punctuation
+-- Step 4: Collapse whitespace
+
+CREATE OR REPLACE TABLE normalized_names AS
+SELECT
+    source_id,
+    raw_name,
+    TRIM(REGEXP_REPLACE(
+        REGEXP_REPLACE(
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(
+                    UPPER(TRIM(raw_name)),
+                    '\\b(LLC|INC|INCORPORATED|CORP|CORPORATION|LTD|LIMITED|CO|COMPANY)\\b',
+                    ''
+                ),
+                -- Add domain-specific terms from profile here
+                '[^A-Z0-9 ]',  -- Remove punctuation
+                ''
+            ),
+            '\\s+',  -- Collapse whitespace
+            ' '
+        ),
+        '^\\s+|\\s+$',  -- Final trim
+        ''
+    )) AS normalized_name
+FROM source_entities;
+```
+
+**Adapt the regex pattern** to include all terms from the loaded domain profile's "Terms to strip" list. Build the alternation dynamically based on the profile.
+
+### AI-assisted name normalization (edge cases only)
+
+For names flagged during profiling as requiring AI assistance:
+
+```sql
+-- Use AI_COMPLETE for complex name normalization edge cases
+SELECT
+    source_id,
+    raw_name,
+    AI_COMPLETE(
+        'mistral-large2',  -- Cost-effective for simple extraction; upgrade to claude-haiku-4-5 if results are poor
+        'Normalize this business name for entity matching. '
+        || 'Remove legal suffixes, expand abbreviations, remove store numbers. '
+        || 'Return ONLY the normalized name, nothing else. '
+        || 'Name: ' || raw_name
+    ) AS ai_normalized_name
+FROM source_entities
+WHERE -- Apply only to flagged rows (mixed languages, embedded locations, heavy abbreviation)
+    needs_ai_normalization = TRUE;
+```
+
+### Model Selection for Name Normalization
+
+| Model | Cost | Use When |
+|-------|------|----------|
+| `mistral-large2` | Low | Default — handles most abbreviation expansion and suffix stripping |
+| `claude-haiku-4-5` | Low | Upgrade if mistral produces too many errors on complex names |
+| `claude-sonnet-4` | Medium | Mixed-language names or names requiring cultural/regional knowledge |
+
+Start with the cheapest model and upgrade only if quality is insufficient on a 50-row sample.
+
+## Section 3: Identifier Format Standardization
+
+### Generic identifier cleanup
+
+```sql
+-- Strip non-alphanumeric characters and pad to expected length
+SELECT
+    source_id,
+    raw_identifier,
+    LPAD(REGEXP_REPLACE(raw_identifier, '[^A-Z0-9]', ''), <expected_length>, '0') AS normalized_id
+FROM source_entities;
+```
+
+### Domain-specific identifier patterns
+
+**NPI (10 digits):**
+```sql
+LPAD(REGEXP_REPLACE(raw_npi, '[^0-9]', ''), 10, '0') AS normalized_npi
+```
+
+**DEA (2 letters + 7 digits):**
+```sql
+UPPER(REGEXP_REPLACE(raw_dea, '[^A-Z0-9]', '')) AS normalized_dea
+-- Validate: REGEXP_LIKE(normalized_dea, '^[A-Z]{2}[0-9]{7}$')
+```
+
+**LEI (20 alphanumeric, ISO 17442):**
+```sql
+UPPER(REGEXP_REPLACE(raw_lei, '[^A-Z0-9]', '')) AS normalized_lei
+-- Validate: REGEXP_LIKE(normalized_lei, '^[A-Z0-9]{20}$')
+```
+
+**GTIN/UPC (8, 12, 13, or 14 digits):**
+```sql
+LPAD(REGEXP_REPLACE(raw_gtin, '[^0-9]', ''), 14, '0') AS normalized_gtin
+-- Always pad to 14 digits for consistent comparison
+```
+
+**DUNS (9 digits):**
+```sql
+LPAD(REGEXP_REPLACE(raw_duns, '[^0-9]', ''), 9, '0') AS normalized_duns
+```
+
+**NAIC Code (5 digits — insurance/payer):**
+```sql
+LPAD(REGEXP_REPLACE(raw_naic, '[^0-9]', ''), 5, '0') AS normalized_naic
+-- Validate: REGEXP_LIKE(normalized_naic, '^[0-9]{5}$')
+-- NAIC codes are assigned by the National Association of Insurance Commissioners
+```
+
+**CMS Payer ID (5 alphanumeric — insurance/payer):**
+```sql
+UPPER(TRIM(REGEXP_REPLACE(raw_cms_payer_id, '[^A-Z0-9]', ''))) AS normalized_cms_payer_id
+-- Validate: REGEXP_LIKE(normalized_cms_payer_id, '^[A-Z0-9]{5}$')
+-- CMS-assigned identifier used in X12 837/835 transactions
+```
+
+## Section 4: Materialized Normalized Output
+
+```sql
+CREATE OR REPLACE TABLE normalized_entities AS
+SELECT
+    s.source_id,
+    s.source_table,
+    -- Normalized fields
+    n.normalized_name,
+    a.street AS normalized_street,
+    a.city AS normalized_city,
+    a.state AS normalized_state,
+    a.zip AS normalized_zip,
+    a.country AS normalized_country,
+    -- Domain-specific normalized identifiers (adapt per profile)
+    -- id.normalized_npi,
+    -- id.normalized_lei,
+    -- Raw originals (for HITL review)
+    s.raw_name,
+    s.raw_address,
+    -- Blocking key (populated in Phase 3)
+    NULL AS blocking_key
+FROM source_entities s
+LEFT JOIN normalized_names n ON s.source_id = n.source_id
+LEFT JOIN normalized_addresses a ON s.source_id = a.source_id;
+-- LEFT JOIN normalized_identifiers id ON s.source_id = id.source_id;
+```
+
+Uncomment and adapt the identifier joins based on the loaded domain profile.

--- a/skills/entity-resolution/references/templates/orchestration.md
+++ b/skills/entity-resolution/references/templates/orchestration.md
@@ -1,0 +1,497 @@
+# Orchestration — Agent Pipeline Execution
+
+Template for orchestrating parallel agent execution in Tier 2 of the agentic matching workflow. Covers: work queue management, prompt building, batch processing, Task DAG parallelism, state-based pipeline control, and finalization.
+
+## Work Queue Population
+
+After Tier 1 and Tier 1.5 resolve their entities, populate the agent work queue with remaining unresolved entities:
+
+```sql
+INSERT INTO agent_work_queue (
+    source_entity_id,
+    entity_name, entity_address, entity_city, entity_state, entity_zip,
+    name_variants,
+    match_candidates,
+    domain_context
+)
+SELECT
+    ne.source_id,
+    ne.normalized_name,
+    ne.normalized_street,
+    ne.normalized_city,
+    ne.normalized_state,
+    ne.normalized_zip,
+    -- Name variants (JSON array of alternative names for this entity)
+    ne.name_variants,
+    -- Top-N embedding match candidates as context for the agent
+    mc.candidates,
+    -- Domain-specific context (class of trade, entity type, etc.)
+    ne.domain_context
+FROM normalized_entities ne
+LEFT JOIN (
+    SELECT
+        id_left,
+        ARRAY_AGG(
+            OBJECT_CONSTRUCT(
+                'reference_id', id_right,
+                'reference_name', reference_name,
+                'cosine_sim', cosine_sim,
+                'name_jw', name_jw,
+                'street_jw', street_jw,
+                'zip_exact', zip_exact,
+                'composite_score', composite_score
+            )
+        ) WITHIN GROUP (ORDER BY composite_score DESC) AS candidates
+    FROM match_candidates
+    WHERE rn <= 5
+    GROUP BY id_left
+) mc ON ne.source_id = mc.id_left
+WHERE ne.source_id NOT IN (SELECT source_entity_id FROM highconf_matches)
+  AND ne.source_id NOT IN (SELECT source_entity_id FROM batch_classify_matches);
+```
+
+### Batch Assignment
+
+Assign balanced batches for parallel processing. Use `NTILE(<N>)` where N is the number of worker tasks (max 98 to stay under Snowflake's 100-child-per-parent task limit):
+
+```sql
+UPDATE agent_work_queue
+SET batch_id = batched.batch_id
+FROM (
+    SELECT queue_id, NTILE(<num_workers>) OVER (ORDER BY queue_id) AS batch_id
+    FROM agent_work_queue
+    WHERE status = 'PENDING'
+) batched
+WHERE agent_work_queue.queue_id = batched.queue_id;
+```
+
+---
+
+## Prompt Builder
+
+Build a per-entity prompt that provides the agent with all context needed to resolve the entity:
+
+```python
+def build_prompt(entity):
+    """Build agent prompt for one source entity."""
+    parts = [
+        f"Resolve this entity to a reference record:",
+        "",
+        "**Source Entity (Primary Name):**",
+        f"- Name: {entity['ENTITY_NAME']}",
+        f"- Address: {entity['ENTITY_ADDRESS'] or 'N/A'}",
+        f"- City: {entity['ENTITY_CITY'] or 'N/A'}",
+        f"- State: {entity['ENTITY_STATE'] or 'N/A'}",
+        f"- ZIP: {entity['ENTITY_ZIP'] or 'N/A'}",
+    ]
+
+    # Domain context (class of trade, entity type, etc.)
+    domain_ctx = entity.get("DOMAIN_CONTEXT")
+    if domain_ctx:
+        # Parse and include domain-specific fields
+        # e.g., "- Detected Class of Trade: Retail Pharmacy"
+        pass
+
+    # Name variants (alternative names for the same entity)
+    variants = entity.get("NAME_VARIANTS")
+    if variants:
+        variants_list = json.loads(variants) if isinstance(variants, str) else variants
+        if isinstance(variants_list, list) and len(variants_list) > 1:
+            parts.append("")
+            parts.append("**Name variants (try these if primary name fails):**")
+            for i, v in enumerate(variants_list[:10], 1):
+                name = v.get("name", str(v)) if isinstance(v, dict) else str(v)
+                parts.append(f"  {i}. {name}")
+
+    # Embedding match candidates as context
+    candidates = entity.get("MATCH_CANDIDATES")
+    if candidates:
+        cands = json.loads(candidates) if isinstance(candidates, str) else candidates
+        if cands:
+            parts.append("")
+            parts.append("**Previous fuzzy-matching candidates (may or may not be correct):**")
+            for i, c in enumerate(cands[:5], 1):
+                parts.append(
+                    f"  {i}. ID={c.get('reference_id','?')} "
+                    f'Name="{c.get("reference_name","?")}" '
+                    f"cosine={c.get('cosine_sim',0):.3f} "
+                    f"name_jw={c.get('name_jw',0):.3f} "
+                    f"street_jw={c.get('street_jw',0):.3f} "
+                    f"zip={c.get('zip_exact',0)}"
+                )
+            parts.append("Verify these and search for better matches if needed.")
+
+    parts.extend([
+        "",
+        "Search strategies to try (in order):",
+        "1. Corpus_Search by the expanded entity name",
+        "2. Corpus_Search by address + city + ZIP",
+        "3. Corpus_Query (SQL) if search returned nothing useful",
+        "4. Web_Search (LAST RESORT) — only if both internal tools failed",
+        "",
+        "Respond with ONLY a JSON object — no markdown fences.",
+    ])
+
+    return "\n".join(parts)
+```
+
+---
+
+## Batch Processing SP
+
+The main stored procedure that processes one batch of entities through the agent:
+
+```sql
+CREATE OR REPLACE PROCEDURE resolve_entity_batch(BATCH_ID INT)
+RETURNS STRING
+LANGUAGE PYTHON
+RUNTIME_VERSION = '3.11'
+PACKAGES = ('snowflake-snowpark-python')
+HANDLER = 'run'
+EXECUTE AS CALLER
+AS
+$$
+import json
+import time
+import uuid
+import re
+
+AGENT_NAME = '<database>.<schema>.entity_resolution_agent'
+MAX_RETRIES = 1
+BASE_RETRY_DELAY = 5
+
+
+def run(session, batch_id: int) -> str:
+    worker_id = str(uuid.uuid4())[:8]
+    batch_id = int(batch_id)
+
+    # Fetch entities (skip already-completed for idempotent restart)
+    entities = session.sql(
+        "SELECT * FROM <schema>.agent_work_queue "
+        f"WHERE batch_id = {batch_id} "
+        "  AND source_entity_id NOT IN ("
+        "      SELECT source_entity_id FROM <schema>.agent_results "
+        "      WHERE decision IS NOT NULL"
+        "  ) "
+        "ORDER BY queue_id"
+    ).collect()
+
+    processed = 0
+    errors = 0
+
+    for entity in entities:
+        thread_id = str(uuid.uuid4())
+        prompt = _build_prompt(entity)
+
+        for attempt in range(MAX_RETRIES + 1):
+            try:
+                start_time = time.time()
+
+                request_body = json.dumps({
+                    "messages": [{
+                        "role": "user",
+                        "content": [{"type": "text", "text": prompt}]
+                    }]
+                })
+                safe_json = request_body.replace("\\", "\\\\").replace("'", "''")
+
+                rows = session.sql(
+                    f"SELECT TRY_PARSE_JSON("
+                    f"SNOWFLAKE.CORTEX.DATA_AGENT_RUN("
+                    f"'{AGENT_NAME}', '{safe_json}'"
+                    f")) AS result"
+                ).collect()
+
+                elapsed = round(time.time() - start_time, 2)
+                parsed = _parse_response(rows[0]["RESULT"])
+
+                # Compute validation JW scores
+                name_jw, addr_jw = _compute_validation_scores(
+                    session, entity, parsed
+                )
+
+                # Write result
+                _write_result(
+                    session, entity, parsed, elapsed,
+                    name_jw, addr_jw, thread_id, worker_id
+                )
+
+                # Record entity discovery if applicable
+                _record_discovery(session, entity, parsed, worker_id)
+
+                processed += 1
+                break  # success
+
+            except Exception as e:
+                err = str(e)
+                is_rate_limit = '429' in err or 'rate' in err.lower()
+                if attempt < MAX_RETRIES:
+                    delay = BASE_RETRY_DELAY * (2 ** attempt)
+                    if not is_rate_limit:
+                        delay = BASE_RETRY_DELAY
+                    time.sleep(delay)
+                    continue
+
+                # Record failure
+                _write_error(
+                    session, entity, err, attempt,
+                    start_time, thread_id, worker_id
+                )
+                errors += 1
+
+    return f"Batch {batch_id}: {processed} ok, {errors} errors, {len(entities)} total"
+$$;
+```
+
+### Key Implementation Functions
+
+**`_build_prompt`**: See Prompt Builder section above.
+
+**`_parse_response`**: See `agent-definition.md` for the response parser.
+
+**`_compute_validation_scores`**: Post-agent JW scoring for audit trail:
+```python
+def _compute_validation_scores(session, entity, parsed):
+    """Compute JW scores between original entity and agent's matched entity."""
+    if not parsed.get("matched_name"):
+        return None, None
+    try:
+        rows = session.sql(
+            "SELECT "
+            "  JAROWINKLER_SIMILARITY(?, ?) / 100.0 AS name_jw, "
+            "  JAROWINKLER_SIMILARITY(?, ?) / 100.0 AS addr_jw",
+            params=[
+                entity["ENTITY_NAME"] or '',
+                parsed.get("matched_name", ''),
+                entity["ENTITY_ADDRESS"] or '',
+                parsed.get("matched_address", ''),
+            ]
+        ).collect()
+        return rows[0]["NAME_JW"], rows[0]["ADDR_JW"]
+    except Exception:
+        return None, None
+```
+
+**`_record_discovery`**: Record entities the agent confirmed exist but are missing from the reference corpus:
+```python
+def _record_discovery(session, entity, parsed, worker_id):
+    """Record agent-discovered entities missing from reference."""
+    decision = parsed.get("decision", "")
+    discovered_name = parsed.get("discovered_name")
+    wve = parsed.get("web_validated_entity")
+    web_searched = parsed.get("web_search_used", False)
+
+    should_record = (
+        decision == 'new_record_needed'
+        or (web_searched and (discovered_name or wve))
+    )
+    if not should_record:
+        return
+
+    d_name = (discovered_name
+              or (wve.get("name") if wve else None)
+              or parsed.get("matched_name")
+              or entity.get("ENTITY_NAME", ""))
+
+    if not d_name:
+        return
+
+    # INSERT INTO discovered_entities (...)
+    # Non-fatal: don't fail the resolution over a discovery insert
+```
+
+---
+
+## Task DAG — Parallel Execution
+
+Use a Snowflake Task DAG with a root task, N parallel workers, and a finalizer:
+
+```sql
+-- Root task (triggers the DAG)
+CREATE OR REPLACE TASK <schema>.root_task
+    WAREHOUSE = <warehouse_name>
+AS
+    SELECT 'Agent pipeline triggered' AS status;
+
+-- Create N worker tasks (one per batch)
+-- Use dynamic SQL to generate workers:
+EXECUTE IMMEDIATE $$
+DECLARE
+    num_batches INT DEFAULT <num_workers>;  -- e.g., 98
+    i INT DEFAULT 0;
+    ddl STRING;
+BEGIN
+    FOR i IN 0 TO :num_batches - 1 DO
+        ddl := 'CREATE OR REPLACE TASK <schema>.er_worker_' || :i::STRING
+               || ' WAREHOUSE = <warehouse_name>'
+               || ' AFTER <schema>.root_task'
+               || ' AS CALL <schema>.resolve_entity_batch(' || :i::STRING || ')';
+        EXECUTE IMMEDIATE :ddl;
+    END FOR;
+    RETURN 'Created ' || :num_batches::STRING || ' worker tasks';
+END;
+$$;
+
+-- Finalizer (runs after all workers complete)
+CREATE OR REPLACE TASK <schema>.finalizer_task
+    WAREHOUSE = <warehouse_name>
+    FINALIZE = <schema>.root_task
+AS
+    CALL <schema>.finalize_results();
+```
+
+### Worker Design Principles
+
+- **No lock contention**: Workers read from the queue by batch_id (pre-assigned). No UPDATE to claim rows. Completion is tracked via INSERT into agent_results.
+- **Skip-completed**: Workers check for existing results before processing, enabling idempotent restart.
+- **Status backfill**: The finalizer updates queue status from agent_results in a single bulk UPDATE after all workers finish.
+
+---
+
+## Finalizer SP
+
+Runs once after all workers complete. Backfills queue status, computes summary stats, and optionally triggers the next processing cycle.
+
+```sql
+CREATE OR REPLACE PROCEDURE finalize_results()
+RETURNS STRING
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS
+BEGIN
+    -- Backfill queue status from results
+    UPDATE agent_work_queue q
+    SET status = CASE
+            WHEN ar.decision = 'error' THEN 'FAILED'
+            ELSE 'COMPLETED'
+        END,
+        worker_id = ar.worker_id,
+        completed_at = ar.created_at
+    FROM agent_results ar
+    WHERE q.source_entity_id = ar.source_entity_id
+      AND q.status = 'PENDING';
+
+    -- Gather summary stats
+    LET total_match INT;
+    LET total_probable INT;
+    LET total_no_match INT;
+    LET total_closed INT;
+    LET total_new_record INT;
+    LET total_errors INT;
+    LET total_web_searched INT;
+
+    SELECT COUNT_IF(decision = 'match') INTO :total_match FROM agent_results;
+    SELECT COUNT_IF(decision = 'probable_match') INTO :total_probable FROM agent_results;
+    SELECT COUNT_IF(decision = 'no_match') INTO :total_no_match FROM agent_results;
+    SELECT COUNT_IF(decision = 'location_closed') INTO :total_closed FROM agent_results;
+    SELECT COUNT_IF(decision = 'new_record_needed') INTO :total_new_record FROM agent_results;
+    SELECT COUNT_IF(decision = 'error') INTO :total_errors FROM agent_results;
+    SELECT COUNT_IF(web_search_used = TRUE) INTO :total_web_searched FROM agent_results;
+
+    RETURN 'Agent results: ' ||
+           :total_match || ' match, ' ||
+           :total_probable || ' probable, ' ||
+           :total_no_match || ' no_match, ' ||
+           :total_closed || ' closed, ' ||
+           :total_new_record || ' new_record, ' ||
+           :total_errors || ' errors. ' ||
+           'Web search used: ' || :total_web_searched || ' entities.';
+END;
+```
+
+---
+
+## State-Based Pipeline Control (Optional)
+
+For large datasets spanning multiple partitions (e.g., US states), process one partition at a time:
+
+### State Queue Table
+
+```sql
+CREATE OR REPLACE TABLE state_batch_queue (
+    state_code    STRING PRIMARY KEY,
+    entity_count  INT,
+    status        STRING DEFAULT 'PENDING',  -- PENDING | ACTIVE | COMPLETED | ERROR
+    started_at    TIMESTAMP_NTZ,
+    completed_at  TIMESTAMP_NTZ,
+    summary       STRING
+);
+```
+
+### Controller SP
+
+Called by the finalizer to auto-feed the next partition:
+
+```sql
+CREATE OR REPLACE PROCEDURE controller_check_and_enqueue(BACKLOG_THRESHOLD INT)
+RETURNS STRING
+LANGUAGE SQL
+EXECUTE AS CALLER
+AS
+BEGIN
+    -- Check current backlog (pending entities in agent queue)
+    LET backlog INT;
+    SELECT COUNT_IF(status = 'PENDING') INTO :backlog FROM agent_work_queue;
+
+    IF (:backlog <= :BACKLOG_THRESHOLD) THEN
+        -- Find next pending state
+        LET next_state STRING;
+        SELECT state_code INTO :next_state
+        FROM state_batch_queue
+        WHERE status = 'PENDING'
+        ORDER BY entity_count ASC  -- Process smallest states first
+        LIMIT 1;
+
+        IF (:next_state IS NOT NULL) THEN
+            -- Enqueue the next state
+            CALL enqueue_state(:next_state);
+            -- Resume the Task DAG
+            EXECUTE TASK root_task;
+            RETURN 'Enqueued state: ' || :next_state;
+        END IF;
+
+        RETURN 'All states processed.';
+    END IF;
+
+    RETURN 'Backlog still high (' || :backlog || '). Waiting.';
+END;
+```
+
+This pattern enables continuous processing: as one state completes, the next is automatically loaded and the Task DAG is re-triggered.
+
+---
+
+## Agent Results Table
+
+```sql
+CREATE OR REPLACE TABLE agent_results (
+    result_id               INT AUTOINCREMENT,
+    source_entity_id        STRING NOT NULL,
+    matched_reference_id    STRING,
+    decision                STRING,
+    confidence              FLOAT,
+    agent_reasoning         STRING,
+    search_steps            VARIANT,
+    matched_name            STRING,
+    matched_address         STRING,
+    matched_city            STRING,
+    matched_state           STRING,
+    matched_zip             STRING,
+    reference_source        STRING,
+    -- Validation scores
+    name_jw                 FLOAT,
+    address_jw              FLOAT,
+    -- Web search metadata
+    web_search_used         BOOLEAN DEFAULT FALSE,
+    web_sources             VARIANT,
+    web_validated_entity    VARIANT,
+    -- Execution metadata
+    thread_id               STRING,
+    worker_id               STRING,
+    model_used              STRING,
+    tokens_used             INT,
+    processing_time_seconds FLOAT,
+    created_at              TIMESTAMP_NTZ DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (result_id)
+);
+```

--- a/skills/entity-resolution/references/templates/search-service.md
+++ b/skills/entity-resolution/references/templates/search-service.md
@@ -1,0 +1,171 @@
+# Search Service — Cortex Search Service for Entity Resolution
+
+Set up a Cortex Search Service over a reference entity corpus to enable fuzzy search for Tier 1.5 (batch search + classify) and Tier 2 (agentic search).
+
+## When to Use
+
+Create a Cortex Search Service when:
+- The agentic matching workflow (see `agentic-matching.md`) is being used
+- The reference corpus has >10K entities (justifies the index build time)
+- Fuzzy search by name + address is needed (not just exact ID matching)
+
+## Step 1: Search Corpus Table
+
+Create a denormalized, search-optimized table from the normalized reference entities. Concatenate key fields into a single `search_text` column for hybrid search.
+
+```sql
+CREATE OR REPLACE TABLE <schema>.search_corpus AS
+SELECT
+    source_id                   AS entity_id,
+    '<source_name>'             AS entity_source,
+    -- Entity name (adapt based on entity type: org name, person name, etc.)
+    UPPER(TRIM(<name_column>))  AS entity_name,
+    -- DBA / trade name if available (improve recall for entities known by multiple names)
+    <dba_name_expression>       AS dba_name,
+    -- Address components
+    UPPER(TRIM(<street_column>))    AS address_line_1,
+    UPPER(TRIM(<city_column>))      AS city,
+    UPPER(TRIM(<state_column>))     AS state,
+    TRIM(<zip_column>)              AS zip5,
+    -- Domain-specific attributes (carry through for filtering/display)
+    <domain_attribute_1>        AS attribute_1,
+    <domain_attribute_2>        AS attribute_2,
+    -- Concatenated search text: name + address + city + state + ZIP + DBA
+    UPPER(TRIM(
+        COALESCE(<name_column>, '') || ' ' ||
+        COALESCE(<street_column>, '') || ' ' ||
+        COALESCE(<city_column>, '') || ' ' ||
+        COALESCE(<state_column>, '') || ' ' ||
+        COALESCE(<zip_column>, '') ||
+        CASE
+            WHEN <dba_name_expression> IS NOT NULL
+            THEN ' ' || <dba_name_expression>
+            ELSE ''
+        END
+    )) AS search_text
+FROM <schema>.normalized_entities
+WHERE <active_filter>;  -- e.g., deactivation_date IS NULL
+```
+
+### Design Principles
+
+- **search_text** includes all searchable fields concatenated — this enables hybrid (semantic + keyword) retrieval
+- **entity_name** and **dba_name** are separate columns for targeted searches and display
+- **state** and **zip5** are filterable attributes (exact match filtering within search)
+- Include **entity_id** and **entity_source** for joining back to the full reference table
+- Keep the corpus table denormalized — one row per entity, no joins at search time
+
+## Step 2: Cortex Search Service
+
+```sql
+CREATE OR REPLACE CORTEX SEARCH SERVICE <schema>.reference_search_svc
+    ON search_text
+    ATTRIBUTES entity_id, entity_source, entity_name, dba_name,
+               address_line_1, city, state, zip5
+    WAREHOUSE = <warehouse_name>
+    TARGET_LAG = '7 days'
+AS (
+    SELECT
+        search_text,
+        entity_id,
+        entity_source,
+        entity_name,
+        dba_name,
+        address_line_1,
+        city,
+        state,
+        zip5
+    FROM <schema>.search_corpus
+);
+```
+
+### Configuration Notes
+
+- **TARGET_LAG**: Set based on how frequently the reference corpus changes. `7 days` for stable corpora (e.g., monthly NPPES loads). `1 day` for frequently updated sources.
+- **Warehouse sizing**: Index build can be resource-intensive for large corpora (>1M records). Use at least a MEDIUM warehouse. Build time scales with corpus size (e.g., ~1 hour for ~5M records on MEDIUM).
+- **Filterable columns**: `state` and `zip5` are commonly used as filters to narrow search results to a geographic area. Add other filterable columns based on domain needs.
+- **ATTRIBUTES vs ON**: The `ON` clause specifies the primary search column (search_text). `ATTRIBUTES` are returned in results and optionally filterable.
+
+## Step 3: Verification
+
+```sql
+-- Verify service exists
+SHOW CORTEX SEARCH SERVICES IN SCHEMA <schema>;
+
+-- Test search
+SELECT PARSE_JSON(
+    SNOWFLAKE.CORTEX.SEARCH_PREVIEW(
+        '<database>.<schema>.reference_search_svc',
+        '{"query": "<test_entity_name>", "columns": ["entity_name","city","zip5","entity_id"], "limit": 5}'
+    )
+) AS results;
+
+-- Test with state filter
+SELECT PARSE_JSON(
+    SNOWFLAKE.CORTEX.SEARCH_PREVIEW(
+        '<database>.<schema>.reference_search_svc',
+        '{"query": "<test_entity_name>", "columns": ["entity_name","city","zip5","entity_id"], "filter": {"@eq": {"state": "<state_code>"}}, "limit": 5}'
+    )
+) AS results;
+```
+
+## Calling from Stored Procedures
+
+When calling Cortex Search from a Python SP (for batch search in Tier 1.5):
+
+```python
+import json
+
+SEARCH_SVC = '<database>.<schema>.reference_search_svc'
+
+search_request = json.dumps({
+    "query": search_query,
+    "columns": ["entity_id", "entity_name", "dba_name",
+                 "address_line_1", "city", "state", "zip5"],
+    "filter": {"@eq": {"state": state}} if state else {},
+    "limit": 10
+})
+safe_req = search_request.replace("'", "''")
+
+rows = session.sql(
+    f"SELECT PARSE_JSON(SNOWFLAKE.CORTEX.SEARCH_PREVIEW("
+    f"'{SEARCH_SVC}', "
+    f"'{safe_req}'"
+    f")) AS result"
+).collect()
+
+result = rows[0]["RESULT"]
+if isinstance(result, str):
+    result = json.loads(result)
+results_arr = result.get("results", [])
+```
+
+### Bulk JW Scoring
+
+After retrieving search results, compute JW scores set-based (not per-row) for performance:
+
+```sql
+WITH raw_results(...) AS (
+    SELECT * FROM VALUES ...
+),
+scored AS (
+    SELECT
+        r.*,
+        ROUND(JAROWINKLER_SIMILARITY(
+            source_fuzzy_name, r.entity_name
+        ) / 100.0, 4) AS name_jw,
+        ROUND(JAROWINKLER_SIMILARITY(
+            source_norm_street, r.address_line_1
+        ) / 100.0, 4) AS street_jw,
+        CASE WHEN TRIM(source_zip) = TRIM(r.zip5)
+             THEN 1 ELSE 0 END AS zip_exact
+    FROM raw_results r
+)
+SELECT
+    s.*,
+    ROUND(0.40 * s.name_jw + 0.35 * s.street_jw + 0.25 * s.zip_exact, 4)
+        AS composite_search_score
+FROM scored s;
+```
+
+Batch search results into groups of 500 entities before INSERT to balance memory usage with round-trip reduction.

--- a/skills/entity-resolution/src/Makefile
+++ b/skills/entity-resolution/src/Makefile
@@ -1,0 +1,222 @@
+# Entity Resolution Integration Tests — 3-Phase Structure
+#
+# Phase 1 (setup)    — Create source tables in Snowflake from fixture SQL
+# Phase 2 (invoke)   — Invoke the skill via cortex -p (slow, LLM-driven)
+# Phase 3 (validate) — Verify the Snowflake objects the skill created
+#
+# Functional Tests (domain profiles):
+#   make setup-pharma     — Phase 1 only for pharma
+#   make invoke-pharma    — Phase 2 only for pharma
+#   make validate-pharma  — Phase 3 only for pharma
+#   make pharma           — All 3 phases for pharma
+#   make setup-all        — Phase 1 for all domains
+#   make invoke-all       — Phase 2 for all domains
+#   make validate-all     — Phase 3 for all domains
+#   make all              — All 3 phases, all domains
+#
+# Benchmark Tests (academic ER datasets — see INTEGRATION-TESTING.md):
+#   make bench-setup-dblp-acm       — Load DBLP-ACM benchmark data
+#   make bench-invoke-dblp-acm      — Run all techniques on DBLP-ACM
+#   make bench-validate-dblp-acm    — Evaluate DBLP-ACM results (P/R/F1)
+#   make bench-dblp-acm             — All 3 phases for DBLP-ACM
+#   make bench-setup-all            — Load all benchmark datasets
+#   make bench-invoke-all           — Run all techniques on all datasets
+#   make bench-validate-all         — Evaluate all benchmark results
+#   make bench-all                  — All 3 phases, all benchmarks
+#
+# Cleanup:
+#   make clean            — Drop the ephemeral test schema
+#
+# Environment:
+#   Set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD, etc.
+#   or use:  make pharma ENV=.env
+#   which loads the .env file via uv's --env-file flag.
+
+ENV ?= .env
+UV_RUN = uv run --env-file $(ENV)
+PYTEST = $(UV_RUN) pytest -v --tb=short
+
+DOMAINS = pharma financial healthcare retail generic
+BENCHMARKS = dblp-acm dblp-scholar walmart-amazon amazon-google abt-buy
+
+.PHONY: all clean $(DOMAINS) \
+        setup-all invoke-all validate-all \
+        $(addprefix setup-,$(DOMAINS)) \
+        $(addprefix invoke-,$(DOMAINS)) \
+        $(addprefix validate-,$(DOMAINS)) \
+        bench-all bench-setup-all bench-invoke-all bench-validate-all \
+        $(addprefix bench-,$(BENCHMARKS)) \
+        $(addprefix bench-setup-,$(BENCHMARKS)) \
+        $(addprefix bench-invoke-,$(BENCHMARKS)) \
+        $(addprefix bench-validate-,$(BENCHMARKS)) \
+        sync
+
+# ── Per-domain: all 3 phases ─────────────────────────────────────────────
+
+pharma: setup-pharma invoke-pharma validate-pharma
+financial: setup-financial invoke-financial validate-financial
+healthcare: setup-healthcare invoke-healthcare validate-healthcare
+retail: setup-retail invoke-retail validate-retail
+generic: setup-generic invoke-generic validate-generic
+
+# ── Phase 1: setup ───────────────────────────────────────────────────────
+
+setup-all: $(addprefix setup-,$(DOMAINS))
+
+setup-pharma:
+	$(PYTEST) tests/phase1_setup/test_setup_pharma.py
+
+setup-financial:
+	$(PYTEST) tests/phase1_setup/test_setup_financial.py
+
+setup-healthcare:
+	$(PYTEST) tests/phase1_setup/test_setup_healthcare.py
+
+setup-retail:
+	$(PYTEST) tests/phase1_setup/test_setup_retail.py
+
+setup-generic:
+	$(PYTEST) tests/phase1_setup/test_setup_generic.py
+
+# ── Phase 2: invoke skill ───────────────────────────────────────────────
+
+invoke-all: $(addprefix invoke-,$(DOMAINS))
+
+invoke-pharma:
+	$(PYTEST) tests/phase2_invoke/test_invoke_pharma.py
+
+invoke-financial:
+	$(PYTEST) tests/phase2_invoke/test_invoke_financial.py
+
+invoke-healthcare:
+	$(PYTEST) tests/phase2_invoke/test_invoke_healthcare.py
+
+invoke-retail:
+	$(PYTEST) tests/phase2_invoke/test_invoke_retail.py
+
+invoke-generic:
+	$(PYTEST) tests/phase2_invoke/test_invoke_generic.py
+
+# ── Phase 3: validate results ───────────────────────────────────────────
+
+validate-all: $(addprefix validate-,$(DOMAINS))
+
+validate-pharma:
+	$(PYTEST) tests/phase3_validate/test_validate_pharma.py
+
+validate-financial:
+	$(PYTEST) tests/phase3_validate/test_validate_financial.py
+
+validate-healthcare:
+	$(PYTEST) tests/phase3_validate/test_validate_healthcare.py
+
+validate-retail:
+	$(PYTEST) tests/phase3_validate/test_validate_retail.py
+
+validate-generic:
+	$(PYTEST) tests/phase3_validate/test_validate_generic.py
+
+# ── All domains, all phases ──────────────────────────────────────────────
+
+all: setup-all invoke-all validate-all
+
+# ════════════════════════════════════════════════════════════════════════
+# Benchmark Integration Tests — Academic ER Datasets
+# See INTEGRATION-TESTING.md for dataset details and methodology.
+# ════════════════════════════════════════════════════════════════════════
+
+# ── Per-benchmark: all 3 phases ────────────────────────────────────────
+
+bench-dblp-acm: bench-setup-dblp-acm bench-invoke-dblp-acm bench-validate-dblp-acm
+bench-dblp-scholar: bench-setup-dblp-scholar bench-invoke-dblp-scholar bench-validate-dblp-scholar
+bench-walmart-amazon: bench-setup-walmart-amazon bench-invoke-walmart-amazon bench-validate-walmart-amazon
+bench-amazon-google: bench-setup-amazon-google bench-invoke-amazon-google bench-validate-amazon-google
+bench-abt-buy: bench-setup-abt-buy bench-invoke-abt-buy bench-validate-abt-buy
+
+# ── Benchmark Phase 1: setup ──────────────────────────────────────────
+
+bench-setup-all: $(addprefix bench-setup-,$(BENCHMARKS))
+
+bench-setup-dblp-acm:
+	$(PYTEST) tests/phase1_setup/test_setup_bench_dblp_acm.py
+
+bench-setup-dblp-scholar:
+	$(PYTEST) tests/phase1_setup/test_setup_bench_dblp_scholar.py
+
+bench-setup-walmart-amazon:
+	$(PYTEST) tests/phase1_setup/test_setup_bench_walmart_amazon.py
+
+bench-setup-amazon-google:
+	$(PYTEST) tests/phase1_setup/test_setup_bench_amazon_google.py
+
+bench-setup-abt-buy:
+	$(PYTEST) tests/phase1_setup/test_setup_bench_abt_buy.py
+
+# ── Benchmark Phase 2: invoke skill ───────────────────────────────────
+
+bench-invoke-all: $(addprefix bench-invoke-,$(BENCHMARKS))
+
+bench-invoke-dblp-acm:
+	$(PYTEST) tests/phase2_invoke/test_invoke_bench_dblp_acm.py
+
+bench-invoke-dblp-scholar:
+	$(PYTEST) tests/phase2_invoke/test_invoke_bench_dblp_scholar.py
+
+bench-invoke-walmart-amazon:
+	$(PYTEST) tests/phase2_invoke/test_invoke_bench_walmart_amazon.py
+
+bench-invoke-amazon-google:
+	$(PYTEST) tests/phase2_invoke/test_invoke_bench_amazon_google.py
+
+bench-invoke-abt-buy:
+	$(PYTEST) tests/phase2_invoke/test_invoke_bench_abt_buy.py
+
+# ── Benchmark Phase 3: validate results ───────────────────────────────
+
+bench-validate-all: $(addprefix bench-validate-,$(BENCHMARKS))
+
+bench-validate-dblp-acm:
+	$(PYTEST) tests/phase3_validate/test_validate_bench_dblp_acm.py
+
+bench-validate-dblp-scholar:
+	$(PYTEST) tests/phase3_validate/test_validate_bench_dblp_scholar.py
+
+bench-validate-walmart-amazon:
+	$(PYTEST) tests/phase3_validate/test_validate_bench_walmart_amazon.py
+
+bench-validate-amazon-google:
+	$(PYTEST) tests/phase3_validate/test_validate_bench_amazon_google.py
+
+bench-validate-abt-buy:
+	$(PYTEST) tests/phase3_validate/test_validate_bench_abt_buy.py
+
+# ── All benchmarks, all phases ─────────────────────────────────────────
+
+bench-all: bench-setup-all bench-invoke-all bench-validate-all
+
+# ── Cleanup ──────────────────────────────────────────────────────────────
+
+clean:
+	@if [ -f .test_schema ]; then \
+		SCHEMA=$$(cat .test_schema); \
+		echo "Dropping schema $$SCHEMA ..."; \
+		$(UV_RUN) python3 -c "import os, snowflake.connector; \
+			c=snowflake.connector.connect( \
+				account=os.environ['SNOWFLAKE_ACCOUNT'], \
+				user=os.environ['SNOWFLAKE_USER'], \
+				password=os.environ['SNOWFLAKE_PASSWORD'], \
+				warehouse=os.environ.get('SNOWFLAKE_WAREHOUSE','COMPUTE_WH'), \
+				database=os.environ.get('SNOWFLAKE_DATABASE','ENTITY_RESOLUTION_TEST'), \
+				role=os.environ.get('SNOWFLAKE_ROLE'), \
+				authenticator=os.environ.get('SNOWFLAKE_AUTHENTICATOR','snowflake')); \
+			c.cursor().execute('DROP SCHEMA IF EXISTS $$SCHEMA CASCADE'); \
+			print('Dropped $$SCHEMA'); c.close()"; \
+		rm -f .test_schema; \
+	else \
+		echo "No .test_schema file found — nothing to clean."; \
+	fi
+
+# ── Dependency sync ──────────────────────────────────────────────────────
+
+sync:
+	uv lock

--- a/skills/entity-resolution/src/pyproject.toml
+++ b/skills/entity-resolution/src/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "entity-resolution-tests"
+version = "0.1.0"
+description = "Integration tests for the entity-resolution skill"
+requires-python = ">=3.11"
+dependencies = [
+    "pytest>=8.0",
+    "snowflake-connector-python>=3.6",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "setup: Phase 1 — create source tables in Snowflake (fast, no CoCo)",
+    "invoke: Phase 2 — invoke the skill via cortex -p (slow, requires CoCo CLI)",
+    "validate: Phase 3 — verify skill outputs in Snowflake (fast, no CoCo)",
+    "pharma: pharma domain scenario",
+    "financial: financial services domain scenario",
+    "healthcare: healthcare provider domain scenario",
+    "retail: retail/CPG domain scenario",
+    "generic: generic name+address domain scenario",
+    "benchmark: benchmark integration tests against academic ER datasets",
+    "bench_dblp_acm: DBLP-ACM bibliographic benchmark",
+    "bench_dblp_scholar: DBLP-Scholar bibliographic benchmark (asymmetric)",
+    "bench_walmart_amazon: Walmart-Amazon product benchmark",
+    "bench_amazon_google: Amazon-Google product benchmark",
+    "bench_abt_buy: Abt-Buy e-commerce benchmark",
+]

--- a/skills/entity-resolution/src/tests/conftest.py
+++ b/skills/entity-resolution/src/tests/conftest.py
@@ -1,0 +1,322 @@
+"""
+Shared fixtures for entity-resolution integration tests.
+
+Three-phase test structure
+--------------------------
+Phase 1 (setup)    — Create source tables in Snowflake from fixture SQL.
+Phase 2 (invoke)   — Invoke the entity-resolution skill via ``cortex -p``.
+Phase 3 (validate) — Verify the Snowflake objects the skill created.
+
+Each phase can be run independently.  The ephemeral schema name is
+persisted to ``.test_schema`` so that Phase 2 and 3 can reuse the schema
+created in Phase 1 without re-creating it.
+
+Connection setup
+~~~~~~~~~~~~~~~~
+Set env vars (or use the checked-in .env with ``uv run --env-file .env``):
+
+    SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PASSWORD,
+    SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE, SNOWFLAKE_ROLE
+
+Optionally set CORTEX_CONNECTION to the named connection to pass via ``-c``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+import snowflake.connector
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+SKILL_DIR = Path(__file__).parent.parent.parent          # skills/entity-resolution
+REPO_ROOT = SKILL_DIR.parent.parent                       # cortex-code-skills
+SRC_DIR = Path(__file__).parent.parent                    # skills/entity-resolution/src
+SCHEMA_FILE = SRC_DIR / ".test_schema"
+
+# How long to wait (seconds) for a single CoCo skill invocation.
+DEFAULT_INVOKE_TIMEOUT = 900
+
+
+# ---------------------------------------------------------------------------
+# Schema persistence helpers
+# ---------------------------------------------------------------------------
+
+def _write_schema(name: str) -> None:
+    """Persist the test schema name so subsequent phases can reuse it."""
+    SCHEMA_FILE.write_text(name)
+
+
+def _read_schema() -> str:
+    """Read the persisted test schema name.  Raises if not found."""
+    if not SCHEMA_FILE.exists():
+        raise RuntimeError(
+            "No .test_schema file found.  Run Phase 1 (setup) first:\n"
+            "  make setup-pharma   (or whichever domain)"
+        )
+    name = SCHEMA_FILE.read_text().strip()
+    if not name:
+        raise RuntimeError(".test_schema file is empty.  Re-run Phase 1.")
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped Snowflake connection
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def sf_connection():
+    """Return a live Snowflake connection for the entire test session."""
+    conn = snowflake.connector.connect(
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        warehouse=os.environ.get("SNOWFLAKE_WAREHOUSE", "COMPUTE_WH"),
+        database=os.environ.get("SNOWFLAKE_DATABASE", "ENTITY_RESOLUTION_TEST"),
+        role=os.environ.get("SNOWFLAKE_ROLE"),
+        authenticator=os.environ.get("SNOWFLAKE_AUTHENTICATOR", "snowflake"),
+    )
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema fixtures — Phase 1 creates, Phase 2/3 reuse
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def test_schema_create(sf_connection):
+    """Phase 1: create a new ephemeral schema and persist its name."""
+    schema = f"ER_TEST_{uuid.uuid4().hex[:8].upper()}"
+    cur = sf_connection.cursor()
+    cur.execute(f"CREATE SCHEMA IF NOT EXISTS {schema}")
+    cur.execute(f"USE SCHEMA {schema}")
+    _write_schema(schema)
+    yield schema
+    # NOTE: no automatic teardown — use ``make clean`` to drop explicitly.
+    cur.close()
+
+
+@pytest.fixture(scope="session")
+def test_schema(sf_connection):
+    """Phase 2 & 3: load the schema name persisted by Phase 1."""
+    schema = _read_schema()
+    cur = sf_connection.cursor()
+    cur.execute(f"USE SCHEMA {schema}")
+    yield schema
+    cur.close()
+
+
+# ---------------------------------------------------------------------------
+# SQL helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def run_sql(sf_connection, test_schema):
+    """Execute one or more SQL statements.  Returns rows for the last one."""
+
+    def _run(sql: str, *, fetch: bool = True):
+        cur = sf_connection.cursor()
+        cur.execute(f"USE SCHEMA {test_schema}")
+        for stmt in _split_statements(sql):
+            stmt = stmt.strip()
+            if stmt:
+                cur.execute(stmt)
+        if fetch:
+            try:
+                return cur.fetchall()
+            except snowflake.connector.errors.ProgrammingError:
+                return []
+        return []
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def run_sql_setup(sf_connection, test_schema_create):
+    """Like run_sql but uses the Phase 1 schema (test_schema_create)."""
+
+    def _run(sql: str, *, fetch: bool = True):
+        cur = sf_connection.cursor()
+        cur.execute(f"USE SCHEMA {test_schema_create}")
+        for stmt in _split_statements(sql):
+            stmt = stmt.strip()
+            if stmt:
+                cur.execute(stmt)
+        if fetch:
+            try:
+                return cur.fetchall()
+            except snowflake.connector.errors.ProgrammingError:
+                return []
+        return []
+
+    return _run
+
+
+@pytest.fixture(scope="session")
+def load_fixture(run_sql_setup):
+    """Execute a ``.sql`` fixture file (Phase 1 only)."""
+
+    def _load(filename: str):
+        path = FIXTURES_DIR / filename
+        run_sql_setup(path.read_text(), fetch=False)
+
+    return _load
+
+
+# ---------------------------------------------------------------------------
+# CoCo invocation helper (Phase 2)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def cortex_connection():
+    """Named connection for ``cortex -c``."""
+    return os.environ.get("CORTEX_CONNECTION", "demoaccount")
+
+
+@pytest.fixture(scope="session")
+def invoke_skill(test_schema, cortex_connection):
+    """Invoke the entity-resolution skill via ``cortex -p`` in headless mode.
+
+    Returns a dict: ``ok`` (bool), ``output`` (stdout+stderr), ``returncode``.
+    """
+
+    def _invoke(
+        prompt: str,
+        *,
+        timeout: int = DEFAULT_INVOKE_TIMEOUT,
+    ) -> dict:
+        cmd = [
+            "cortex",
+            "-p", prompt,
+            "-c", cortex_connection,
+            "-w", str(REPO_ROOT),
+            "--bypass",
+            "--auto-accept-plans",
+            "--no-auto-update",
+            "--no-mcp",
+            "--output-format", "stream-json",
+        ]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            return {"ok": False, "output": "TIMEOUT", "returncode": -1}
+
+        return {
+            "ok": result.returncode == 0,
+            "output": result.stdout + result.stderr,
+            "returncode": result.returncode,
+        }
+
+    return _invoke
+
+
+# ---------------------------------------------------------------------------
+# Snowflake assertion helpers (Phase 3)
+# ---------------------------------------------------------------------------
+
+class SnowflakeAssertions:
+    """Convenience assertions against the test schema."""
+
+    def __init__(self, run_sql_fn, schema: str):
+        self._sql = run_sql_fn
+        self._schema = schema
+
+    def table_exists(self, name: str) -> bool:
+        rows = self._sql(
+            f"SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES "
+            f"WHERE TABLE_SCHEMA = '{self._schema}' "
+            f"AND UPPER(TABLE_NAME) = '{name.upper()}'"
+        )
+        return rows[0][0] > 0
+
+    def assert_table_exists(self, name: str):
+        assert self.table_exists(name), (
+            f"Expected table {self._schema}.{name} to exist"
+        )
+
+    def assert_table_not_exists(self, name: str):
+        assert not self.table_exists(name), (
+            f"Expected table {self._schema}.{name} to NOT exist"
+        )
+
+    def columns(self, table: str) -> set[str]:
+        rows = self._sql(
+            f"SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS "
+            f"WHERE TABLE_SCHEMA = '{self._schema}' "
+            f"AND UPPER(TABLE_NAME) = '{table.upper()}'"
+        )
+        return {r[0].upper() for r in rows}
+
+    def assert_columns_include(self, table: str, expected: set[str]):
+        actual = self.columns(table)
+        missing = {c.upper() for c in expected} - actual
+        assert not missing, (
+            f"Table {table} missing columns: {missing}. Has: {actual}"
+        )
+
+    def row_count(self, table: str) -> int:
+        rows = self._sql(f"SELECT COUNT(*) FROM {table}")
+        return rows[0][0]
+
+    def assert_row_count_between(self, table: str, lo: int, hi: int):
+        n = self.row_count(table)
+        assert lo <= n <= hi, (
+            f"Expected {table} to have {lo}-{hi} rows, got {n}"
+        )
+
+    def query_set(self, sql: str) -> set:
+        """Run sql that returns single-column rows; return as a set."""
+        rows = self._sql(sql)
+        return {r[0] for r in rows}
+
+    def query_map(self, sql: str) -> dict:
+        """Run sql that returns (key, value) rows; return as a dict."""
+        rows = self._sql(sql)
+        return {r[0]: r[1] for r in rows}
+
+
+@pytest.fixture(scope="session")
+def sf(run_sql, test_schema):
+    """Session-scoped Snowflake assertion helper."""
+    return SnowflakeAssertions(run_sql, test_schema)
+
+
+@pytest.fixture(scope="session")
+def sf_setup(run_sql_setup, test_schema_create):
+    """Snowflake assertion helper for Phase 1 (uses test_schema_create)."""
+    return SnowflakeAssertions(run_sql_setup, test_schema_create)
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def _split_statements(sql: str) -> list[str]:
+    """Split SQL on semicolons, ignoring semicolons inside string literals."""
+    stmts: list[str] = []
+    buf: list[str] = []
+    in_str = False
+    for ch in sql:
+        if ch == "'" and not in_str:
+            in_str = True
+        elif ch == "'" and in_str:
+            in_str = False
+        if ch == ";" and not in_str:
+            stmts.append("".join(buf))
+            buf = []
+            continue
+        buf.append(ch)
+    tail = "".join(buf).strip()
+    if tail:
+        stmts.append(tail)
+    return stmts

--- a/skills/entity-resolution/src/tests/fixtures/financial_data.sql
+++ b/skills/entity-resolution/src/tests/fixtures/financial_data.sql
@@ -1,0 +1,38 @@
+-- Financial services domain test data — 12 records
+--
+-- EXPECTED MATCHES (same entity):
+--   FN001 <-> FN002  : Same LEI 784F5XWPLTWKTBV3E584 (Goldman Sachs, name/addr variation)
+--   FN003 <-> FN004  : Same DUNS 987654321 (Midwest Financial Advisors, no LEI)
+--   FN007 <-> FN008  : Same LEI 7LTWFZYICNSX8D621K86 (Deutsche Bank, German name variant)
+--
+-- EXPECTED NON-MATCHES (different entities):
+--   FN005 vs FN006   : JPMorgan Chase & Co vs JPMorgan Chase Bank NA — parent vs subsidiary, DIFFERENT LEIs
+--   FN009 vs FN010   : HSBC Holdings PLC (UK) vs HSBC Bank USA — different jurisdictions, DIFFERENT LEIs
+--   FN011 vs FN012   : Both small firms at same address — DIFFERENT DUNS/Tax IDs
+--
+
+CREATE OR REPLACE TABLE financial_source (
+    source_id    VARCHAR,
+    source_table VARCHAR DEFAULT 'fin_a',
+    raw_name     VARCHAR,
+    raw_address  VARCHAR,
+    raw_lei      VARCHAR,
+    raw_duns     VARCHAR,
+    raw_tax_id   VARCHAR,
+    raw_crd      VARCHAR,
+    raw_swift    VARCHAR
+);
+
+INSERT INTO financial_source VALUES
+('FN001', 'fin_a', 'Goldman Sachs Group, Inc.',        '200 West St, New York, NY 10282', '784F5XWPLTWKTBV3E584', '001234567', '13-1234567', NULL, 'GSCMUS33'),
+('FN002', 'fin_b', 'GOLDMAN SACHS GROUP INC',          '200 West Street, New York, NY 10282', '784F5XWPLTWKTBV3E584', '001234567', '13-1234567', NULL, 'GSCMUS33'),
+('FN003', 'fin_a', 'Midwest Financial Advisors',       '100 Finance Blvd, Chicago, IL 60601', NULL, '987654321', '36-9876543', '1234567', NULL),
+('FN004', 'fin_b', 'Midwest Financial Advisors LLC',   '100 Finance Boulevard, Chicago, IL 60601', NULL, '987654321', '36-9876543', '1234567', NULL),
+('FN005', 'fin_a', 'JPMorgan Chase & Co.',             '383 Madison Ave, New York, NY 10179', '8I5DZWZKVSZI1NUHU748', '006969150', '13-2624428', NULL, 'CHASUS33'),
+('FN006', 'fin_b', 'JPMorgan Chase Bank, N.A.',        '1111 Polaris Pkwy, Columbus, OH 43240', '7H6GLXDRUGQFU57RNE97', '006969224', '13-4994650', NULL, 'CHASUS33XXX'),
+('FN007', 'fin_a', 'Deutsche Bank AG',                 'Taunusanlage 12, Frankfurt, Germany 60325', '7LTWFZYICNSX8D621K86', '314733909', NULL, NULL, 'DEUTDEFF'),
+('FN008', 'fin_b', 'DEUTSCHE BANK AKTIENGESELLSCHAFT', 'Taunusanlage 12, 60325 Frankfurt am Main, DE', '7LTWFZYICNSX8D621K86', '314733909', NULL, NULL, 'DEUTDEFF'),
+('FN009', 'fin_a', 'HSBC Holdings PLC',                '8 Canada Square, London, UK E14 5HQ', 'MLU0ZO3ML4LN2LL2TL39', '217479718', NULL, NULL, 'HSBCGB2L'),
+('FN010', 'fin_b', 'HSBC Bank USA, N.A.',              '452 Fifth Ave, New York, NY 10018', 'CYYGQCGNHMHPSMRL3R97', '004977852', '13-4776207', NULL, 'HSBCUS33'),
+('FN011', 'fin_a', 'Alpha Capital Advisors',           '50 State St, Suite 300, Boston, MA 02109', NULL, '111111111', '04-1111111', '9999999', NULL),
+('FN012', 'fin_b', 'Beta Wealth Management Inc',       '50 State St, Suite 300, Boston, MA 02109', NULL, '222222222', '04-2222222', '8888888', NULL);

--- a/skills/entity-resolution/src/tests/fixtures/generic_data.sql
+++ b/skills/entity-resolution/src/tests/fixtures/generic_data.sql
@@ -1,0 +1,32 @@
+-- Generic domain test data — 10 records (no authoritative IDs)
+--
+-- EXPECTED MATCHES (same entity):
+--   GN001 <-> GN002  : Near-identical name+address+phone (Acme Manufacturing / ACME MFG CO)
+--   GN003 <-> GN004  : Abbreviation variants (National Insurance Associates / Natl Ins Assoc) + same phone
+--   GN009 <-> GN010  : DBA variant (Robert Williams / Williams Plumbing dba Rob Williams) + same phone
+--
+-- EXPECTED NON-MATCHES (different entities):
+--   GN005 vs GN006   : Smith & Associates — same name, DIFFERENT addresses (branches)
+--   GN007 vs GN008   : Alpha Consulting vs Beta Technologies — different names, same address
+--
+
+CREATE OR REPLACE TABLE generic_source (
+    source_id    VARCHAR,
+    source_table VARCHAR DEFAULT 'gen_a',
+    raw_name     VARCHAR,
+    raw_address  VARCHAR,
+    raw_phone    VARCHAR,
+    raw_email    VARCHAR
+);
+
+INSERT INTO generic_source VALUES
+('GN001', 'gen_a', 'Acme Manufacturing Company',   '100 Industrial Blvd, Springfield, IL 62701', '217-555-0100', 'info@acmemfg.com'),
+('GN002', 'gen_b', 'ACME MFG CO',                  '100 Industrial Boulevard, Springfield, IL 62701', '217-555-0100', 'info@acmemfg.com'),
+('GN003', 'gen_a', 'National Insurance Associates', '200 Finance Dr, Suite 300, Chicago, IL 60601', '312-555-0200', NULL),
+('GN004', 'gen_b', 'Natl Ins Assoc',               '200 Finance Drive, Ste 300, Chicago, IL 60601', '312-555-0200', NULL),
+('GN005', 'gen_a', 'Smith & Associates',            '300 Oak St, Springfield, IL 62701', '217-555-0300', 'springfield@smith.com'),
+('GN006', 'gen_b', 'Smith & Associates',            '400 Lake Shore Dr, Chicago, IL 60611', '312-555-0400', 'chicago@smith.com'),
+('GN007', 'gen_a', 'Alpha Consulting Group',        '500 Business Park, Suite 100, Peoria, IL 61602', '309-555-0500', NULL),
+('GN008', 'gen_b', 'Beta Technologies LLC',         '500 Business Park, Suite 100, Peoria, IL 61602', '309-555-0600', NULL),
+('GN009', 'gen_a', 'Robert Williams',               '800 Elm St, Champaign, IL 61820', '217-555-0900', NULL),
+('GN010', 'gen_b', 'Williams Plumbing dba Rob Williams Services', '800 Elm Street, Champaign, IL 61820', '217-555-0900', NULL);

--- a/skills/entity-resolution/src/tests/fixtures/healthcare_data.sql
+++ b/skills/entity-resolution/src/tests/fixtures/healthcare_data.sql
@@ -1,0 +1,39 @@
+-- Healthcare provider domain test data — 12 records
+--
+-- EXPECTED MATCHES (same entity):
+--   HC001 <-> HC002  : Same NPI 1234567890, both Type 1 (Dr. John Smith, name format variation)
+--   HC003 <-> HC004  : Same NPI 9876543210, both Type 2 (Springfield Medical Group, case variation)
+--   HC007 <-> HC008  : Same NPI 3333333333, Type 1, DIFFERENT addresses (multi-location provider)
+--
+-- EXPECTED NON-MATCHES (different entities):
+--   HC005 vs HC006   : Type 1 individual vs Type 2 organization at same address — MUST NOT cross-match
+--   HC009 vs HC010   : Same building, different suites (210 vs 220), different NPIs — separate practices
+--   HC011 vs HC012   : Same NPI but we put different NPIs to test — actually same person, credential variation
+--
+-- NOTE: HC007 and HC008 share an NPI but are in different cities (Peoria vs Champaign).
+-- Blocking by state+zip3 may separate them.  The skill must still resolve them via Tier 1 NPI match
+-- if its blocking strategy covers them (e.g., compound blocking or NPI-prefix blocking).
+
+CREATE OR REPLACE TABLE healthcare_source (
+    source_id       VARCHAR,
+    source_table    VARCHAR DEFAULT 'hc_a',
+    raw_name        VARCHAR,
+    raw_address     VARCHAR,
+    raw_npi         VARCHAR,
+    npi_type        VARCHAR,
+    raw_taxonomy    VARCHAR
+);
+
+INSERT INTO healthcare_source VALUES
+('HC001', 'hc_a', 'Smith, John A, MD',              '100 Medical Dr, Suite 200, Springfield, IL 62701', '1234567890', '1', '207R00000X'),
+('HC002', 'hc_b', 'Dr. John Smith MD',               '100 Medical Drive, Ste 200, Springfield, IL 62701', '1234567890', '1', '207R00000X'),
+('HC003', 'hc_a', 'Springfield Medical Group Inc',   '100 Medical Dr, Springfield, IL 62701', '9876543210', '2', '261QM0801X'),
+('HC004', 'hc_b', 'SPRINGFIELD MEDICAL GROUP',       '100 Medical Drive, Springfield, IL 62701', '9876543210', '2', '261QM0801X'),
+('HC005', 'hc_a', 'Johnson, Mary, DO',               '200 Health Pkwy, Suite 100, Chicago, IL 60601', '1111111111', '1', '208000000X'),
+('HC006', 'hc_b', 'Chicago Health Associates PC',    '200 Health Pkwy, Suite 100, Chicago, IL 60601', '2222222222', '2', '261QP2300X'),
+('HC007', 'hc_a', 'Williams, Robert, MD',            '300 Oak St, Suite 400, Peoria, IL 61602', '3333333333', '1', '208600000X'),
+('HC008', 'hc_b', 'Williams, Robert, MD',            '500 Pine Ave, Suite 100, Champaign, IL 61820', '3333333333', '1', '208600000X'),
+('HC009', 'hc_a', 'Davis Orthopedic Clinic',         '400 Medical Pkwy, Suite 210, Springfield, IL 62701', '4444444444', '2', '207X00000X'),
+('HC010', 'hc_b', 'Springfield Physical Therapy LLC', '400 Medical Pkwy, Suite 220, Springfield, IL 62701', '5555555555', '2', '225100000X'),
+('HC011', 'hc_a', 'Garcia, Maria Elena, NP',         '600 University Ave, Urbana, IL 61801', '6666666666', '1', '363L00000X'),
+('HC012', 'hc_b', 'Maria Garcia ARNP',               '600 University Avenue, Urbana, IL 61801', '6666666666', '1', '363L00000X');

--- a/skills/entity-resolution/src/tests/fixtures/pharma_data.sql
+++ b/skills/entity-resolution/src/tests/fixtures/pharma_data.sql
@@ -1,0 +1,36 @@
+-- Pharma domain test data — 12 records
+--
+-- EXPECTED MATCHES (same entity):
+--   PH001 <-> PH002  : Same NPI 1234567890 (CVS Pharmacy, same location, name variation)
+--   PH003 <-> PH004  : Same DEA CD9876543  (Springfield Family Pharmacy/Phcy)
+--   PH009 <-> PH010  : Same NPI 5555555555 (CVS, same address, store number format variation)
+--
+-- EXPECTED NON-MATCHES (different entities):
+--   PH005 vs PH006   : Walgreens — same chain name, DIFFERENT addresses/NPIs (separate locations)
+--   PH007 vs PH008   : Same street address, DIFFERENT suites (200 vs 310) and DIFFERENT NPIs
+--   PH011 vs PH012   : Prescriber vs pharmacy at same address — different entity types
+--
+
+CREATE OR REPLACE TABLE pharma_source (
+    source_id    VARCHAR,
+    source_table VARCHAR DEFAULT 'pharma_a',
+    raw_name     VARCHAR,
+    raw_address  VARCHAR,
+    raw_npi      VARCHAR,
+    raw_dea      VARCHAR,
+    raw_ncpdp    VARCHAR
+);
+
+INSERT INTO pharma_source VALUES
+('PH001', 'pharma_a', 'CVS Pharmacy #4523',           '100 Main St, Suite 101, Springfield, IL 62701', '1234567890', 'AB1234567', '1234567'),
+('PH002', 'pharma_b', 'CVS PHARMACY 4523',            '100 Main Street, Ste 101, Springfield, IL 62701', '1234567890', 'AB1234567', '1234567'),
+('PH003', 'pharma_a', 'Springfield Family Pharmacy',   '200 Oak Ave, Springfield, IL 62702', NULL, 'CD9876543', '7654321'),
+('PH004', 'pharma_b', 'Springfield Family Phcy LLC',   '200 Oak Avenue, Springfield, IL 62702', NULL, 'CD9876543', '7654321'),
+('PH005', 'pharma_a', 'Walgreens',                     '300 Elm St, Springfield, IL 62701', '1111111111', 'EF1111111', '1111111'),
+('PH006', 'pharma_b', 'Walgreens',                     '500 Pine St, Chicago, IL 60601', '2222222222', 'EF2222222', '2222222'),
+('PH007', 'pharma_a', 'Dr. Smith Medical Practice',    '400 Medical Pkwy, Suite 200, Springfield, IL 62701', '3333333333', 'GH3333333', NULL),
+('PH008', 'pharma_b', 'Springfield Urgent Care',       '400 Medical Pkwy, Suite 310, Springfield, IL 62701', '4444444444', 'IJ4444444', NULL),
+('PH009', 'pharma_a', 'CVS/pharmacy #12345',           '600 Broadway, Chicago, IL 60602', '5555555555', 'KL5555555', '5555555'),
+('PH010', 'pharma_b', 'CVS Pharmacy Store 12345',      '600 Broadway, Chicago, IL 60602', '5555555555', 'KL5555555', '5555555'),
+('PH011', 'pharma_a', 'Dr. Jane Doe, MD',              '400 Medical Pkwy, Suite 200, Springfield, IL 62701', '6666666666', 'MN6666666', NULL),
+('PH012', 'pharma_b', 'Springfield Medical Group Inc',  '400 Medical Pkwy, Suite 200, Springfield, IL 62701', '7777777777', NULL, NULL);

--- a/skills/entity-resolution/src/tests/fixtures/retail_data.sql
+++ b/skills/entity-resolution/src/tests/fixtures/retail_data.sql
@@ -1,0 +1,38 @@
+-- Retail/CPG domain test data — 12 records
+--
+-- EXPECTED MATCHES (same entity):
+--   RT001 <-> RT002  : Same GLN 0012345678901 (Walmart Supercenter, store number format variation)
+--   RT003 <-> RT004  : Same GTIN 00049000028904 (Coca-Cola 12pk, catalog description variation)
+--   RT009 <-> RT010  : Same GLN 0022222222201 (CVS, store number normalization)
+--
+-- EXPECTED NON-MATCHES (different entities):
+--   RT005 vs RT006   : Target — different store locations, different GLNs
+--   RT007 vs RT008   : McDonald's corporate vs franchise at same address — different DUNS
+--   RT011 vs RT012   : Different GTIN (24-pack vs 6-pack) — different products
+--
+
+CREATE OR REPLACE TABLE retail_source (
+    source_id       VARCHAR,
+    source_table    VARCHAR DEFAULT 'ret_a',
+    raw_name        VARCHAR,
+    raw_address     VARCHAR,
+    raw_gtin        VARCHAR,
+    raw_gln         VARCHAR,
+    raw_supplier_id VARCHAR,
+    raw_duns        VARCHAR,
+    entity_type     VARCHAR
+);
+
+INSERT INTO retail_source VALUES
+('RT001', 'ret_a', 'Walmart Supercenter #3456',        '100 Retail Blvd, Springfield, IL 62701', NULL, '0012345678901', 'SUP-001', '123456789', 'store'),
+('RT002', 'ret_b', 'WALMART SUPERCENTER 3456',          '100 Retail Boulevard, Springfield, IL 62701', NULL, '0012345678901', 'SUP-001', '123456789', 'store'),
+('RT003', 'ret_a', 'Coca-Cola Classic 12oz Can 12-Pack', NULL, '00049000028904', NULL, NULL, NULL, 'product'),
+('RT004', 'ret_b', 'Coca Cola Classic 12pk 12 oz cans',  NULL, '00049000028904', NULL, NULL, NULL, 'product'),
+('RT005', 'ret_a', 'Target T-1892',                     '200 Commerce Dr, Springfield, IL 62701', NULL, '0098765432101', NULL, '333333333', 'store'),
+('RT006', 'ret_b', 'Target T-2104',                     '500 Lake Shore Dr, Chicago, IL 60611', NULL, '0098765432102', NULL, '333333333', 'store'),
+('RT007', 'ret_a', 'McDonald''s Restaurant',             '300 Main St, Springfield, IL 62701', NULL, '0011111111101', NULL, '444444444', 'store'),
+('RT008', 'ret_b', 'ABC Foods LLC dba McDonald''s',      '300 Main St, Springfield, IL 62701', NULL, '0011111111101', NULL, '555555555', 'store'),
+('RT009', 'ret_a', 'CVS/pharmacy #08821',               '400 Elm St, Chicago, IL 60602', NULL, '0022222222201', NULL, '666666666', 'store'),
+('RT010', 'ret_b', 'CVS Pharmacy Store 8821',            '400 Elm Street, Chicago, IL 60602', NULL, '0022222222201', NULL, '666666666', 'store'),
+('RT011', 'ret_a', 'Coca-Cola Classic 12oz Can 24-Pack', NULL, '00049000028911', NULL, NULL, NULL, 'product'),
+('RT012', 'ret_b', 'Coca-Cola Classic 12oz Can 6-Pack',  NULL, '00049000028898', NULL, NULL, NULL, 'product');

--- a/skills/entity-resolution/src/tests/phase1_setup/test_setup_financial.py
+++ b/skills/entity-resolution/src/tests/phase1_setup/test_setup_financial.py
@@ -1,0 +1,21 @@
+"""Phase 1 — Setup financial services source data in Snowflake."""
+import pytest
+
+pytestmark = [pytest.mark.setup, pytest.mark.financial]
+
+
+class TestSetupFinancial:
+    def test_load_fixture(self, load_fixture):
+        load_fixture("financial_data.sql")
+
+    def test_source_table_exists(self, sf_setup):
+        sf_setup.assert_table_exists("FINANCIAL_SOURCE")
+
+    def test_source_row_count(self, sf_setup):
+        sf_setup.assert_row_count_between("FINANCIAL_SOURCE", 12, 12)
+
+    def test_source_columns(self, sf_setup):
+        sf_setup.assert_columns_include("FINANCIAL_SOURCE", {
+            "SOURCE_ID", "SOURCE_TABLE", "RAW_NAME", "RAW_ADDRESS",
+            "RAW_LEI", "RAW_DUNS", "RAW_TAX_ID", "RAW_CRD", "RAW_SWIFT",
+        })

--- a/skills/entity-resolution/src/tests/phase1_setup/test_setup_generic.py
+++ b/skills/entity-resolution/src/tests/phase1_setup/test_setup_generic.py
@@ -1,0 +1,21 @@
+"""Phase 1 — Setup generic (name+address) source data in Snowflake."""
+import pytest
+
+pytestmark = [pytest.mark.setup, pytest.mark.generic]
+
+
+class TestSetupGeneric:
+    def test_load_fixture(self, load_fixture):
+        load_fixture("generic_data.sql")
+
+    def test_source_table_exists(self, sf_setup):
+        sf_setup.assert_table_exists("GENERIC_SOURCE")
+
+    def test_source_row_count(self, sf_setup):
+        sf_setup.assert_row_count_between("GENERIC_SOURCE", 10, 10)
+
+    def test_source_columns(self, sf_setup):
+        sf_setup.assert_columns_include("GENERIC_SOURCE", {
+            "SOURCE_ID", "SOURCE_TABLE", "RAW_NAME", "RAW_ADDRESS",
+            "RAW_PHONE", "RAW_EMAIL",
+        })

--- a/skills/entity-resolution/src/tests/phase1_setup/test_setup_healthcare.py
+++ b/skills/entity-resolution/src/tests/phase1_setup/test_setup_healthcare.py
@@ -1,0 +1,21 @@
+"""Phase 1 — Setup healthcare provider source data in Snowflake."""
+import pytest
+
+pytestmark = [pytest.mark.setup, pytest.mark.healthcare]
+
+
+class TestSetupHealthcare:
+    def test_load_fixture(self, load_fixture):
+        load_fixture("healthcare_data.sql")
+
+    def test_source_table_exists(self, sf_setup):
+        sf_setup.assert_table_exists("HEALTHCARE_SOURCE")
+
+    def test_source_row_count(self, sf_setup):
+        sf_setup.assert_row_count_between("HEALTHCARE_SOURCE", 12, 12)
+
+    def test_source_columns(self, sf_setup):
+        sf_setup.assert_columns_include("HEALTHCARE_SOURCE", {
+            "SOURCE_ID", "SOURCE_TABLE", "RAW_NAME", "RAW_ADDRESS",
+            "RAW_NPI", "NPI_TYPE", "RAW_TAXONOMY",
+        })

--- a/skills/entity-resolution/src/tests/phase1_setup/test_setup_pharma.py
+++ b/skills/entity-resolution/src/tests/phase1_setup/test_setup_pharma.py
@@ -1,0 +1,21 @@
+"""Phase 1 — Setup pharma source data in Snowflake."""
+import pytest
+
+pytestmark = [pytest.mark.setup, pytest.mark.pharma]
+
+
+class TestSetupPharma:
+    def test_load_fixture(self, load_fixture):
+        load_fixture("pharma_data.sql")
+
+    def test_source_table_exists(self, sf_setup):
+        sf_setup.assert_table_exists("PHARMA_SOURCE")
+
+    def test_source_row_count(self, sf_setup):
+        sf_setup.assert_row_count_between("PHARMA_SOURCE", 12, 12)
+
+    def test_source_columns(self, sf_setup):
+        sf_setup.assert_columns_include("PHARMA_SOURCE", {
+            "SOURCE_ID", "SOURCE_TABLE", "RAW_NAME", "RAW_ADDRESS",
+            "RAW_NPI", "RAW_DEA", "RAW_NCPDP",
+        })

--- a/skills/entity-resolution/src/tests/phase1_setup/test_setup_retail.py
+++ b/skills/entity-resolution/src/tests/phase1_setup/test_setup_retail.py
@@ -1,0 +1,21 @@
+"""Phase 1 — Setup retail/CPG source data in Snowflake."""
+import pytest
+
+pytestmark = [pytest.mark.setup, pytest.mark.retail]
+
+
+class TestSetupRetail:
+    def test_load_fixture(self, load_fixture):
+        load_fixture("retail_data.sql")
+
+    def test_source_table_exists(self, sf_setup):
+        sf_setup.assert_table_exists("RETAIL_SOURCE")
+
+    def test_source_row_count(self, sf_setup):
+        sf_setup.assert_row_count_between("RETAIL_SOURCE", 12, 12)
+
+    def test_source_columns(self, sf_setup):
+        sf_setup.assert_columns_include("RETAIL_SOURCE", {
+            "SOURCE_ID", "SOURCE_TABLE", "RAW_NAME", "RAW_ADDRESS",
+            "RAW_GTIN", "RAW_GLN", "RAW_SUPPLIER_ID", "RAW_DUNS", "ENTITY_TYPE",
+        })

--- a/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_financial.py
+++ b/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_financial.py
@@ -1,0 +1,25 @@
+"""Phase 2 — Invoke the entity-resolution skill for the financial services domain."""
+import pytest
+
+pytestmark = [pytest.mark.invoke, pytest.mark.financial]
+
+PROMPT_TEMPLATE = (
+    "I need to run entity resolution on the table {db}.{schema}.FINANCIAL_SOURCE. "
+    "This is a financial services dataset with bank and investment firm records. "
+    "The columns are: source_id, source_table, raw_name, raw_address, raw_lei, "
+    "raw_duns, raw_tax_id, raw_crd, raw_swift. "
+    "Write all output tables (normalized_entities, candidate_pairs, match_results, entity_groups) "
+    "to the schema {db}.{schema}. "
+    "Use the entity-resolution skill with the financial-services domain profile."
+)
+
+
+class TestInvokeFinancial:
+    def test_skill_completes(self, invoke_skill, test_schema, sf_connection):
+        db = sf_connection.database
+        prompt = PROMPT_TEMPLATE.format(db=db, schema=test_schema)
+        result = invoke_skill(prompt, timeout=900)
+        assert result["ok"], (
+            f"Skill invocation failed (rc={result['returncode']}). "
+            f"Output tail:\n{result['output'][-3000:]}"
+        )

--- a/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_generic.py
+++ b/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_generic.py
@@ -1,0 +1,24 @@
+"""Phase 2 — Invoke the entity-resolution skill for the generic domain."""
+import pytest
+
+pytestmark = [pytest.mark.invoke, pytest.mark.generic]
+
+PROMPT_TEMPLATE = (
+    "I need to run entity resolution on the table {db}.{schema}.GENERIC_SOURCE. "
+    "This is a generic name-and-address dataset with no authoritative identifiers. "
+    "The columns are: source_id, source_table, raw_name, raw_address, raw_phone, raw_email. "
+    "Write all output tables (normalized_entities, candidate_pairs, match_results, entity_groups) "
+    "to the schema {db}.{schema}. "
+    "Use the entity-resolution skill with the generic domain profile."
+)
+
+
+class TestInvokeGeneric:
+    def test_skill_completes(self, invoke_skill, test_schema, sf_connection):
+        db = sf_connection.database
+        prompt = PROMPT_TEMPLATE.format(db=db, schema=test_schema)
+        result = invoke_skill(prompt, timeout=900)
+        assert result["ok"], (
+            f"Skill invocation failed (rc={result['returncode']}). "
+            f"Output tail:\n{result['output'][-3000:]}"
+        )

--- a/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_healthcare.py
+++ b/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_healthcare.py
@@ -1,0 +1,25 @@
+"""Phase 2 — Invoke the entity-resolution skill for the healthcare provider domain."""
+import pytest
+
+pytestmark = [pytest.mark.invoke, pytest.mark.healthcare]
+
+PROMPT_TEMPLATE = (
+    "I need to run entity resolution on the table {db}.{schema}.HEALTHCARE_SOURCE. "
+    "This is a healthcare provider dataset with individual and organizational providers. "
+    "The columns are: source_id, source_table, raw_name, raw_address, raw_npi, "
+    "npi_type, raw_taxonomy. "
+    "Write all output tables (normalized_entities, candidate_pairs, match_results, entity_groups) "
+    "to the schema {db}.{schema}. "
+    "Use the entity-resolution skill with the healthcare-provider domain profile."
+)
+
+
+class TestInvokeHealthcare:
+    def test_skill_completes(self, invoke_skill, test_schema, sf_connection):
+        db = sf_connection.database
+        prompt = PROMPT_TEMPLATE.format(db=db, schema=test_schema)
+        result = invoke_skill(prompt, timeout=900)
+        assert result["ok"], (
+            f"Skill invocation failed (rc={result['returncode']}). "
+            f"Output tail:\n{result['output'][-3000:]}"
+        )

--- a/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_pharma.py
+++ b/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_pharma.py
@@ -1,0 +1,24 @@
+"""Phase 2 — Invoke the entity-resolution skill for the pharma domain."""
+import pytest
+
+pytestmark = [pytest.mark.invoke, pytest.mark.pharma]
+
+PROMPT_TEMPLATE = (
+    "I need to run entity resolution on the table {db}.{schema}.PHARMA_SOURCE. "
+    "This is a pharma dataset with pharmacy/prescriber records. "
+    "The columns are: source_id, source_table, raw_name, raw_address, raw_npi, raw_dea, raw_ncpdp. "
+    "Write all output tables (normalized_entities, candidate_pairs, match_results, entity_groups) "
+    "to the schema {db}.{schema}. "
+    "Use the entity-resolution skill with the pharma domain profile."
+)
+
+
+class TestInvokePharma:
+    def test_skill_completes(self, invoke_skill, test_schema, sf_connection):
+        db = sf_connection.database
+        prompt = PROMPT_TEMPLATE.format(db=db, schema=test_schema)
+        result = invoke_skill(prompt, timeout=900)
+        assert result["ok"], (
+            f"Skill invocation failed (rc={result['returncode']}). "
+            f"Output tail:\n{result['output'][-3000:]}"
+        )

--- a/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_retail.py
+++ b/skills/entity-resolution/src/tests/phase2_invoke/test_invoke_retail.py
@@ -1,0 +1,25 @@
+"""Phase 2 — Invoke the entity-resolution skill for the retail/CPG domain."""
+import pytest
+
+pytestmark = [pytest.mark.invoke, pytest.mark.retail]
+
+PROMPT_TEMPLATE = (
+    "I need to run entity resolution on the table {db}.{schema}.RETAIL_SOURCE. "
+    "This is a retail/CPG dataset with store locations and product records. "
+    "The columns are: source_id, source_table, raw_name, raw_address, raw_gtin, "
+    "raw_gln, raw_supplier_id, raw_duns, entity_type. "
+    "Write all output tables (normalized_entities, candidate_pairs, match_results, entity_groups) "
+    "to the schema {db}.{schema}. "
+    "Use the entity-resolution skill with the retail-cpg domain profile."
+)
+
+
+class TestInvokeRetail:
+    def test_skill_completes(self, invoke_skill, test_schema, sf_connection):
+        db = sf_connection.database
+        prompt = PROMPT_TEMPLATE.format(db=db, schema=test_schema)
+        result = invoke_skill(prompt, timeout=900)
+        assert result["ok"], (
+            f"Skill invocation failed (rc={result['returncode']}). "
+            f"Output tail:\n{result['output'][-3000:]}"
+        )

--- a/skills/entity-resolution/src/tests/phase3_validate/test_validate_financial.py
+++ b/skills/entity-resolution/src/tests/phase3_validate/test_validate_financial.py
@@ -1,0 +1,183 @@
+"""
+Phase 3 — Validate the financial services domain entity-resolution results.
+
+Expected matches:
+    FN001 <-> FN002  (Same LEI 784F5XWPLTWKTBV3E584 — Goldman Sachs)
+    FN003 <-> FN004  (Same DUNS 987654321 — Midwest Financial Advisors)
+    FN007 <-> FN008  (Same LEI 7LTWFZYICNSX8D621K86 — Deutsche Bank)
+
+Expected non-matches:
+    FN005 vs FN006  (JPMorgan parent vs subsidiary — different LEIs)
+    FN009 vs FN010  (HSBC Holdings PLC vs HSBC Bank USA — different LEIs)
+    FN011 vs FN012  (Different firms at same address — different DUNS/Tax IDs)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.validate, pytest.mark.financial]
+
+
+# ── Normalized entities ──────────────────────────────────────────────────
+
+class TestNormalizedEntities:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("NORMALIZED_ENTITIES")
+
+    def test_row_count(self, sf):
+        sf.assert_row_count_between("NORMALIZED_ENTITIES", 12, 12)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("NORMALIZED_ENTITIES", {
+            "SOURCE_ID", "NORMALIZED_NAME",
+        })
+
+    def test_lei_normalized(self, run_sql):
+        """LEIs should be 20-char uppercase alphanumeric."""
+        rows = run_sql(
+            "SELECT SOURCE_ID, NORMALIZED_LEI FROM NORMALIZED_ENTITIES "
+            "WHERE SOURCE_ID = 'FN001'"
+        )
+        if rows and rows[0][1] is not None:
+            lei = str(rows[0][1])
+            assert len(lei) == 20 and lei.isalnum(), (
+                f"Expected 20-char alphanumeric LEI, got: {lei}"
+            )
+
+
+# ── Candidate pairs ──────────────────────────────────────────────────────
+
+class TestCandidatePairs:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("CANDIDATE_PAIRS")
+
+    def test_has_pairs(self, sf):
+        sf.assert_row_count_between("CANDIDATE_PAIRS", 1, 1000)
+
+
+# ── Match results ────────────────────────────────────────────────────────
+
+class TestMatchResults:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("MATCH_RESULTS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("MATCH_RESULTS", {
+            "ID_LEFT", "ID_RIGHT", "DECISION", "CONFIDENCE", "MATCH_METHOD",
+        })
+
+    def test_has_tier1_matches(self, run_sql):
+        """Financial profile has LEI/DUNS/Tax ID → should produce Tier 1 matches."""
+        rows = run_sql(
+            "SELECT COUNT(*) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        assert rows[0][0] > 0, (
+            "Financial domain should produce Tier 1 exact-ID matches"
+        )
+
+
+# ── Known matches ────────────────────────────────────────────────────────
+
+class TestKnownMatches:
+    EXPECTED_MATCHES = [
+        ("FN001", "FN002"),  # Same LEI — Goldman Sachs
+        ("FN003", "FN004"),  # Same DUNS — Midwest Financial Advisors
+        ("FN007", "FN008"),  # Same LEI — Deutsche Bank
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_MATCHES)
+    def test_pair_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            f"Expected {left}<->{right} to match, got decisions={decisions}"
+        )
+
+
+# ── Known non-matches ────────────────────────────────────────────────────
+
+class TestKnownNonMatches:
+    EXPECTED_NON_MATCHES = [
+        ("FN005", "FN006"),  # JPMorgan parent vs subsidiary — different LEIs
+        ("FN009", "FN010"),  # HSBC Holdings vs HSBC Bank USA — different LEIs
+        ("FN011", "FN012"),  # Different firms, same address, different DUNS
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_NON_MATCHES)
+    def test_pair_not_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            f"Expected {left}<->{right} to NOT match, got decisions={decisions}"
+        )
+
+
+# ── Financial domain specifics ───────────────────────────────────────────
+
+class TestFinancialDomainSpecifics:
+    def test_parent_subsidiary_separation(self, run_sql):
+        """FN005 (JPMorgan Chase & Co) and FN006 (JPMorgan Chase Bank NA)
+        have different LEIs — parent vs subsidiary = separate."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'FN005' AND ID_RIGHT = 'FN006') "
+            "   OR (ID_LEFT = 'FN006' AND ID_RIGHT = 'FN005')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Parent and subsidiary with different LEIs should not match"
+        )
+
+    def test_cross_jurisdiction_separation(self, run_sql):
+        """FN009 (HSBC Holdings PLC, UK) and FN010 (HSBC Bank USA)
+        have different LEIs — different jurisdictions = separate."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'FN009' AND ID_RIGHT = 'FN010') "
+            "   OR (ID_LEFT = 'FN010' AND ID_RIGHT = 'FN009')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Cross-jurisdiction entities with different LEIs should not match"
+        )
+
+
+# ── Entity groups ────────────────────────────────────────────────────────
+
+class TestEntityGroups:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("ENTITY_GROUPS")
+
+    def test_lei_match_shares_group(self, run_sql):
+        """FN001 and FN002 (same LEI) should be in the same entity group."""
+        rows = run_sql(
+            "SELECT ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('FN001', 'FN002')"
+        )
+        if len(rows) >= 2:
+            groups = {r[0] for r in rows}
+            assert len(groups) == 1, (
+                f"FN001 and FN002 should share a group, got {groups}"
+            )
+
+    def test_parent_subsidiary_different_groups(self, run_sql):
+        """FN005 and FN006 (parent vs subsidiary) should be in separate groups."""
+        rows = run_sql(
+            "SELECT ENTITY_ID, ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('FN005', 'FN006')"
+        )
+        if len(rows) == 2:
+            groups = {r[1] for r in rows}
+            assert len(groups) == 2, (
+                f"FN005 and FN006 should be in different groups, got {groups}"
+            )

--- a/skills/entity-resolution/src/tests/phase3_validate/test_validate_generic.py
+++ b/skills/entity-resolution/src/tests/phase3_validate/test_validate_generic.py
@@ -1,0 +1,166 @@
+"""
+Phase 3 — Validate the generic domain entity-resolution results.
+
+No skill invocation here — just queries the Snowflake objects
+created by Phase 2 and asserts correctness.
+
+Expected matches:
+    GN001 <-> GN002  (Acme Manufacturing / ACME MFG CO)
+    GN003 <-> GN004  (National Insurance Associates / Natl Ins Assoc)
+    GN009 <-> GN010  (Robert Williams / Williams Plumbing dba Rob Williams)
+
+Expected non-matches:
+    GN005 vs GN006  (same name, different addresses — separate branches)
+    GN007 vs GN008  (different names, same address — different companies)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.validate, pytest.mark.generic]
+
+
+# ── Normalized entities ──────────────────────────────────────────────────
+
+class TestNormalizedEntities:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("NORMALIZED_ENTITIES")
+
+    def test_row_count(self, sf):
+        sf.assert_row_count_between("NORMALIZED_ENTITIES", 10, 10)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("NORMALIZED_ENTITIES", {
+            "SOURCE_ID", "NORMALIZED_NAME",
+        })
+
+    def test_names_normalized(self, run_sql):
+        """Normalized names should be uppercase and stripped of legal suffixes."""
+        rows = run_sql(
+            "SELECT SOURCE_ID, NORMALIZED_NAME FROM NORMALIZED_ENTITIES "
+            "WHERE SOURCE_ID IN ('GN001', 'GN002') ORDER BY SOURCE_ID"
+        )
+        assert len(rows) == 2
+        for _, name in rows:
+            assert name == name.upper(), f"Expected uppercase, got: {name}"
+
+
+# ── Candidate pairs ──────────────────────────────────────────────────────
+
+class TestCandidatePairs:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("CANDIDATE_PAIRS")
+
+    def test_has_pairs(self, sf):
+        sf.assert_row_count_between("CANDIDATE_PAIRS", 1, 1000)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("CANDIDATE_PAIRS", {"ID_LEFT", "ID_RIGHT"})
+
+
+# ── Match results ────────────────────────────────────────────────────────
+
+class TestMatchResults:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("MATCH_RESULTS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("MATCH_RESULTS", {
+            "ID_LEFT", "ID_RIGHT", "DECISION", "CONFIDENCE", "MATCH_METHOD",
+        })
+
+    def test_decisions_valid(self, run_sql):
+        decisions = {r[0] for r in run_sql(
+            "SELECT DISTINCT DECISION FROM MATCH_RESULTS"
+        )}
+        assert decisions <= {"match", "probable_match", "no_match"}, (
+            f"Unexpected decisions: {decisions}"
+        )
+
+    def test_no_tier1_matches(self, run_sql):
+        """Generic profile has no authoritative IDs → no Tier 1 results."""
+        rows = run_sql(
+            "SELECT COUNT(*) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        assert rows[0][0] == 0, "Generic domain should not produce Tier 1 matches"
+
+
+# ── Known matches ────────────────────────────────────────────────────────
+
+class TestKnownMatches:
+    EXPECTED_MATCHES = [
+        ("GN001", "GN002"),  # Acme Manufacturing / ACME MFG CO
+        ("GN003", "GN004"),  # National Insurance Associates / Natl Ins Assoc
+        ("GN009", "GN010"),  # Robert Williams / Williams Plumbing dba
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_MATCHES)
+    def test_pair_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            f"Expected {left}<->{right} to match, got decisions={decisions}"
+        )
+
+
+# ── Known non-matches ────────────────────────────────────────────────────
+
+class TestKnownNonMatches:
+    EXPECTED_NON_MATCHES = [
+        ("GN005", "GN006"),  # Same name, different cities
+        ("GN007", "GN008"),  # Different names, same address
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_NON_MATCHES)
+    def test_pair_not_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            f"Expected {left}<->{right} to NOT match, got decisions={decisions}"
+        )
+
+
+# ── Entity groups ────────────────────────────────────────────────────────
+
+class TestEntityGroups:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("ENTITY_GROUPS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("ENTITY_GROUPS", {
+            "ENTITY_ID", "ENTITY_GROUP_ID",
+        })
+
+    def test_matched_pair_shares_group(self, run_sql):
+        """GN001 and GN002 should be in the same entity group."""
+        rows = run_sql(
+            "SELECT ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('GN001', 'GN002')"
+        )
+        if len(rows) >= 2:
+            groups = {r[0] for r in rows}
+            assert len(groups) == 1, (
+                f"GN001 and GN002 should share a group, got {groups}"
+            )
+
+    def test_non_match_different_groups(self, run_sql):
+        """GN005 and GN006 (same name, different addresses) should be separate."""
+        rows = run_sql(
+            "SELECT ENTITY_ID, ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('GN005', 'GN006')"
+        )
+        if len(rows) == 2:
+            groups = {r[1] for r in rows}
+            assert len(groups) == 2, (
+                f"GN005 and GN006 should be in different groups, got {groups}"
+            )

--- a/skills/entity-resolution/src/tests/phase3_validate/test_validate_healthcare.py
+++ b/skills/entity-resolution/src/tests/phase3_validate/test_validate_healthcare.py
@@ -1,0 +1,193 @@
+"""
+Phase 3 — Validate the healthcare provider domain entity-resolution results.
+
+Expected matches:
+    HC001 <-> HC002  (Same NPI 1234567890, Type 1 — Dr. John Smith)
+    HC003 <-> HC004  (Same NPI 9876543210, Type 2 — Springfield Medical Group)
+    HC007 <-> HC008  (Same NPI 3333333333, Type 1, different cities — multi-location)
+    HC011 <-> HC012  (Same NPI 6666666666, Type 1 — Maria Garcia)
+
+Expected non-matches:
+    HC005 vs HC006  (Type 1 individual vs Type 2 org — MUST NOT cross-match)
+    HC009 vs HC010  (Same building, different suites, different NPIs)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.validate, pytest.mark.healthcare]
+
+
+# ── Normalized entities ──────────────────────────────────────────────────
+
+class TestNormalizedEntities:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("NORMALIZED_ENTITIES")
+
+    def test_row_count(self, sf):
+        sf.assert_row_count_between("NORMALIZED_ENTITIES", 12, 12)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("NORMALIZED_ENTITIES", {
+            "SOURCE_ID", "NORMALIZED_NAME",
+        })
+
+    def test_npi_normalized(self, run_sql):
+        """NPIs should be 10-digit zero-padded strings."""
+        rows = run_sql(
+            "SELECT SOURCE_ID, NORMALIZED_NPI FROM NORMALIZED_ENTITIES "
+            "WHERE SOURCE_ID = 'HC001'"
+        )
+        if rows and rows[0][1] is not None:
+            npi = str(rows[0][1])
+            assert len(npi) == 10 and npi.isdigit(), (
+                f"Expected 10-digit NPI, got: {npi}"
+            )
+
+
+# ── Candidate pairs ──────────────────────────────────────────────────────
+
+class TestCandidatePairs:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("CANDIDATE_PAIRS")
+
+    def test_has_pairs(self, sf):
+        sf.assert_row_count_between("CANDIDATE_PAIRS", 1, 1000)
+
+
+# ── Match results ────────────────────────────────────────────────────────
+
+class TestMatchResults:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("MATCH_RESULTS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("MATCH_RESULTS", {
+            "ID_LEFT", "ID_RIGHT", "DECISION", "CONFIDENCE", "MATCH_METHOD",
+        })
+
+    def test_has_tier1_matches(self, run_sql):
+        """Healthcare profile has NPI → should produce Tier 1 matches."""
+        rows = run_sql(
+            "SELECT COUNT(*) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        assert rows[0][0] > 0, (
+            "Healthcare domain should produce Tier 1 NPI matches"
+        )
+
+
+# ── Known matches ────────────────────────────────────────────────────────
+
+class TestKnownMatches:
+    EXPECTED_MATCHES = [
+        ("HC001", "HC002"),  # Same NPI, Type 1 — Dr. John Smith
+        ("HC003", "HC004"),  # Same NPI, Type 2 — Springfield Medical Group
+        ("HC007", "HC008"),  # Same NPI, Type 1, different cities — multi-location
+        ("HC011", "HC012"),  # Same NPI, Type 1 — Maria Garcia
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_MATCHES)
+    def test_pair_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            f"Expected {left}<->{right} to match, got decisions={decisions}"
+        )
+
+
+# ── Known non-matches ────────────────────────────────────────────────────
+
+class TestKnownNonMatches:
+    EXPECTED_NON_MATCHES = [
+        ("HC005", "HC006"),  # Type 1 individual vs Type 2 org
+        ("HC009", "HC010"),  # Same building, different suites, different NPIs
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_NON_MATCHES)
+    def test_pair_not_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            f"Expected {left}<->{right} to NOT match, got decisions={decisions}"
+        )
+
+
+# ── Healthcare domain specifics ──────────────────────────────────────────
+
+class TestHealthcareDomainSpecifics:
+    def test_npi_type_isolation(self, run_sql):
+        """HC005 (NPI Type 1) and HC006 (NPI Type 2) MUST NOT cross-match."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'HC005' AND ID_RIGHT = 'HC006') "
+            "   OR (ID_LEFT = 'HC006' AND ID_RIGHT = 'HC005')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "NPI Type 1 (individual) and Type 2 (org) must not cross-match"
+        )
+
+    def test_multi_location_same_npi(self, run_sql):
+        """HC007 and HC008 share NPI but are in different cities — same entity."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'HC007' AND ID_RIGHT = 'HC008') "
+            "   OR (ID_LEFT = 'HC008' AND ID_RIGHT = 'HC007')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            "Multi-location providers with same NPI should match"
+        )
+
+    def test_suite_differentiation(self, run_sql):
+        """HC009 (Suite 210) and HC010 (Suite 220) — different NPIs, different suites."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'HC009' AND ID_RIGHT = 'HC010') "
+            "   OR (ID_LEFT = 'HC010' AND ID_RIGHT = 'HC009')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Different suites with different NPIs should not match"
+        )
+
+
+# ── Entity groups ────────────────────────────────────────────────────────
+
+class TestEntityGroups:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("ENTITY_GROUPS")
+
+    def test_npi_match_shares_group(self, run_sql):
+        """HC001 and HC002 (same NPI) should be in the same entity group."""
+        rows = run_sql(
+            "SELECT ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('HC001', 'HC002')"
+        )
+        if len(rows) >= 2:
+            groups = {r[0] for r in rows}
+            assert len(groups) == 1, (
+                f"HC001 and HC002 should share a group, got {groups}"
+            )
+
+    def test_type_isolation_different_groups(self, run_sql):
+        """HC005 (Type 1) and HC006 (Type 2) should be in different groups."""
+        rows = run_sql(
+            "SELECT ENTITY_ID, ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('HC005', 'HC006')"
+        )
+        if len(rows) == 2:
+            groups = {r[1] for r in rows}
+            assert len(groups) == 2, (
+                f"HC005 and HC006 should be in different groups, got {groups}"
+            )

--- a/skills/entity-resolution/src/tests/phase3_validate/test_validate_pharma.py
+++ b/skills/entity-resolution/src/tests/phase3_validate/test_validate_pharma.py
@@ -1,0 +1,192 @@
+"""
+Phase 3 — Validate the pharma domain entity-resolution results.
+
+Expected matches:
+    PH001 <-> PH002  (Same NPI 1234567890 — CVS #4523)
+    PH003 <-> PH004  (Same DEA CD9876543 — Springfield Family Pharmacy)
+    PH009 <-> PH010  (Same NPI 5555555555 — CVS #12345)
+
+Expected non-matches:
+    PH005 vs PH006  (Walgreens — different locations, different NPIs)
+    PH007 vs PH008  (Same address block, different suites, different NPIs)
+    PH011 vs PH012  (Prescriber vs pharmacy at same address)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.validate, pytest.mark.pharma]
+
+
+# ── Normalized entities ──────────────────────────────────────────────────
+
+class TestNormalizedEntities:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("NORMALIZED_ENTITIES")
+
+    def test_row_count(self, sf):
+        sf.assert_row_count_between("NORMALIZED_ENTITIES", 12, 12)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("NORMALIZED_ENTITIES", {
+            "SOURCE_ID", "NORMALIZED_NAME",
+        })
+
+    def test_npi_normalized(self, run_sql):
+        """NPIs should be 10-digit zero-padded strings."""
+        rows = run_sql(
+            "SELECT SOURCE_ID, NORMALIZED_NPI FROM NORMALIZED_ENTITIES "
+            "WHERE SOURCE_ID = 'PH001'"
+        )
+        if rows and rows[0][1] is not None:
+            npi = str(rows[0][1])
+            assert len(npi) == 10 and npi.isdigit(), (
+                f"Expected 10-digit NPI, got: {npi}"
+            )
+
+
+# ── Candidate pairs ──────────────────────────────────────────────────────
+
+class TestCandidatePairs:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("CANDIDATE_PAIRS")
+
+    def test_has_pairs(self, sf):
+        sf.assert_row_count_between("CANDIDATE_PAIRS", 1, 1000)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("CANDIDATE_PAIRS", {"ID_LEFT", "ID_RIGHT"})
+
+
+# ── Match results ────────────────────────────────────────────────────────
+
+class TestMatchResults:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("MATCH_RESULTS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("MATCH_RESULTS", {
+            "ID_LEFT", "ID_RIGHT", "DECISION", "CONFIDENCE", "MATCH_METHOD",
+        })
+
+    def test_has_tier1_matches(self, run_sql):
+        """Pharma profile has NPI/DEA/NCPDP → should produce Tier 1 matches."""
+        rows = run_sql(
+            "SELECT COUNT(*) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        assert rows[0][0] > 0, "Pharma domain should produce Tier 1 exact-ID matches"
+
+    def test_tier1_confidence_is_1(self, run_sql):
+        """Tier 1 deterministic matches should have confidence = 1.0."""
+        rows = run_sql(
+            "SELECT MIN(CONFIDENCE) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        if rows and rows[0][0] is not None:
+            assert rows[0][0] == 1.0, (
+                f"Tier 1 confidence should be 1.0, got min={rows[0][0]}"
+            )
+
+
+# ── Known matches ────────────────────────────────────────────────────────
+
+class TestKnownMatches:
+    EXPECTED_MATCHES = [
+        ("PH001", "PH002"),  # Same NPI — CVS 4523
+        ("PH003", "PH004"),  # Same DEA — Springfield Family Pharmacy
+        ("PH009", "PH010"),  # Same NPI — CVS 12345
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_MATCHES)
+    def test_pair_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            f"Expected {left}<->{right} to match, got decisions={decisions}"
+        )
+
+
+# ── Known non-matches ────────────────────────────────────────────────────
+
+class TestKnownNonMatches:
+    EXPECTED_NON_MATCHES = [
+        ("PH005", "PH006"),  # Walgreens — different NPIs, different locations
+        ("PH007", "PH008"),  # Same address block, different suites + NPIs
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_NON_MATCHES)
+    def test_pair_not_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            f"Expected {left}<->{right} to NOT match, got decisions={decisions}"
+        )
+
+
+# ── Pharma domain specifics ─────────────────────────────────────────────
+
+class TestPharmaDomainSpecifics:
+    def test_suite_differentiation(self, run_sql):
+        """PH007 (Suite 200) and PH008 (Suite 310) should NOT match."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'PH007' AND ID_RIGHT = 'PH008') "
+            "   OR (ID_LEFT = 'PH008' AND ID_RIGHT = 'PH007')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Suite-differentiated pharmacies should not match"
+        )
+
+    def test_prescriber_vs_pharmacy_isolation(self, run_sql):
+        """PH011 (prescriber) and PH012 (pharmacy) should NOT match."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'PH011' AND ID_RIGHT = 'PH012') "
+            "   OR (ID_LEFT = 'PH012' AND ID_RIGHT = 'PH011')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Prescriber and pharmacy at same address should not match"
+        )
+
+
+# ── Entity groups ────────────────────────────────────────────────────────
+
+class TestEntityGroups:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("ENTITY_GROUPS")
+
+    def test_npi_match_shares_group(self, run_sql):
+        """PH001 and PH002 (same NPI) should be in the same entity group."""
+        rows = run_sql(
+            "SELECT ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('PH001', 'PH002')"
+        )
+        if len(rows) >= 2:
+            groups = {r[0] for r in rows}
+            assert len(groups) == 1, (
+                f"PH001 and PH002 should share a group, got {groups}"
+            )
+
+    def test_different_npi_different_groups(self, run_sql):
+        """PH005 and PH006 (different NPIs, different locations) should be separate."""
+        rows = run_sql(
+            "SELECT ENTITY_ID, ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('PH005', 'PH006')"
+        )
+        if len(rows) == 2:
+            groups = {r[1] for r in rows}
+            assert len(groups) == 2, (
+                f"PH005 and PH006 should be in different groups, got {groups}"
+            )

--- a/skills/entity-resolution/src/tests/phase3_validate/test_validate_retail.py
+++ b/skills/entity-resolution/src/tests/phase3_validate/test_validate_retail.py
@@ -1,0 +1,198 @@
+"""
+Phase 3 — Validate the retail/CPG domain entity-resolution results.
+
+Expected matches:
+    RT001 <-> RT002  (Same GLN 0012345678901 — Walmart Supercenter #3456)
+    RT003 <-> RT004  (Same GTIN 00049000028904 — Coca-Cola 12pk)
+    RT009 <-> RT010  (Same GLN 0022222222201 — CVS #8821)
+
+Expected non-matches:
+    RT005 vs RT006  (Target — different store locations, different GLNs)
+    RT007 vs RT008  (McDonald's corporate vs franchise — different DUNS)
+    RT011 vs RT012  (Different GTIN — 24-pack vs 6-pack, different products)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.validate, pytest.mark.retail]
+
+
+# ── Normalized entities ──────────────────────────────────────────────────
+
+class TestNormalizedEntities:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("NORMALIZED_ENTITIES")
+
+    def test_row_count(self, sf):
+        sf.assert_row_count_between("NORMALIZED_ENTITIES", 12, 12)
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("NORMALIZED_ENTITIES", {
+            "SOURCE_ID", "NORMALIZED_NAME",
+        })
+
+    def test_gtin_padded_to_14(self, run_sql):
+        """GTINs should be zero-padded to 14 digits per retail-cpg profile."""
+        rows = run_sql(
+            "SELECT SOURCE_ID, NORMALIZED_GTIN FROM NORMALIZED_ENTITIES "
+            "WHERE SOURCE_ID = 'RT003'"
+        )
+        if rows and rows[0][1] is not None:
+            gtin = str(rows[0][1])
+            assert len(gtin) == 14 and gtin.isdigit(), (
+                f"Expected 14-digit padded GTIN, got: {gtin}"
+            )
+
+
+# ── Candidate pairs ──────────────────────────────────────────────────────
+
+class TestCandidatePairs:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("CANDIDATE_PAIRS")
+
+    def test_has_pairs(self, sf):
+        sf.assert_row_count_between("CANDIDATE_PAIRS", 1, 1000)
+
+
+# ── Match results ────────────────────────────────────────────────────────
+
+class TestMatchResults:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("MATCH_RESULTS")
+
+    def test_schema_columns(self, sf):
+        sf.assert_columns_include("MATCH_RESULTS", {
+            "ID_LEFT", "ID_RIGHT", "DECISION", "CONFIDENCE", "MATCH_METHOD",
+        })
+
+    def test_has_tier1_matches(self, run_sql):
+        """Retail profile has GLN/GTIN → should produce Tier 1 matches."""
+        rows = run_sql(
+            "SELECT COUNT(*) FROM MATCH_RESULTS "
+            "WHERE MATCH_METHOD = 'tier1_exact_id'"
+        )
+        assert rows[0][0] > 0, (
+            "Retail domain should produce Tier 1 exact-ID matches"
+        )
+
+
+# ── Known matches ────────────────────────────────────────────────────────
+
+class TestKnownMatches:
+    EXPECTED_MATCHES = [
+        ("RT001", "RT002"),  # Same GLN — Walmart Supercenter #3456
+        ("RT003", "RT004"),  # Same GTIN — Coca-Cola 12pk
+        ("RT009", "RT010"),  # Same GLN — CVS #8821
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_MATCHES)
+    def test_pair_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert decisions & {"match", "probable_match"}, (
+            f"Expected {left}<->{right} to match, got decisions={decisions}"
+        )
+
+
+# ── Known non-matches ────────────────────────────────────────────────────
+
+class TestKnownNonMatches:
+    EXPECTED_NON_MATCHES = [
+        ("RT005", "RT006"),  # Target — different GLNs, different locations
+        ("RT007", "RT008"),  # McDonald's corporate vs franchise — different DUNS
+        ("RT011", "RT012"),  # 24-pack vs 6-pack — different GTINs
+    ]
+
+    @pytest.mark.parametrize("left,right", EXPECTED_NON_MATCHES)
+    def test_pair_not_matched(self, left, right, run_sql):
+        rows = run_sql(
+            f"SELECT DECISION FROM MATCH_RESULTS "
+            f"WHERE (ID_LEFT = '{left}' AND ID_RIGHT = '{right}') "
+            f"   OR (ID_LEFT = '{right}' AND ID_RIGHT = '{left}')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            f"Expected {left}<->{right} to NOT match, got decisions={decisions}"
+        )
+
+
+# ── Retail domain specifics ──────────────────────────────────────────────
+
+class TestRetailDomainSpecifics:
+    def test_franchise_vs_corporate_separation(self, run_sql):
+        """RT007 (McDonald's corporate) and RT008 (franchise) share GLN
+        but have different DUNS.  Franchise vs corporate = different entities."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'RT007' AND ID_RIGHT = 'RT008') "
+            "   OR (ID_LEFT = 'RT008' AND ID_RIGHT = 'RT007')"
+        )
+        decisions = {r[0] for r in rows}
+        # They share GLN so Tier 1 might match them.  If so, acceptable.
+        if "match" in decisions:
+            pytest.skip(
+                "RT007/RT008 matched via shared GLN despite different DUNS — "
+                "acceptable if skill prioritizes location-level GLN matching"
+            )
+
+    def test_different_gtin_different_products(self, run_sql):
+        """RT011 (24-pack) and RT012 (6-pack) have different GTINs = different products."""
+        rows = run_sql(
+            "SELECT DECISION FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'RT011' AND ID_RIGHT = 'RT012') "
+            "   OR (ID_LEFT = 'RT012' AND ID_RIGHT = 'RT011')"
+        )
+        decisions = {r[0] for r in rows}
+        assert "match" not in decisions, (
+            "Products with different GTINs should not match"
+        )
+
+    def test_store_number_normalization(self, run_sql):
+        """RT001 (#3456) and RT002 (3456) should Tier 1 match via GLN."""
+        rows = run_sql(
+            "SELECT MATCH_METHOD FROM MATCH_RESULTS "
+            "WHERE (ID_LEFT = 'RT001' AND ID_RIGHT = 'RT002') "
+            "   OR (ID_LEFT = 'RT002' AND ID_RIGHT = 'RT001')"
+        )
+        if rows:
+            methods = {r[0] for r in rows}
+            assert "tier1_exact_id" in methods, (
+                f"RT001/RT002 share GLN — expected Tier 1 match, got {methods}"
+            )
+
+
+# ── Entity groups ────────────────────────────────────────────────────────
+
+class TestEntityGroups:
+    def test_table_exists(self, sf):
+        sf.assert_table_exists("ENTITY_GROUPS")
+
+    def test_gln_match_shares_group(self, run_sql):
+        """RT001 and RT002 (same GLN) should be in the same entity group."""
+        rows = run_sql(
+            "SELECT ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('RT001', 'RT002')"
+        )
+        if len(rows) >= 2:
+            groups = {r[0] for r in rows}
+            assert len(groups) == 1, (
+                f"RT001 and RT002 should share a group, got {groups}"
+            )
+
+    def test_different_locations_different_groups(self, run_sql):
+        """RT005 and RT006 (Target, different GLNs) should be in separate groups."""
+        rows = run_sql(
+            "SELECT ENTITY_ID, ENTITY_GROUP_ID FROM ENTITY_GROUPS "
+            "WHERE ENTITY_ID IN ('RT005', 'RT006')"
+        )
+        if len(rows) == 2:
+            groups = {r[1] for r in rows}
+            assert len(groups) == 2, (
+                f"RT005 and RT006 should be in different groups, got {groups}"
+            )

--- a/skills/entity-resolution/src/uv.lock
+++ b/skills/entity-resolution/src/uv.lock
@@ -1,0 +1,529 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "asn1crypto"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c", size = 121080, upload-time = "2022-03-15T14:46:52.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67", size = 105045, upload-time = "2022-03-15T14:46:51.055Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/c9/8ff8a901cf62374f1289cf36391f855e1702c70f545c28d1b57608a84ff2/boto3-1.42.65.tar.gz", hash = "sha256:c740af6bdaebcc1a00f3827a5729050bf6fc820ee148bf7d06f28db11c80e2a1", size = 112805, upload-time = "2026-03-10T19:44:58.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/bb/ace5921655df51e3c9b787b3f0bd6aa25548e5cf1dabae02e53fa88f2d98/boto3-1.42.65-py3-none-any.whl", hash = "sha256:cc7f2e0aec6c68ee5b10232cf3e01326acf6100bc785a770385b61a0474b31f4", size = 140556, upload-time = "2026-03-10T19:44:55.433Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.65"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/81/2c832e2117d24da4fe800861e8ddd19bbaa308623b1198eb2c2cc6fcd3d4/botocore-1.42.65.tar.gz", hash = "sha256:7d52c148df07f70c375eeda58f99b439c7c7836c25df74cccfba3bb6e12444d2", size = 14970239, upload-time = "2026-03-10T19:44:43.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/9e/2ca03a55408c0820d7f0a04ae52bc6dfc7e4fff1f007a90135a68e056c93/botocore-1.42.65-py3-none-any.whl", hash = "sha256:0283c332ce00cbd1b894e86b7bed89dd624a5ca3a4ee62ec4db3898d16652e98", size = 14644794, upload-time = "2026-03-10T19:44:37.442Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/35/02daf95b9cd686320bb622eb148792655c9412dbb9b67abb5694e5910a24/charset_normalizer-3.4.5.tar.gz", hash = "sha256:95adae7b6c42a6c5b5b559b1a99149f090a57128155daeea91732c8d970d8644", size = 134804, upload-time = "2026-03-06T06:03:19.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/9e/bcec3b22c64ecec47d39bf5167c2613efd41898c019dccd4183f6aa5d6a7/charset_normalizer-3.4.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:610f72c0ee565dfb8ae1241b666119582fdbfe7c0975c175be719f940e110694", size = 279531, upload-time = "2026-03-06T06:00:52.252Z" },
+    { url = "https://files.pythonhosted.org/packages/58/12/81fd25f7e7078ab5d1eedbb0fac44be4904ae3370a3bf4533c8f2d159acd/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60d68e820af339df4ae8358c7a2e7596badeb61e544438e489035f9fbf3246a5", size = 188006, upload-time = "2026-03-06T06:00:53.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6e/f2d30e8c27c1b0736a6520311982cf5286cfc7f6cac77d7bc1325e3a23f2/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:10b473fc8dca1c3ad8559985794815f06ca3fc71942c969129070f2c3cdf7281", size = 205085, upload-time = "2026-03-06T06:00:55.311Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/90/d12cefcb53b5931e2cf792a33718d7126efb116a320eaa0742c7059a95e4/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d4eb8ac7469b2a5d64b5b8c04f84d8bf3ad340f4514b98523805cbf46e3b3923", size = 200545, upload-time = "2026-03-06T06:00:56.532Z" },
+    { url = "https://files.pythonhosted.org/packages/03/f4/44d3b830a20e89ff82a3134912d9a1cf6084d64f3b95dcad40f74449a654/charset_normalizer-3.4.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bcb3227c3d9aaf73eaaab1db7ccd80a8995c509ee9941e2aae060ca6e4e5d81", size = 193863, upload-time = "2026-03-06T06:00:57.823Z" },
+    { url = "https://files.pythonhosted.org/packages/25/4b/f212119c18a6320a9d4a730d1b4057875cdeabf21b3614f76549042ef8a8/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:75ee9c1cce2911581a70a3c0919d8bccf5b1cbc9b0e5171400ec736b4b569497", size = 181827, upload-time = "2026-03-06T06:00:59.323Z" },
+    { url = "https://files.pythonhosted.org/packages/74/00/b26158e48b425a202a92965f8069e8a63d9af1481dfa206825d7f74d2a3c/charset_normalizer-3.4.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d1401945cb77787dbd3af2446ff2d75912327c4c3a1526ab7955ecf8600687c", size = 191085, upload-time = "2026-03-06T06:01:00.546Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1c1737bf6fd40335fe53d28fe49afd99ee4143cc57a845e99635ce0b9b6d/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a45e504f5e1be0bd385935a8e1507c442349ca36f511a47057a71c9d1d6ea9e", size = 190688, upload-time = "2026-03-06T06:01:02.479Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3d/abb5c22dc2ef493cd56522f811246a63c5427c08f3e3e50ab663de27fcf4/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e09f671a54ce70b79a1fc1dc6da3072b7ef7251fadb894ed92d9aa8218465a5f", size = 183077, upload-time = "2026-03-06T06:01:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/44/33/5298ad4d419a58e25b3508e87f2758d1442ff00c2471f8e0403dab8edad5/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d01de5e768328646e6a3fa9e562706f8f6641708c115c62588aef2b941a4f88e", size = 206706, upload-time = "2026-03-06T06:01:05.773Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/17/51e7895ac0f87c3b91d276a449ef09f5532a7529818f59646d7a55089432/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:131716d6786ad5e3dc542f5cc6f397ba3339dc0fb87f87ac30e550e8987756af", size = 191665, upload-time = "2026-03-06T06:01:07.473Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8f/cce9adf1883e98906dbae380d769b4852bb0fa0004bc7d7a2243418d3ea8/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a374cc0b88aa710e8865dc1bd6edb3743c59f27830f0293ab101e4cf3ce9f85", size = 201950, upload-time = "2026-03-06T06:01:08.973Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ca/bce99cd5c397a52919e2769d126723f27a4c037130374c051c00470bcd38/charset_normalizer-3.4.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d31f0d1671e1534e395f9eb84a68e0fb670e1edb1fe819a9d7f564ae3bc4e53f", size = 195830, upload-time = "2026-03-06T06:01:10.155Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4f/2e3d023a06911f1281f97b8f036edc9872167036ca6f55cc874a0be6c12c/charset_normalizer-3.4.5-cp311-cp311-win32.whl", hash = "sha256:cace89841c0599d736d3d74a27bc5821288bb47c5441923277afc6059d7fbcb4", size = 132029, upload-time = "2026-03-06T06:01:11.706Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1f/a853b73d386521fd44b7f67ded6b17b7b2367067d9106a5c4b44f9a34274/charset_normalizer-3.4.5-cp311-cp311-win_amd64.whl", hash = "sha256:f8102ae93c0bc863b1d41ea0f4499c20a83229f52ed870850892df555187154a", size = 142404, upload-time = "2026-03-06T06:01:12.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/10/dba36f76b71c38e9d391abe0fd8a5b818790e053c431adecfc98c35cd2a9/charset_normalizer-3.4.5-cp311-cp311-win_arm64.whl", hash = "sha256:ed98364e1c262cf5f9363c3eca8c2df37024f52a8fa1180a3610014f26eac51c", size = 132796, upload-time = "2026-03-06T06:01:14.106Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b6/9ee9c1a608916ca5feae81a344dffbaa53b26b90be58cc2159e3332d44ec/charset_normalizer-3.4.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ed97c282ee4f994ef814042423a529df9497e3c666dca19be1d4cd1129dc7ade", size = 280976, upload-time = "2026-03-06T06:01:15.276Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d8/a54f7c0b96f1df3563e9190f04daf981e365a9b397eedfdfb5dbef7e5c6c/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0294916d6ccf2d069727d65973c3a1ca477d68708db25fd758dd28b0827cff54", size = 189356, upload-time = "2026-03-06T06:01:16.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/69/2bf7f76ce1446759a5787cb87d38f6a61eb47dbbdf035cfebf6347292a65/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dc57a0baa3eeedd99fafaef7511b5a6ef4581494e8168ee086031744e2679467", size = 206369, upload-time = "2026-03-06T06:01:17.853Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9c/949d1a46dab56b959d9a87272482195f1840b515a3380e39986989a893ae/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ed1a9a204f317ef879b32f9af507d47e49cd5e7f8e8d5d96358c98373314fc60", size = 203285, upload-time = "2026-03-06T06:01:19.473Z" },
+    { url = "https://files.pythonhosted.org/packages/67/5c/ae30362a88b4da237d71ea214a8c7eb915db3eec941adda511729ac25fa2/charset_normalizer-3.4.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7ad83b8f9379176c841f8865884f3514d905bcd2a9a3b210eaa446e7d2223e4d", size = 196274, upload-time = "2026-03-06T06:01:20.728Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/07/c9f2cb0e46cb6d64fdcc4f95953747b843bb2181bda678dc4e699b8f0f9a/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:a118e2e0b5ae6b0120d5efa5f866e58f2bb826067a646431da4d6a2bdae7950e", size = 184715, upload-time = "2026-03-06T06:01:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/36/64/6b0ca95c44fddf692cd06d642b28f63009d0ce325fad6e9b2b4d0ef86a52/charset_normalizer-3.4.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:754f96058e61a5e22e91483f823e07df16416ce76afa4ebf306f8e1d1296d43f", size = 193426, upload-time = "2026-03-06T06:01:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bc/a730690d726403743795ca3f5bb2baf67838c5fea78236098f324b965e40/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0c300cefd9b0970381a46394902cd18eaf2aa00163f999590ace991989dcd0fc", size = 191780, upload-time = "2026-03-06T06:01:25.053Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4f/6c0bc9af68222b22951552d73df4532b5be6447cee32d58e7e8c74ecbb7b/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:c108f8619e504140569ee7de3f97d234f0fbae338a7f9f360455071ef9855a95", size = 185805, upload-time = "2026-03-06T06:01:26.294Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/b9/a523fb9b0ee90814b503452b2600e4cbc118cd68714d57041564886e7325/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:d1028de43596a315e2720a9849ee79007ab742c06ad8b45a50db8cdb7ed4a82a", size = 208342, upload-time = "2026-03-06T06:01:27.55Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/61/c59e761dee4464050713e50e27b58266cc8e209e518c0b378c1580c959ba/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:19092dde50335accf365cce21998a1c6dd8eafd42c7b226eb54b2747cdce2fac", size = 193661, upload-time = "2026-03-06T06:01:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/43/729fa30aad69783f755c5ad8649da17ee095311ca42024742701e202dc59/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4354e401eb6dab9aed3c7b4030514328a6c748d05e1c3e19175008ca7de84fb1", size = 204819, upload-time = "2026-03-06T06:01:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/87/33/d9b442ce5a91b96fc0840455a9e49a611bbadae6122778d0a6a79683dd31/charset_normalizer-3.4.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a68766a3c58fde7f9aaa22b3786276f62ab2f594efb02d0a1421b6282e852e98", size = 198080, upload-time = "2026-03-06T06:01:31.478Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5a/b8b5a23134978ee9885cee2d6995f4c27cc41f9baded0a9685eabc5338f0/charset_normalizer-3.4.5-cp312-cp312-win32.whl", hash = "sha256:1827734a5b308b65ac54e86a618de66f935a4f63a8a462ff1e19a6788d6c2262", size = 132630, upload-time = "2026-03-06T06:01:33.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/53/e44a4c07e8904500aec95865dc3f6464dc3586a039ef0df606eb3ac38e35/charset_normalizer-3.4.5-cp312-cp312-win_amd64.whl", hash = "sha256:728c6a963dfab66ef865f49286e45239384249672cd598576765acc2a640a636", size = 142856, upload-time = "2026-03-06T06:01:34.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/aa/c5628f7cad591b1cf45790b7a61483c3e36cf41349c98af7813c483fd6e8/charset_normalizer-3.4.5-cp312-cp312-win_arm64.whl", hash = "sha256:75dfd1afe0b1647449e852f4fb428195a7ed0588947218f7ba929f6538487f02", size = 132982, upload-time = "2026-03-06T06:01:35.641Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/48/9f34ec4bb24aa3fdba1890c1bddb97c8a4be1bd84ef5c42ac2352563ad05/charset_normalizer-3.4.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ac59c15e3f1465f722607800c68713f9fbc2f672b9eb649fe831da4019ae9b23", size = 280788, upload-time = "2026-03-06T06:01:37.126Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/09/6003e7ffeb90cc0560da893e3208396a44c210c5ee42efff539639def59b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:165c7b21d19365464e8f70e5ce5e12524c58b48c78c1f5a57524603c1ab003f8", size = 188890, upload-time = "2026-03-06T06:01:38.73Z" },
+    { url = "https://files.pythonhosted.org/packages/42/1e/02706edf19e390680daa694d17e2b8eab4b5f7ac285e2a51168b4b22ee6b/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:28269983f25a4da0425743d0d257a2d6921ea7d9b83599d4039486ec5b9f911d", size = 206136, upload-time = "2026-03-06T06:01:40.016Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/87/942c3def1b37baf3cf786bad01249190f3ca3d5e63a84f831e704977de1f/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d27ce22ec453564770d29d03a9506d449efbb9fa13c00842262b2f6801c48cce", size = 202551, upload-time = "2026-03-06T06:01:41.522Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0a/af49691938dfe175d71b8a929bd7e4ace2809c0c5134e28bc535660d5262/charset_normalizer-3.4.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0625665e4ebdddb553ab185de5db7054393af8879fb0c87bd5690d14379d6819", size = 195572, upload-time = "2026-03-06T06:01:43.208Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ea/dfb1792a8050a8e694cfbde1570ff97ff74e48afd874152d38163d1df9ae/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:c23eb3263356d94858655b3e63f85ac5d50970c6e8febcdde7830209139cc37d", size = 184438, upload-time = "2026-03-06T06:01:44.755Z" },
+    { url = "https://files.pythonhosted.org/packages/72/12/c281e2067466e3ddd0595bfaea58a6946765ace5c72dfa3edc2f5f118026/charset_normalizer-3.4.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e6302ca4ae283deb0af68d2fbf467474b8b6aedcd3dab4db187e07f94c109763", size = 193035, upload-time = "2026-03-06T06:01:46.051Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4f/3792c056e7708e10464bad0438a44708886fb8f92e3c3d29ec5e2d964d42/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e51ae7d81c825761d941962450f50d041db028b7278e7b08930b4541b3e45cb9", size = 191340, upload-time = "2026-03-06T06:01:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/86/80ddba897127b5c7a9bccc481b0cd36c8fefa485d113262f0fe4332f0bf4/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:597d10dec876923e5c59e48dbd366e852eacb2b806029491d307daea6b917d7c", size = 185464, upload-time = "2026-03-06T06:01:48.764Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/00/b5eff85ba198faacab83e0e4b6f0648155f072278e3b392a82478f8b988b/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5cffde4032a197bd3b42fd0b9509ec60fb70918d6970e4cc773f20fc9180ca67", size = 208014, upload-time = "2026-03-06T06:01:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/d36f70be01597fd30850dde8a1269ebc8efadd23ba5785808454f2389bde/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2da4eedcb6338e2321e831a0165759c0c620e37f8cd044a263ff67493be8ffb3", size = 193297, upload-time = "2026-03-06T06:01:51.933Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1d/259eb0a53d4910536c7c2abb9cb25f4153548efb42800c6a9456764649c0/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:65a126fb4b070d05340a84fc709dd9e7c75d9b063b610ece8a60197a291d0adf", size = 204321, upload-time = "2026-03-06T06:01:53.887Z" },
+    { url = "https://files.pythonhosted.org/packages/84/31/faa6c5b9d3688715e1ed1bb9d124c384fe2fc1633a409e503ffe1c6398c1/charset_normalizer-3.4.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c7a80a9242963416bd81f99349d5f3fce1843c303bd404f204918b6d75a75fd6", size = 197509, upload-time = "2026-03-06T06:01:56.439Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/c7d9dd1503ffc08950b3260f5d39ec2366dd08254f0900ecbcf3a6197c7c/charset_normalizer-3.4.5-cp313-cp313-win32.whl", hash = "sha256:f1d725b754e967e648046f00c4facc42d414840f5ccc670c5670f59f83693e4f", size = 132284, upload-time = "2026-03-06T06:01:57.812Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/0f/57072b253af40c8aa6636e6de7d75985624c1eb392815b2f934199340a89/charset_normalizer-3.4.5-cp313-cp313-win_amd64.whl", hash = "sha256:e37bd100d2c5d3ba35db9c7c5ba5a9228cbcffe5c4778dc824b164e5257813d7", size = 142630, upload-time = "2026-03-06T06:01:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/31/41/1c4b7cc9f13bd9d369ce3bc993e13d374ce25fa38a2663644283ecf422c1/charset_normalizer-3.4.5-cp313-cp313-win_arm64.whl", hash = "sha256:93b3b2cc5cf1b8743660ce77a4f45f3f6d1172068207c1defc779a36eea6bb36", size = 133254, upload-time = "2026-03-06T06:02:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/43/be/0f0fd9bb4a7fa4fb5067fb7d9ac693d4e928d306f80a0d02bde43a7c4aee/charset_normalizer-3.4.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8197abe5ca1ffb7d91e78360f915eef5addff270f8a71c1fc5be24a56f3e4873", size = 280232, upload-time = "2026-03-06T06:02:01.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/02/983b5445e4bef49cd8c9da73a8e029f0825f39b74a06d201bfaa2e55142a/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2aecdb364b8a1802afdc7f9327d55dad5366bc97d8502d0f5854e50712dbc5f", size = 189688, upload-time = "2026-03-06T06:02:02.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/88/152745c5166437687028027dc080e2daed6fe11cfa95a22f4602591c42db/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a66aa5022bf81ab4b1bebfb009db4fd68e0c6d4307a1ce5ef6a26e5878dfc9e4", size = 206833, upload-time = "2026-03-06T06:02:05.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0f/ebc15c8b02af2f19be9678d6eed115feeeccc45ce1f4b098d986c13e8769/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d77f97e515688bd615c1d1f795d540f32542d514242067adcb8ef532504cb9ee", size = 202879, upload-time = "2026-03-06T06:02:06.446Z" },
+    { url = "https://files.pythonhosted.org/packages/38/9c/71336bff6934418dc8d1e8a1644176ac9088068bc571da612767619c97b3/charset_normalizer-3.4.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01a1ed54b953303ca7e310fafe0fe347aab348bd81834a0bcd602eb538f89d66", size = 195764, upload-time = "2026-03-06T06:02:08.763Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/95/ce92fde4f98615661871bc282a856cf9b8a15f686ba0af012984660d480b/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:b2d37d78297b39a9eb9eb92c0f6df98c706467282055419df141389b23f93362", size = 183728, upload-time = "2026-03-06T06:02:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e7/f5b4588d94e747ce45ae680f0f242bc2d98dbd4eccfab73e6160b6893893/charset_normalizer-3.4.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e71bbb595973622b817c042bd943c3f3667e9c9983ce3d205f973f486fec98a7", size = 192937, upload-time = "2026-03-06T06:02:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/29/9d94ed6b929bf9f48bf6ede6e7474576499f07c4c5e878fb186083622716/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4cd966c2559f501c6fd69294d082c2934c8dd4719deb32c22961a5ac6db0df1d", size = 192040, upload-time = "2026-03-06T06:02:13.489Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d2/1a093a1cf827957f9445f2fe7298bcc16f8fc5e05c1ed2ad1af0b239035e/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d5e52d127045d6ae01a1e821acfad2f3a1866c54d0e837828538fabe8d9d1bd6", size = 184107, upload-time = "2026-03-06T06:02:14.83Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/7d/82068ce16bd36135df7b97f6333c5d808b94e01d4599a682e2337ed5fd14/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:30a2b1a48478c3428d047ed9690d57c23038dac838a87ad624c85c0a78ebeb39", size = 208310, upload-time = "2026-03-06T06:02:16.165Z" },
+    { url = "https://files.pythonhosted.org/packages/84/4e/4dfb52307bb6af4a5c9e73e482d171b81d36f522b21ccd28a49656baa680/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:d8ed79b8f6372ca4254955005830fd61c1ccdd8c0fac6603e2c145c61dd95db6", size = 192918, upload-time = "2026-03-06T06:02:18.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a4/159ff7da662cf7201502ca89980b8f06acf3e887b278956646a8aeb178ab/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c5af897b45fa606b12464ccbe0014bbf8c09191e0a66aab6aa9d5cf6e77e0c94", size = 204615, upload-time = "2026-03-06T06:02:19.821Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/62/0dd6172203cb6b429ffffc9935001fde42e5250d57f07b0c28c6046deb6b/charset_normalizer-3.4.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1088345bcc93c58d8d8f3d783eca4a6e7a7752bbff26c3eee7e73c597c191c2e", size = 197784, upload-time = "2026-03-06T06:02:21.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5e/1aab5cb737039b9c59e63627dc8bbc0d02562a14f831cc450e5f91d84ce1/charset_normalizer-3.4.5-cp314-cp314-win32.whl", hash = "sha256:ee57b926940ba00bca7ba7041e665cc956e55ef482f851b9b65acb20d867e7a2", size = 133009, upload-time = "2026-03-06T06:02:23.289Z" },
+    { url = "https://files.pythonhosted.org/packages/40/65/e7c6c77d7aaa4c0d7974f2e403e17f0ed2cb0fc135f77d686b916bf1eead/charset_normalizer-3.4.5-cp314-cp314-win_amd64.whl", hash = "sha256:4481e6da1830c8a1cc0b746b47f603b653dadb690bcd851d039ffaefe70533aa", size = 143511, upload-time = "2026-03-06T06:02:26.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/91/52b0841c71f152f563b8e072896c14e3d83b195c188b338d3cc2e582d1d4/charset_normalizer-3.4.5-cp314-cp314-win_arm64.whl", hash = "sha256:97ab7787092eb9b50fb47fa04f24c75b768a606af1bcba1957f07f128a7219e4", size = 133775, upload-time = "2026-03-06T06:02:27.473Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/60/3a621758945513adfd4db86827a5bafcc615f913dbd0b4c2ed64a65731be/charset_normalizer-3.4.5-py3-none-any.whl", hash = "sha256:9db5e3fcdcee89a78c04dffb3fe33c79f77bd741a624946db2591c81b2fc85b0", size = 55455, upload-time = "2026-03-06T06:03:17.827Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
+]
+
+[[package]]
+name = "entity-resolution-tests"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytest" },
+    { name = "snowflake-connector-python" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "snowflake-connector-python", specifier = ">=3.6" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8b/4c32ecde6bea6486a2a5d05340e695174351ff6b06cf651a74c005f9df00/filelock-3.25.1.tar.gz", hash = "sha256:b9a2e977f794ef94d77cdf7d27129ac648a61f585bff3ca24630c1629f701aa9", size = 40319, upload-time = "2026-03-09T19:38:47.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/b8/2f664b56a3b4b32d28d3d106c71783073f712ba43ff6d34b9ea0ce36dc7b/filelock-3.25.1-py3-none-any.whl", hash = "sha256:18972df45473c4aa2c7921b609ee9ca4925910cc3a0fb226c96b92fc224ef7bf", size = 26720, upload-time = "2026-03-09T19:38:45.718Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/be/97b83a464498a79103036bc74d1038df4a7ef0e402cfaf4d5e113fb14759/pyopenssl-25.3.0.tar.gz", hash = "sha256:c981cb0a3fd84e8602d7afc209522773b94c1c2446a3c710a75b06fe1beae329", size = 184073, upload-time = "2025-09-17T00:32:21.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/81/ef2b1dfd1862567d573a4fdbc9f969067621764fbb74338496840a1d2977/pyopenssl-25.3.0-py3-none-any.whl", hash = "sha256:1fda6fc034d5e3d179d39e59c1895c9faeaf40a79de5fc4cbbfbe0d36f4a77b6", size = 57268, upload-time = "2025-09-17T00:32:19.474Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "snowflake-connector-python"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1crypto" },
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "cryptography" },
+    { name = "filelock" },
+    { name = "idna" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "sortedcontainers" },
+    { name = "tomlkit" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/2f/9b0d1ea2196eeb32e9ac3f9cdf0cfc516ad3788333a75f197c3f55888f70/snowflake_connector_python-4.3.0.tar.gz", hash = "sha256:79f150297b39cfd2481b732554fc4d68b43c83c82eb01e670cc4051cffc089d6", size = 922395, upload-time = "2026-02-12T10:42:31.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/ea/d4206836b28ff74ad836414b811942c5bf2c70d3aec2f8985e4ea1890d50/snowflake_connector_python-4.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:762ffa9673465ccc630aba438d648e0b1a2452ba49669a54a60d1625f36898f3", size = 11916055, upload-time = "2026-02-12T10:42:39.327Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/55/b29070a5b2ec2f7bbb0051a724e5e6c8ba91a2da0086bd691b419d28c1f6/snowflake_connector_python-4.3.0-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:3e2ce47485862fa14ffbf2732f0fd02aa69a7c68a50d5f6286f34ed17527cf87", size = 11928750, upload-time = "2026-02-12T10:42:42.11Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/48/b1e2d99b1dbb6698cb88385e800b43e30c575bcf5450810803526857b204/snowflake_connector_python-4.3.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c6fa80373b82125552e691f47b603766ed783f3d90a5782564854aa224aee9d1", size = 2811711, upload-time = "2026-02-12T10:42:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/51/a1b293fba2d63794283f487173a0c0d3b209464b915427a88d0cfa2408c2/snowflake_connector_python-4.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:676b56eedcc268b7e25a447e736eb8bf8bcacfbc71196c94d6f45746672ee6d5", size = 2841077, upload-time = "2026-02-12T10:42:18.461Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bf/48a0fdb8378e8bcf5448d6c07c495d2b76faa6b910ebcbcf57ffe7e56a0e/snowflake_connector_python-4.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:55163c5d9b93e10d7217aabd56f776b16c0fe13774f8d5db9188824731da9586", size = 12067474, upload-time = "2026-02-12T10:43:04.462Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b0/a23284f8c2ae977251071737287d7648fee4ef08de386f37eb6e971e8609/snowflake_connector_python-4.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c18b5021ffa6de8313f2c7f0ae6050c36bcee7cb33bb23d40a7fdf3e0a751f2", size = 11915171, upload-time = "2026-02-12T10:42:44.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e7/2f91baf604acc4eb7795d7a25b4d414b81a82561dfac2d39c5e103da2947/snowflake_connector_python-4.3.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:9faa9280e41258fb479ec5395b6a17d3dbb316146832e436aed582b300de655e", size = 11926986, upload-time = "2026-02-12T10:42:47.455Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/0b/09342214ec888192f9e7305d0a2d438531613f2a32ff5c2155e1e1964371/snowflake_connector_python-4.3.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca9d22c61f4e3d171b0adad3e9211747917c3a978dfb99564307c1ceadb0f0cd", size = 2867063, upload-time = "2026-02-12T10:42:20.261Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/74/a1a2bd427394214bd7752e72fde257495a18d87d3457343ece9fee00e386/snowflake_connector_python-4.3.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ac18b37e03a29014a9c91aac10c7dbdfa11134c620c6f93dd16f4b99b6a38c2a", size = 2899440, upload-time = "2026-02-12T10:42:22.424Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5a/eda0e80c8cbbef24cfc4aa68587674d8ac0f15fded14e5abc296b8568005/snowflake_connector_python-4.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:726435b2769135b6282601efb2cd8fd53f7deb1ff2fb7da93d28141fa3c8b17e", size = 12066477, upload-time = "2026-02-12T10:43:06.48Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/7a/eda732425c713e07d7327f0c98473615814365e1a75c8d67c31c43ed2fa9/snowflake_connector_python-4.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e42dd9af46fa3ad0e61c1aa6a227357cace481916797ecb92dbb14adb61931e1", size = 11916032, upload-time = "2026-02-12T10:42:49.957Z" },
+    { url = "https://files.pythonhosted.org/packages/92/40/9ba14e500d1d92f12f0dac8d5b975606f0f15bee69c4ceadba64a8853b16/snowflake_connector_python-4.3.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:e96aaf23f2b021e0d2aac8ac1b541975cd1f6896d9115eefe0938114e694a562", size = 11927984, upload-time = "2026-02-12T10:42:52.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/be/25125ba4b4a1bb211ad8eadff233549cd9a5152c77d92586cd5693ee608f/snowflake_connector_python-4.3.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2e0f66acee330388815fb842f91a46c9cacdefdf02c816354e6adeca8c2c3f86", size = 2832570, upload-time = "2026-02-12T10:42:25.348Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c1/19144f2e590d55bce17e089017b5dca71fad46a2a0ddb7b1a69a4c91c5c9/snowflake_connector_python-4.3.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5a8d91c3e0127360bc3de605df9d02ea4d87e4524a50bf2e7c5c4200f9abf78", size = 2866972, upload-time = "2026-02-12T10:42:26.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/28/8f4854bcf267f69387ea785758b3cc5fac1a13452359c234f2fc81eb8ffd/snowflake_connector_python-4.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:c1356a2c615e120f913e5235fe87ff8aadbb479ad5a5ac5c0a84881d5fbe981d", size = 12066562, upload-time = "2026-02-12T10:43:08.846Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary

Promotes the `entity-resolution` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
