### PR TITLE
Promote snowpipe-bcdr from Snowflake-Solutions

### DIFF
--- a/skills/snowpipe-bcdr/LICENSE
+++ b/skills/snowpipe-bcdr/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/snowpipe-bcdr/SKILL.md
+++ b/skills/snowpipe-bcdr/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: snowpipe-bcdr
+title: Snowpipe BCDR on Azure
+summary: Snowpipe disaster recovery patterns for Azure ADLS Gen2 with failover, failback, and catchup procedures.
+description: "Use when designing or operating Snowpipe disaster recovery on Azure ADLS Gen2 — choosing between dual-pipe, RA-GRS, active-active, or Failover Group patterns, and running failover/failback/catchup. Triggers: snowpipe BCDR, snowpipe disaster recovery, snowpipe failover, dual pipe, active-active pipe, RA-GRS snowpipe, GZRS snowpipe, snowpipe catchup, pipe failback, snowpipe high availability, failover group snowpipe, snowpipe RPO RTO."
+tools:
+  - snowflake_sql_execute
+  - Read
+  - Write
+prompt: Help me design and implement a Snowpipe BCDR pattern on Azure ADLS Gen2 with failover and catchup.
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+# Snowpipe BCDR on Azure
+
+## Overview
+
+This skill helps developers and data engineers design, implement, and operate Snowpipe business continuity / disaster recovery on **Azure ADLS Gen2**. Six patterns are supported — pick one based on your RPO, RTO, edition, and cost tolerance.
+
+| # | Pattern | RPO | RTO | Cost | Complexity |
+|---|---------|-----|-----|------|------------|
+| 1 | Manual Catchup (single pipe) | Min–hrs | 30–90 min | Lowest | Low |
+| 2 | Active-Active + Dedup | Zero | ~1 min | Highest | High |
+| 3 | RA-GRS Read Pattern | Near-zero | 5–15 min | Medium | Medium |
+| 4 | Active-Passive (SF + GRS) | Near-zero | 5–15 min | Medium | Medium |
+| 5 | Snowflake-Only Failover Group | Near-zero | 5–15 min | Low–Med | Low |
+| 6 | Dual Storage, Dual Pipes | Near-zero | 5–10 min | Medium | Medium |
+
+Options 2–6 require **Business Critical Edition** for Failover Groups. On lower editions, only Option 1 applies.
+
+## Decision
+
+```
+Business Critical?
+├── No → Option 1
+└── Yes
+    ├── Zero data loss?           → Option 2
+    ├── Azure is the failure?     → Option 4 or 6
+    ├── Snowflake is the failure? → Option 5
+    ├── Have RA-GRS?              → Option 3
+    └── Budget constrained?       → Option 1 or 5
+```
+
+This skill is **Azure ADLS Gen2 only**. AWS S3 / GCS variants are out of scope.
+
+## Core Rules
+
+1. **Single writer per file set.** Only one pipe active per file set, except Option 2 (which dedups).
+2. **Storage integration must allow both URLs:**
+   ```sql
+   STORAGE_ALLOWED_LOCATIONS = (
+     'azure://<primary>.blob.core.windows.net/<container>/',
+     'azure://<secondary>.blob.core.windows.net/<container>/'
+   );
+   ```
+3. **`COPY_HISTORY` is replicated** in Failover Groups but only retains 14 days. For longer history, maintain a `FILE_LOAD_HISTORY` backup table.
+4. **`ALTER PIPE ... REFRESH` is hard-capped at 7 days.** For older files, use `DIRECTORY(@stage)` + `COPY INTO`.
+5. **Inbound notification integrations (`DIRECTION = INBOUND`) do NOT replicate.** After failover-group promotion you must recreate them with the same name in the DR account, re-establish Service Principal trust, and create the DR-region Event Grid subscription.
+
+## Workflow
+
+### Step 1 — Confirm prerequisites
+- Edition (Business Critical for Options 2–6)
+- Azure storage type (LRS / GRS / RA-GRS / GZRS / RA-GZRS)
+- Event Grid + Storage Queue exists in target regions
+
+### Step 2 — Implement chosen option
+
+Each option follows the same shape: storage integration → stage → pipe (with `AUTO_INGEST=TRUE` and notification integration) → monitoring views → catchup procedure.
+
+**Option 2 dedup hash columns:**
+```sql
+MD5(METADATA$FILENAME)                          AS FILE_HASH,
+MD5(CONCAT_WS('|', $1, $2, $3, $4, $5))         AS RECORD_HASH,
+'PRIMARY'                                       AS SOURCE_REGION
+```
+Dedup with a Dynamic Table: `QUALIFY ROW_NUMBER() OVER (PARTITION BY FILE_HASH, RECORD_HASH ORDER BY LOAD_TIMESTAMP) = 1`.
+
+**Option 6 dual pipe pattern:**
+```sql
+CREATE PIPE PIPE_PRIMARY   AUTO_INGEST=TRUE INTEGRATION='NOTIF_INT_A' AS
+  COPY INTO TARGET_TABLE (..., 'PRIMARY' AS _source_region)   FROM @STAGE_PRIMARY;
+CREATE PIPE PIPE_SECONDARY AUTO_INGEST=TRUE INTEGRATION='NOTIF_INT_B' AS
+  COPY INTO TARGET_TABLE (..., 'SECONDARY' AS _source_region) FROM @STAGE_SECONDARY;
+ALTER PIPE PIPE_SECONDARY SET PIPE_EXECUTION_PAUSED = TRUE;
+```
+
+⚠️ STOPPING POINT: Show planned `CREATE STORAGE INTEGRATION`, `CREATE PIPE`, and `ALTER FAILOVER GROUP` statements to the user and wait for approval before executing.
+
+### Step 3 — Validate
+
+```sql
+SELECT PARSE_JSON(SYSTEM$PIPE_STATUS('pipe_name')):executionState::STRING  AS state,
+       PARSE_JSON(SYSTEM$PIPE_STATUS('pipe_name')):pendingFileCount::NUMBER AS pending;
+```
+
+Monitor pending files (`>1000` for `>15 min`), error rate from `SNOWFLAKE.ACCOUNT_USAGE.COPY_HISTORY` (`>5%/hr`), and load latency (`>30 min`).
+
+### Step 4 — Failover / failback / catchup
+
+```sql
+ALTER PIPE pipe_primary   SET PIPE_EXECUTION_PAUSED = TRUE;
+-- record checkpoint from COPY_HISTORY
+ALTER PIPE pipe_secondary SET PIPE_EXECUTION_PAUSED = FALSE;
+ALTER PIPE pipe_secondary REFRESH MODIFIED_AFTER = '<checkpoint-15min>';
+```
+
+⚠️ STOPPING POINT: Confirm the failover decision and the checkpoint timestamp with the user before pausing the primary pipe.
+
+Catchup choices: `ALTER PIPE … REFRESH` (≤7 days), `COPY INTO … FROM @stage` (any age), or a cursor proc that diffs `DIRECTORY(@stage)` against `COPY_HISTORY` for an audit trail.
+
+## Common Mistakes
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| Both pipes running | Duplicate loads | Pause standby; use a failover proc |
+| Secondary URL missing from integration | `ACCESS_DENIED` on failover | Recreate integration with both URLs |
+| Relying on `COPY_HISTORY` past 14 days | Catchup finds nothing | Maintain `FILE_LOAD_HISTORY` table |
+| No DR Event Grid subscription | `pendingFileCount = 0` post-failover | Create matching Event Grid + queue in DR region |
+| `PIPE REFRESH` for old files | Files >7 days skipped silently | Switch to `DIRECTORY(@stage)` + `COPY INTO` |
+| Pipe recreated without `AUTO_INGEST=TRUE` | Pipe stops auto-loading | Include `AUTO_INGEST=TRUE` and `INTEGRATION=` |
+| Inbound notification integration not recreated post-failover | Pipe healthy but `pendingFileCount=0` | Recreate `DIRECTION=INBOUND` integration in DR account, re-grant Service Principal |
+
+## Stopping Points
+
+- Step 2 — wait for approval before running `CREATE`/`ALTER` for storage integrations, pipes, and failover groups.
+- Step 4 — confirm the failover decision and checkpoint timestamp before pausing the active pipe.
+
+## References
+
+- [Stage, Pipe, and Load History Replication](https://docs.snowflake.com/en/user-guide/account-replication-stages-pipes-load-history)
+- [Automating Snowpipe for Azure Blob Storage](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-azure)


### PR DESCRIPTION
## Summary

Promotes the `snowpipe-bcdr` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
