### PR TITLE
Promote dynamic-tables-guidance from Snowflake-Solutions

### DIFF
--- a/skills/dynamic-tables-guidance/LICENSE
+++ b/skills/dynamic-tables-guidance/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/dynamic-tables-guidance/SKILL.md
+++ b/skills/dynamic-tables-guidance/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: dynamic-tables-guidance
+title: Dynamic Tables Guidance
+summary: Decide when to use Dynamic Tables vs MVs, streams+tasks, or dbt, and design production-ready DT pipelines.
+description: "Use when choosing between Dynamic Tables and alternatives (materialized views, streams+tasks, dbt), designing multi-layer DT pipelines, debugging FULL-refresh fallback, or hardening DTs for production. Covers comparison matrices, decision flowcharts, common pitfalls, monitoring queries, and hybrid DT+task patterns. Triggers: dynamic tables guidance, when to use DT, DT vs MV, DT vs streams tasks, DT vs dbt, DT pitfalls, DT best practices, DT pipeline design, target lag, downstream lag, full refresh fallback."
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+prompt: Should I use Dynamic Tables or streams+tasks for my CDC pipeline?
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+# Dynamic Tables Guidance
+
+## Overview
+
+Dynamic Tables (DTs) are declarative, auto-refreshing materialized queries. You write a `SELECT`, set a `TARGET_LAG`, and Snowflake keeps results fresh on the schedule you pick. This skill helps you decide when DTs are the right tool, design multi-layer pipelines, and avoid the failure modes that catch real teams in production.
+
+Use this skill when picking between DTs, materialized views, streams+tasks, or dbt — or when an existing DT pipeline is misbehaving (full-refresh fallback, lag drift, runaway cost).
+
+## Quick Decision Flowchart
+
+```
+Need to transform data in Snowflake?
+  ├─ Single table, accelerate queries?           → Materialized View
+  ├─ Multi-step SQL pipeline, fresh data?        → Dynamic Tables
+  ├─ Stream-static joins / append-only?          → Custom Incremental DTs (PrPr)
+  ├─ Cross-warehouse portability or dbt tests?   → dbt models
+  ├─ Procedural logic, IF/ELSE, API calls?       → Streams + Tasks
+  └─ Sub-15-second latency?                      → Streams + Tasks
+```
+
+## Comparison Matrix
+
+| Dimension | Dynamic Tables | Materialized Views | Streams + Tasks | dbt |
+|---|---|---|---|---|
+| Refresh | Target lag (15s+) | Auto, near-real-time | Manual schedule/trigger | Batch (`dbt run`) |
+| SQL support | Full SELECT, JOINs, windows | Single table only | Full + procedural | Full + Jinja |
+| Chaining | `TARGET_LAG = DOWNSTREAM` | No | Manual DAG | Ref graph |
+| Incremental | Built-in for supported ops | Auto | You write it | Manual `is_incremental` |
+| Side effects | None | None | Email, API, externals | None |
+| Cost | Your warehouse | Serverless | Your warehouse | Your warehouse |
+
+**Rule of thumb:** Start with DTs. Reach for streams+tasks only when you need procedural logic, side effects, or sub-15s latency. Use dbt when you need its testing framework or cross-warehouse portability.
+
+## Pipeline Pattern: Bronze → Silver → Gold
+
+```sql
+-- Bronze: parse raw VARIANT
+CREATE DYNAMIC TABLE bronze_events
+  TARGET_LAG = DOWNSTREAM
+  WAREHOUSE = pipeline_wh
+  AS SELECT
+    record_content:event_id::STRING AS event_id,
+    record_content:event_type::STRING AS event_type,
+    record_content:timestamp::TIMESTAMP_NTZ AS event_ts
+  FROM raw_events_topic;
+
+-- Silver: business logic + joins
+CREATE DYNAMIC TABLE silver_purchases
+  TARGET_LAG = DOWNSTREAM
+  WAREHOUSE = pipeline_wh
+  AS SELECT e.event_id, e.event_ts, p.product_name, p.category
+     FROM bronze_events e
+     JOIN products p ON e.payload:product_id::STRING = p.product_id
+     WHERE e.event_type = 'purchase';
+
+-- Gold: only the leaf has a time-based lag
+CREATE DYNAMIC TABLE gold_hourly_sales
+  TARGET_LAG = '5 minutes'
+  WAREHOUSE = pipeline_wh
+  AS SELECT DATE_TRUNC('hour', event_ts) AS sales_hour, category,
+            COUNT(*) AS order_count
+     FROM silver_purchases
+     GROUP BY 1, 2;
+```
+
+**Key rule:** Only the leaf DT has a time-based `TARGET_LAG`. Intermediates use `DOWNSTREAM` so Snowflake derives their lag from the leaf.
+
+## Monitoring Essentials
+
+```sql
+-- Health check
+SELECT name, scheduling_state, last_completed_refresh_state,
+       refresh_mode, time_within_target_lag_ratio
+FROM TABLE(INFORMATION_SCHEMA.DYNAMIC_TABLES())
+ORDER BY time_within_target_lag_ratio ASC;
+
+-- Recent refresh history
+SELECT name, state, refresh_action,
+       DATEDIFF('second', refresh_start_time, refresh_end_time) AS duration_sec
+FROM TABLE(INFORMATION_SCHEMA.DYNAMIC_TABLE_REFRESH_HISTORY(
+  NAME_PREFIX => '<db>.<schema>'))
+ORDER BY refresh_start_time DESC LIMIT 20;
+
+-- Errors only
+SELECT name, state, state_message
+FROM TABLE(INFORMATION_SCHEMA.DYNAMIC_TABLE_REFRESH_HISTORY(
+  NAME_PREFIX => '<db>.<schema>', ERROR_ONLY => TRUE));
+```
+
+For account-wide DT cost, query `SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY` filtered to refresh queries.
+
+## Common Mistakes
+
+- **`SELECT *` in DT definition** — breaks incremental refresh on schema changes. Always use explicit column lists.
+- **Time-based lag on every layer** — only the leaf should have a time-based lag. Use `TARGET_LAG = DOWNSTREAM` on intermediates.
+- **Change tracking off on base tables** — DTs require `CHANGE_TRACKING = TRUE` for incremental refresh. Check with `SHOW TABLES`.
+- **Falling back to FULL refresh silently** — check `refresh_mode_reason` if `refresh_mode` shows `FULL` when you expected `INCREMENTAL`.
+- **Missing PRIMARY KEY RELY** — without it, `INSERT OVERWRITE` reprocesses everything downstream and you lose incremental chains.
+- **DISTINCT/UNION fanout** — these operators force full refresh. Refactor with `QUALIFY ROW_NUMBER()` or `UNION ALL` where possible.
+- **Sharing one warehouse with interactive queries** — DT refreshes will compete with user queries. Use a dedicated warehouse.
+- **No `INITIALIZATION_WAREHOUSE` for big initial loads** — first refresh on large DTs can OOM a small warehouse. Set a larger init WH, then unset.
+
+## Production Readiness Checklist
+
+- [ ] Explicit column lists (no `SELECT *`)
+- [ ] `CHANGE_TRACKING = TRUE` on all base tables
+- [ ] Intermediates use `TARGET_LAG = DOWNSTREAM`
+- [ ] Leaf target lag ≥ all upstream lags
+- [ ] `refresh_mode` is `INCREMENTAL` (verify `refresh_mode_reason`)
+- [ ] Dedicated warehouse for DT refreshes
+- [ ] Monitoring on `time_within_target_lag_ratio > 0.95`
+- [ ] Alerting on refresh failures
+- [ ] `INITIALIZATION_WAREHOUSE` set for large initial loads
+
+## Hybrid Pattern: DT + Task for Side Effects
+
+```sql
+CREATE STREAM gold_metrics_stream ON DYNAMIC TABLE gold_metrics;
+
+CREATE TASK notify_on_refresh
+  WAREHOUSE = ops_wh
+  WHEN SYSTEM$STREAM_HAS_DATA('gold_metrics_stream')
+AS
+BEGIN
+  LET change_count INT := (SELECT COUNT(*) FROM gold_metrics_stream);
+  CALL SYSTEM$SEND_EMAIL('team@co.com', 'Metrics Updated',
+    change_count || ' rows changed');
+  CREATE OR REPLACE TEMP TABLE _consume AS SELECT * FROM gold_metrics_stream;
+END;
+```
+
+## Workflow
+
+1. **Assess fit** — run the decision flowchart. If DTs aren't the right tool, stop here.
+2. **Pick refresh mode** — `AUTO` (default), `INCREMENTAL` (force, fail if ineligible), `FULL`, or `CUSTOM_INCREMENTAL` (PrPr).
+3. **Design layers** — Bronze→Silver→Gold with `DOWNSTREAM` on intermediates.
+4. **Harden** — apply the production checklist.
+
+⚠️ STOPPING POINT: Before running `CREATE OR REPLACE DYNAMIC TABLE` against existing pipelines, show the user the planned DDL and confirm. Replacing a DT triggers a full reload and may invalidate downstream incremental chains.
+
+⚠️ STOPPING POINT: Before applying `ALTER DYNAMIC TABLE ... SUSPEND` or `DROP DYNAMIC TABLE`, confirm with the user — downstream DTs depending on the target will stop refreshing.
+
+## Stopping Points
+
+- Workflow Step 4 — confirm DDL before `CREATE OR REPLACE DYNAMIC TABLE` on existing pipelines
+- Workflow Step 4 — confirm before `ALTER ... SUSPEND` or `DROP DYNAMIC TABLE`
+
+## References
+
+- `references/pitfalls-and-pks.md` — full pitfall deep-dive plus `PRIMARY KEY RELY`, `IMMUTABLE WHERE`, `BACKFILL FROM`
+- `references/custom-incremental.md` — Custom Incremental DTs (PrPr) syntax and patterns
+- `references/dcm-for-dts.md` — Database Change Management for git-native DT deployment
+- Built-in Cortex Code skill: `dynamic-tables`

--- a/skills/dynamic-tables-guidance/references/custom-incremental.md
+++ b/skills/dynamic-tables-guidance/references/custom-incremental.md
@@ -1,0 +1,176 @@
+# Custom Incremental Dynamic Tables (Private Preview)
+
+Custom incremental DTs let you define refresh logic using **imperative DML** (MERGE or INSERT INTO) instead of a declarative SELECT. This unlocks patterns that standard DTs can't express efficiently.
+
+**When to use:** Standard DTs should always be your first choice. Use custom incremental only when:
+- You need **stream-static joins** (fact stream + dimension snapshot)
+- You need **append-only pipelines** (only process inserts, ignore updates/deletes)
+- You need **user-defined semantics** (audit deletes, soft-delete, running aggregates)
+
+## Syntax
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE my_dt (
+  col1 TYPE, col2 TYPE  -- explicit columns required
+)
+  TARGET_LAG = '5 minutes'
+  WAREHOUSE = my_wh
+  REFRESH_MODE = CUSTOM_INCREMENTAL
+  [ BACKFILL FROM existing_table ]
+  REFRESH USING (
+    -- MERGE INTO SELF or INSERT INTO SELF
+  );
+```
+
+Key concepts:
+- `SELF` references the DT being created (you cannot use the DT's name)
+- `CHANGES(INFORMATION => { DEFAULT | APPEND_ONLY })` consumes changes since last refresh
+- Tables outside `CHANGES()` are read as static snapshots at refresh time
+- Explicit column schema is required (no `AS SELECT` inference)
+
+## Pattern: Stream-Static Join (Append-Only)
+
+Enrich new events with current dimension data. Only new events are processed — dimension changes don't trigger reprocessing.
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE enriched_clicks (
+  click_id INT, user_id INT, page_title STRING,
+  section STRING, click_ts TIMESTAMP
+)
+  TARGET_LAG = DOWNSTREAM
+  WAREHOUSE = my_wh
+  REFRESH USING (
+    INSERT INTO SELF
+    SELECT c.click_id, c.user_id, p.page_title, p.section, c.click_ts
+    FROM clicks CHANGES(INFORMATION => APPEND_ONLY) AS c
+    LEFT OUTER JOIN pages AS p ON c.page_id = p.page_id
+  );
+```
+
+## Pattern: Stream-Static Join (MERGE with Updates/Deletes)
+
+When the fact table has updates and deletes, use MERGE with `ROW_NUMBER()` dedup:
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE enriched_inventory (
+  sku_id INT, product_name STRING, category STRING,
+  warehouse_name STRING, region STRING, qty_on_hand INT
+)
+  TARGET_LAG = DOWNSTREAM
+  WAREHOUSE = my_wh
+  REFRESH USING (
+    MERGE INTO SELF AS tgt
+    USING (
+      SELECT sku_id, product_name, category, warehouse_name, region,
+             qty_on_hand, action
+      FROM (
+        SELECT s.sku_id, p.product_name, p.category,
+               w.warehouse_name, w.region, s.qty_on_hand,
+               s.METADATA$ACTION AS action,
+               ROW_NUMBER() OVER (
+                 PARTITION BY s.sku_id
+                 ORDER BY CASE s.METADATA$ACTION WHEN 'INSERT' THEN 0 ELSE 1 END
+               ) AS rn
+        FROM stock CHANGES(INFORMATION => DEFAULT) AS s
+        LEFT OUTER JOIN products AS p ON s.product_id = p.product_id
+        LEFT OUTER JOIN warehouses AS w ON s.warehouse_id = w.warehouse_id
+      )
+      WHERE rn = 1
+    ) AS src
+    ON tgt.sku_id = src.sku_id
+    WHEN MATCHED AND src.action = 'DELETE' THEN DELETE
+    WHEN MATCHED AND src.action = 'INSERT' THEN
+      UPDATE SET tgt.product_name = src.product_name,
+                 tgt.category = src.category,
+                 tgt.warehouse_name = src.warehouse_name,
+                 tgt.region = src.region,
+                 tgt.qty_on_hand = src.qty_on_hand
+    WHEN NOT MATCHED AND src.action = 'INSERT' THEN
+      INSERT (sku_id, product_name, category, warehouse_name, region, qty_on_hand)
+      VALUES (src.sku_id, src.product_name, src.category, src.warehouse_name,
+              src.region, src.qty_on_hand)
+  );
+```
+
+## Example: Stream-Static Join End-to-End
+
+A complete walkthrough showing how a stream-static join works in practice. Scenario: an IoT pipeline where sensor readings (high-volume, append-only) are enriched with device metadata (low-volume, rarely changes).
+
+```sql
+-- 1. Setup: fact table (append-only sensor readings) + dimension table (device registry)
+CREATE TABLE sensor_readings (
+  reading_id INT AUTOINCREMENT,
+  device_id INT,
+  temperature FLOAT,
+  humidity FLOAT,
+  reading_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP()
+);
+ALTER TABLE sensor_readings SET CHANGE_TRACKING = TRUE;
+
+CREATE TABLE devices (
+  device_id INT PRIMARY KEY,
+  device_name STRING,
+  location STRING,
+  floor INT
+);
+
+-- 2. Custom incremental DT: enrich readings with device info
+--    - sensor_readings is the STREAM side (CHANGES => APPEND_ONLY)
+--    - devices is the STATIC side (read in full at each refresh, changes ignored)
+CREATE OR REPLACE DYNAMIC TABLE enriched_readings (
+  reading_id INT,
+  device_id INT,
+  device_name STRING,
+  location STRING,
+  floor INT,
+  temperature FLOAT,
+  humidity FLOAT,
+  reading_ts TIMESTAMP
+)
+  TARGET_LAG = '1 minute'
+  WAREHOUSE = iot_wh
+  REFRESH USING (
+    INSERT INTO SELF
+    SELECT
+      r.reading_id, r.device_id,
+      d.device_name, d.location, d.floor,
+      r.temperature, r.humidity, r.reading_ts
+    FROM sensor_readings CHANGES(INFORMATION => APPEND_ONLY) AS r
+    LEFT OUTER JOIN devices AS d ON r.device_id = d.device_id
+  );
+```
+
+**What happens at each refresh:**
+1. `CHANGES(APPEND_ONLY)` returns only new sensor readings since last refresh
+2. Each new reading is joined to the **current** device metadata (static snapshot)
+3. Results are appended to the DT — previously enriched rows are never touched
+4. If a device name changes in `devices`, old readings keep the old name — only new readings pick up the update
+
+**Why this matters:** A standard DT would reprocess ALL readings whenever a device name changes (since it depends on `devices`). The custom incremental version only processes new readings, making it orders of magnitude cheaper for high-volume fact tables with slowly-changing dimensions.
+
+---
+
+## Pattern: Audit Deletes Log
+
+Append-only log of every deletion from a source table:
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE deletions_log (id INT, name STRING, email STRING)
+  TARGET_LAG = DOWNSTREAM
+  WAREHOUSE = my_wh
+  INITIALIZE = ON_SCHEDULE
+  REFRESH USING (
+    INSERT INTO SELF
+    SELECT * EXCLUDE (METADATA$ISUPDATE, METADATA$ACTION)
+    FROM users CHANGES(INFORMATION => DEFAULT)
+    WHERE NOT METADATA$ISUPDATE AND METADATA$ACTION = 'DELETE'
+  );
+```
+
+## Limitations (PrPr)
+
+- No cloning or replication
+- No DCM/dbt integration yet
+- No data governance policies on custom incremental DTs
+- No CREATE OR ALTER — must use CREATE OR REPLACE
+- Correctness is the user's responsibility (not delayed-view semantics)

--- a/skills/dynamic-tables-guidance/references/dcm-for-dts.md
+++ b/skills/dynamic-tables-guidance/references/dcm-for-dts.md
@@ -1,0 +1,70 @@
+# DCM for Dynamic Tables
+
+DCM (Database Change Management) provides **git-native infrastructure-as-code** for DT pipelines. Define your DTs declaratively, version them in git, and deploy with `snow dcm plan` → `snow dcm deploy`.
+
+## Why DCM for DTs
+
+- **Version controlled** — DT definitions live in git alongside your other infrastructure
+- **Repeatable deployments** — same definitions deploy to dev/staging/prod via templating
+- **Schema evolution** — change a DT definition, redeploy, DCM handles the diff
+- **Full pipeline IaC** — database, schema, warehouses, tables, DTs, roles, and grants in one project
+
+## DCM DT Syntax (DEFINE)
+
+```sql
+DEFINE DYNAMIC TABLE {{ database }}.{{ schema }}.BRONZE_EVENTS
+TARGET_LAG = DOWNSTREAM
+WAREHOUSE = {{ database }}_DT_WH
+AS
+  SELECT
+    record_content:event_id::STRING AS event_id,
+    record_content:event_type::STRING AS event_type,
+    record_content:user_id::STRING AS user_id,
+    record_content:timestamp::TIMESTAMP_NTZ AS event_ts,
+    record_content:payload AS payload
+  FROM {{ database }}.{{ schema }}.RAW_EVENTS_TOPIC;
+
+DEFINE DYNAMIC TABLE {{ database }}.{{ schema }}.GOLD_HOURLY_SALES
+TARGET_LAG = '5 minutes'
+WAREHOUSE = {{ database }}_DT_WH
+AS
+  SELECT
+    DATE_TRUNC('hour', event_ts) AS sales_hour,
+    category,
+    COUNT(DISTINCT event_id) AS order_count,
+    SUM(line_total) AS revenue
+  FROM {{ database }}.{{ schema }}.SILVER_PURCHASES
+  GROUP BY 1, 2;
+```
+
+## DCM Manifest (manifest.yml)
+
+```yaml
+manifest_version: 2
+type: DCM_PROJECT
+default_target: 'DEV'
+targets:
+  DEV:
+    project_name: '{{DATABASE}}.{{SCHEMA}}.MY_PROJECT'
+    project_owner: SYSADMIN
+    templating_config: 'DEV'
+templating:
+  defaults:
+    database: 'MY_DB'
+    schema: 'PUBLIC'
+  configurations:
+    DEV:
+      database: 'MY_DB_DEV'
+    PROD:
+      database: 'MY_DB_PROD'
+```
+
+## DCM Workflow
+
+```bash
+snow dcm raw-analyze dcm/ -c <connection>
+snow dcm plan dcm/ -c <connection> --save-output
+snow dcm deploy dcm/ -c <connection> --alias "v1-initial"
+```
+
+**Tip:** Put all DT definitions in a single `dynamic_tables.sql` file within `dcm/definitions/`. DCM processes all `.sql` files in that directory. Use Jinja templating (`{{ database }}`, `{{ schema }}`) for environment portability.

--- a/skills/dynamic-tables-guidance/references/pitfalls-and-pks.md
+++ b/skills/dynamic-tables-guidance/references/pitfalls-and-pks.md
@@ -1,0 +1,234 @@
+# Common Pitfalls, Primary Keys, Immutability & Backfill
+
+## Common Pitfalls and How to Fix Them
+
+### Pitfall 1: FULL Refresh When You Expected INCREMENTAL
+
+**Symptom:** `refresh_mode = FULL` and `refresh_mode_reason = QUERY_NOT_SUPPORTED_FOR_INCREMENTAL`
+
+**Common causes and fixes:**
+
+| Cause | Fix |
+|-------|-----|
+| `UNION DISTINCT` | Use `UNION ALL` + `QUALIFY ROW_NUMBER() = 1` for dedup |
+| `EXCEPT` / `INTERSECT` | Rewrite as `LEFT JOIN ... WHERE b.id IS NULL` (anti-join) |
+| `CURRENT_TIMESTAMP()` in SELECT list | Move to WHERE clause, or use `METADATA$ROW_LAST_COMMIT_TIME` |
+| Self outer join (same table on both sides) | Break into intermediate DT |
+| Outer join with GROUP BY subqueries on both sides | Materialize aggregations as separate DTs |
+| Non-deterministic functions (`RANDOM()`, `UUID_STRING()`) | Move to application layer |
+
+**Diagnostic:**
+```sql
+SHOW DYNAMIC TABLES LIKE '<dt_name>' IN SCHEMA <db>.<schema>;
+-- Check: refresh_mode, refresh_mode_reason
+```
+
+**Key insight:** When AUTO chooses FULL, try explicit `REFRESH_MODE = INCREMENTAL` first — it often works for window functions and other "Limited" operators.
+
+### Pitfall 2: SELECT * Breaks on Schema Changes
+
+**Symptom:** DT refresh fails after a column is added/removed from the source table.
+
+**Fix:** Always use explicit column lists.
+
+```sql
+-- BAD
+CREATE DYNAMIC TABLE my_dt AS SELECT * FROM source_table;
+
+-- GOOD
+CREATE DYNAMIC TABLE my_dt AS SELECT id, name, amount, created_at FROM source_table;
+```
+
+### Pitfall 3: Change Tracking Not Enabled
+
+**Symptom:** `CHANGE_TRACKING_NOT_ENABLED` in refresh_mode_reason, or DT creation fails.
+
+**Fix:**
+```sql
+ALTER TABLE source_table SET CHANGE_TRACKING = TRUE;
+
+-- Verify
+SELECT table_name, change_tracking
+FROM information_schema.tables
+WHERE table_schema = 'MY_SCHEMA' AND table_name = 'SOURCE_TABLE';
+```
+
+DTs auto-enable change tracking on their sources at creation time, but if it's explicitly disabled afterward, refreshes break.
+
+### Pitfall 4: Target Lag Shorter Than Upstream
+
+**Symptom:** Downstream DT can never meet its target lag.
+
+```sql
+-- WRONG: child asks for 1 min but parent delivers every 10 min
+CREATE DYNAMIC TABLE parent TARGET_LAG = '10 minutes' AS ...;
+CREATE DYNAMIC TABLE child  TARGET_LAG = '1 minute' AS SELECT * FROM parent;
+```
+
+**Fix:** Child target lag must be ≥ parent target lag. Use `DOWNSTREAM` for intermediates.
+
+### Pitfall 5: Monolithic DT That's Slow and Expensive
+
+**Symptom:** Single DT with 5+ JOINs, refresh takes >50% of target lag, disk spill.
+
+**Fix: Decompose.** Break into intermediate DTs:
+
+```
+BEFORE: SourceA + SourceB + SourceC → [Complex 5-JOIN query] → final_dt
+
+AFTER:
+SourceA + SourceB → intermediate_1 (TARGET_LAG = DOWNSTREAM, INCREMENTAL)
+                          ↓
+intermediate_1 + SourceC → final_dt (TARGET_LAG = '5 minutes', INCREMENTAL)
+```
+
+Intermediates use `TARGET_LAG = DOWNSTREAM` so they only refresh when the final DT needs fresh data.
+
+### Pitfall 6: Incremental DT Depends on Full-Refresh DT
+
+**Symptom:** Creation fails or unexpected FULL refreshes propagate.
+
+**Rule:** An incremental DT cannot have a FULL-refresh DT as an upstream dependency — unless the upstream has a **primary key** (declared or derived). With a PK, Snowflake can diff the FULL refresh output and pass only actual changes downstream. See the [Primary Keys](#primary-keys-rely--the-smallest-change-with-the-biggest-impact) section below.
+
+Without a PK, fix the upstream DT first, or accept FULL on the downstream.
+
+### Pitfall 7: DISTINCT-Masked Join Fanout in Migrations
+
+**Symptom:** Converting a `SELECT DISTINCT ... FROM a JOIN b` query to a DT produces 10x the expected rows.
+
+**Root cause:** The original query used `DISTINCT` to mask a many-to-many join. Removing DISTINCT (or not having it in a DT) exposes the fanout.
+
+**Fix:** Check join key uniqueness BEFORE creating the DT. Replace DISTINCT with `GROUP BY` on the intended grain:
+```sql
+-- WRONG: naive migration
+CREATE DYNAMIC TABLE my_dt AS
+SELECT a.*, b.lookup_col FROM facts a JOIN lookup b ON a.key = b.key;
+-- ↑ Fanout: lookup has duplicate keys
+
+-- RIGHT: explicit grain
+CREATE DYNAMIC TABLE my_dt AS
+SELECT a.key, a.data_col, MAX(b.lookup_col) AS lookup_col
+FROM facts a JOIN lookup b ON a.key = b.key
+GROUP BY a.key, a.data_col;
+```
+
+### Pitfall 8: Immutability Misuse
+
+`IMMUTABLE WHERE` logically partitions a DT into an **immutable region** (rows matching the predicate are frozen — never recomputed) and a **mutable region** (rows that don't match continue refreshing normally). This is powerful for audit trails, cost optimization, and data lifecycle management.
+
+**Restrictions** (designed so the immutable boundary is deterministic and can only grow):
+- No subqueries
+- No UDFs or external functions
+- No non-deterministic functions (except timestamp functions used in a monotonically-growing pattern)
+- No `METADATA$` column references
+- No aggregate/window function columns in the predicate
+
+```sql
+-- GOOD: timestamp-based immutability (region only grows)
+CREATE DYNAMIC TABLE my_dt
+  IMMUTABLE WHERE (event_time < CURRENT_TIMESTAMP() - INTERVAL '7 days')
+  TARGET_LAG = '5 minutes'
+  WAREHOUSE = my_wh
+  AS SELECT * FROM events;
+
+-- GOOD: status-based immutability (order tracking audit trail)
+CREATE DYNAMIC TABLE shipped_orders_log
+  TARGET_LAG = '1 minute'
+  WAREHOUSE = my_wh
+  IMMUTABLE WHERE (status = 'SHIPPED')
+  AS SELECT order_id, status, amount, last_updated FROM orders;
+-- Once an order ships, the row is frozen — even if someone updates the source.
+-- Query METADATA$IS_IMMUTABLE to verify which rows are locked.
+
+-- BAD: subquery
+CREATE DYNAMIC TABLE my_dt
+  IMMUTABLE WHERE (id IN (SELECT id FROM archived)) -- ERROR
+  ...
+```
+
+**Real-world use cases for IMMUTABLE WHERE:**
+- **Audit trail protection**: Lock shipped/completed orders so source corrections can't corrupt history
+- **Data deletion resilience**: Freeze historical data before purging base tables for compliance — downstream DTs retain the locked rows
+- **Schema evolution**: Lock old data when adding new columns — only future records get refreshed with the new schema
+- **Dimension change isolation**: Freeze historical aggregates so dimension table updates don't trigger reprocessing old fact records
+
+---
+
+## BACKFILL FROM: Migrate Without Reprocessing History
+
+`BACKFILL FROM` seeds a new DT with data from an existing table, eliminating the need to recompute all historical data on first refresh.
+
+```sql
+CREATE OR REPLACE DYNAMIC TABLE regional_sales_summary
+  IMMUTABLE WHERE (sale_date < '2024-01-01')
+  TARGET_LAG = '60 seconds'
+  WAREHOUSE = my_wh
+  BACKFILL FROM historical_sales
+  AS
+    SELECT sale_id, product_name, sale_amount, DATE(sale_timestamp) AS sale_date
+    FROM enriched_sales
+    WHERE country IN ('US', 'CA');
+```
+
+**Key rules:**
+- Clustering keys must be identical between the new DT and the backfill table
+- Only data matching the `IMMUTABLE WHERE` constraint can be backfilled
+- Without `BACKFILL FROM`, the first refresh runs the `REFRESH USING` query against the entire source
+
+**Use cases:**
+- Migrating legacy pipelines to DTs without reprocessing years of history
+- Splitting or restructuring DTs while preserving data
+- Seeding with pre-computed historical aggregates
+
+---
+
+## Primary Keys (RELY) — The Smallest Change with the Biggest Impact
+
+Adding `PRIMARY KEY RELY` to base tables unlocks two critical DT optimizations:
+
+**Problem 1: INSERT OVERWRITE resets change tracking.** Many ELT patterns use `INSERT OVERWRITE` to reload dimension tables. This resets Snowflake's change-tracking columns — every row looks "new", and your incremental DT reprocesses everything.
+
+**Problem 2: FULL refresh propagates downstream.** If a DT uses FULL refresh (e.g., float aggregation with JOINs), every downstream DT is also forced to FULL.
+
+**The fix — one line of DDL:**
+
+```sql
+ALTER TABLE dimension_products ADD PRIMARY KEY (product_id) RELY;
+```
+
+`RELY` tells Snowflake: "this key is unique and stable — use it for change detection." Instead of comparing change-tracking columns, Snowflake compares rows by primary key values. Only rows that actually changed get processed.
+
+**Real numbers (INSERT OVERWRITE scenario):**
+- Without PK: `{"insertedRows": 100, "copiedRows": 0, "deletedRows": 100}` — reprocessed everything
+- With PK RELY: `{"insertedRows": 2, "copiedRows": 98, "deletedRows": 2}` — only changed rows
+
+**Derived keys — Snowflake reads your SQL:**
+- `GROUP BY` columns automatically become derived unique keys
+- `QUALIFY ROW_NUMBER() OVER (PARTITION BY ...) = 1` — partition columns become derived keys
+- Check with: `SHOW UNIQUE KEYS IN my_dynamic_table` — look for `SYS_CONSTRAINT_DERIVED_PK`
+
+**Incremental after FULL (the chain reaction fix):**
+
+```sql
+CREATE DYNAMIC TABLE sales_summary
+  TARGET_LAG = '1 minute'
+  WAREHOUSE = my_wh
+  REFRESH_MODE = AUTO  -- resolves to FULL (float aggregation + joins)
+  AS
+    SELECT region_name, channel_name, COUNT(*) AS sale_count, SUM(amount) AS total
+    FROM fact_sales f
+    LEFT JOIN dim_region r ON f.region_id = r.region_id
+    GROUP BY region_name, channel_name;
+-- Snowflake auto-derives PK on (region_name, channel_name) from the GROUP BY
+
+CREATE DYNAMIC TABLE regional_trends
+  TARGET_LAG = '1 minute'
+  WAREHOUSE = my_wh
+  REFRESH_MODE = INCREMENTAL  -- works because parent has derived PK
+  AS
+    SELECT region_name, SUM(sale_count) AS total_sales, SUM(total) AS total_revenue
+    FROM sales_summary
+    GROUP BY region_name;
+```
+
+**Important:** Adding a PK to a base table does NOT retroactively update existing downstream DTs. You must `CREATE OR REPLACE` downstream DTs for the key to take effect. When switching from FULL to INCREMENTAL, you must explicitly set `REFRESH_MODE = INCREMENTAL` — `AUTO` will still resolve to FULL.


### PR DESCRIPTION
## Summary

Promotes the `dynamic-tables-guidance` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
