### PR TITLE
Promote ml-migration from Snowflake-Solutions

### DIFF
--- a/skills/ml-migration/LICENSE
+++ b/skills/ml-migration/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/ml-migration/RULES.md
+++ b/skills/ml-migration/RULES.md
@@ -1,0 +1,322 @@
+# ML Migration Skill Rules
+
+## ⛔ Required Reads Tracking (MANDATORY)
+
+**This is the MOST IMPORTANT rule.** You MUST track all file reads in `migration-config.yaml`.
+
+### Why This Exists
+
+Agents often skip reading reference files even when instructed to read them. This tracking system ensures:
+1. Every required file is actually read (using the Read tool)
+2. Progress is visible and verifiable
+3. You cannot proceed to the next phase without completing reads
+
+### How to Track Reads
+
+1. **Before each phase**, check `required_reads` in config for files needed
+2. **Add the file** to `required_reads` with `status: pending`
+3. **Actually read the file** using the Read tool
+4. **Update status to `read`** in config ONLY AFTER reading
+5. **Verify all phase reads** show `status: read` before proceeding
+
+### Required Reads Format
+
+```yaml
+required_reads:
+  - file: "path/to/file.md"
+    phase: "I3"
+    status: pending  # → read (after using Read tool)
+```
+
+### Gate Check Before Each Phase
+
+**MANDATORY:** Before transitioning to any phase, output this check:
+
+```
+⛔ PHASE [X] GATE CHECK:
+Required reads:
+- [x] file1.md (status: read)
+- [ ] file2.md (status: pending) ← BLOCKED
+
+Status: BLOCKED - Must read file2.md first
+```
+
+**NEVER proceed with any `status: pending` reads for the current or earlier phases.**
+
+### What Happens If You Skip Reads
+
+- Wrong CLI commands for the detected platform
+- Failed authentication patterns
+- Incorrect model registration code
+- Broken SPCS deployments
+- User frustration and wasted time
+
+### ⚠️ Sub-Skill Files ARE Required Reads
+
+**CRITICAL:** Sub-skill files (`SKILL.md` from other skills) are tracked the same way as reference files.
+
+| Phase | Required Sub-Skill | Why |
+|-------|-------------------|-----|
+| I7 | `../model-registry/SKILL.md` | Contains actual registration workflow |
+| I7 | `../spcs-inference/SKILL.md` | Contains actual SPCS deployment workflow |
+| T3 | `../ml-jobs/SKILL.md` | Contains actual job submission workflow |
+
+**Common mistake:** Reading a reference file (like `xgboost-booster.md`) and skipping the sub-skill file. Reference files provide context, but sub-skill files provide the **workflow you must execute**.
+
+```
+❌ WRONG: Read xgboost-booster.md → Skip model-registry/SKILL.md → Guess at registration
+✅ RIGHT: Read xgboost-booster.md → Read model-registry/SKILL.md → Follow its workflow
+```
+
+---
+
+## Universal Rules
+
+### Resource Selection
+
+- **NEVER assume** which role, database, schema, warehouse, compute pool, or image repository to use
+- **ALWAYS list available options** and ask the user to select
+- Even if only one option exists, confirm with the user before proceeding
+- Present options with brief descriptions (e.g., instance size, purpose)
+- Make sure you are running all commands with the role the user specified
+
+### Authentication
+
+- **Use programmatic authentication** when possible instead of asking users to run commands manually
+- **Snowflake image registry:**
+  - **NEVER use username/password** - only token-based authentication
+  - Use: `snow spcs image-registry token --format=JSON | $CONTAINER_CMD login <url> -u 0sessiontoken --password-stdin`
+  - Get URL with: `snow spcs image-registry url --connection <conn>`
+- For AWS: check `aws configure list-profiles` and ask user to select a profile
+- For Azure: check `az account list` for available subscriptions
+- For GCP: check `gcloud auth list` for authenticated accounts
+- For Databricks: check `databricks auth profiles` for available profiles
+- Only fall back to interactive login if programmatic methods fail
+
+### Config File
+
+- **Generate `migration-config.yaml`** after collecting all user decisions
+- **Only include fields relevant** to the detected migration type - do not include all possible fields
+- **Stop and wait** for user to review/edit the config before execution
+- **Read from config** during execution - never re-prompt for values already in config
+- Config file should be in the current working directory, not /tmp/
+
+### Communication
+
+- **Explain assumptions** when you make them - let user know what you detected and decided
+- **Present trade-offs** when multiple approaches exist
+- **Stop at defined checkpoints** - don't proceed through multiple phases without user confirmation
+- When errors occur, explain what went wrong and what alternatives exist
+
+### Error Recovery - NO FALLBACKS
+
+**This is a critical rule across all workflows.**
+
+When a user specifies resources in their config (role, database, schema, compute pool, stage, warehouse), you MUST:
+
+1. **ONLY use those exact resources** - no substitutions
+2. **NEVER try alternatives** if the specified resource fails
+3. **STOP and report the error** if access is denied
+4. **Ask user to update config** with valid resources
+
+**WHY:** The config-driven approach exists so users control exactly what resources are used. Trying alternatives:
+- May use resources the user doesn't want to use
+- May incur unexpected costs
+- May write data to wrong locations
+- Violates user trust and expectations
+
+**WRONG:**
+```
+User config specifies: compute_pool: MY_POOL
+Error: Permission denied on MY_POOL
+Agent: "Let me try ANOTHER_POOL instead..."  ❌ NEVER DO THIS
+```
+
+**RIGHT:**
+```
+User config specifies: compute_pool: MY_POOL
+Error: Permission denied on MY_POOL
+Agent: "Permission denied on MY_POOL. Please either:
+1. Update your config to use a different compute pool
+2. Ask your admin to grant USAGE on MY_POOL to your role
+Run: SHOW COMPUTE POOLS; to see available pools."  ✅ CORRECT
+```
+
+### Migration Rules File
+
+- **ALWAYS create `rules/migration-rule.md` FIRST** before any other files (Phase 0)
+- Create the `rules/` directory in the current working directory if it doesn't exist
+- The rules file guides the agent throughout the migration
+
+---
+
+## Inference-Specific Rules
+
+### Docker Operations
+
+- Prefer **pulling existing images** over building new ones for lift-and-shift migrations
+- Check for available container runtimes: `docker`, `podman`, `nerdctl` in that order
+- Use `--platform linux/amd64` when pulling images for Snowflake SPCS
+- For model artifacts stored separately (e.g., S3), prefer mounting from Snowflake stage over baking into image
+
+### SPCS Service Deployment
+
+- **Ask user for ingress preference FIRST** before checking privileges:
+  - Public ingress (HTTP access from outside Snowflake)
+  - Internal-only (SQL/Python within Snowflake only)
+- **If user chose Public ingress, CHECK privilege before proceeding:**
+  ```sql
+  SHOW GRANTS TO ROLE <user_role>;
+  -- Look for: BIND SERVICE ENDPOINT on ACCOUNT
+  ```
+- **⛔ BLOCKING RULE: If user chose Public but lacks BIND SERVICE ENDPOINT privilege:**
+  - **DO NOT create an internal-only endpoint as a fallback**
+  - **STOP and inform user** they must either:
+    1. Get the privilege granted: `GRANT BIND SERVICE ENDPOINT ON ACCOUNT TO ROLE <role>;`
+    2. Switch to a role that has the privilege
+    3. Explicitly choose internal-only access (restart the choice)
+  - **Never silently downgrade** from public to internal-only
+- Only set `ingress_enabled=False` if user **explicitly chose** internal-only access
+
+### Framework Support
+
+- **Known built-in supported types** (direct `log_model()`):
+  - scikit-learn, XGBoost (sklearn API), LightGBM, CatBoost, Prophet
+  - PyTorch, TensorFlow, Keras
+  - Sentence Transformers, Hugging Face pipeline, MLFlow PyFunc
+- **Known exceptions** requiring CustomModel:
+  - `xgb.core.Booster` (raw Booster lacks sklearn interface)
+- **If model type not in either list above:**
+  1. Check official docs for current support
+  2. If supported → direct `log_model()`
+  3. If not supported → CustomModel required
+- **Do NOT assume** an unknown type requires CustomModel without checking docs first
+
+### SageMaker-Specific
+
+- SageMaker endpoints separate container image from model artifacts
+- Model artifacts are typically in S3, mounted at `/opt/ml/model` at runtime
+- Entry point is specified via `SAGEMAKER_PROGRAM` environment variable
+- AWS Deep Learning Container images require ECR login before pulling
+
+---
+
+## Training-Specific Rules
+
+### Execution Model (Local vs Container Runtime)
+
+**⚠️ CRITICAL: Understand where code runs.**
+
+There are TWO execution contexts - never confuse them:
+
+| Context | Where it runs | What APIs are available |
+|---------|---------------|------------------------|
+| **Launcher script** | Your local machine | `snowflake.ml.jobs` (submit_file, remote, etc.) |
+| **Training script** | Container Runtime | `snowflake.ml.modeling.tune` (Tuner), `snowflake.ml.data` (DataConnector), etc. |
+
+**Container Runtime APIs** (Tuner, PyTorchDistributor, etc.) are **ONLY available inside Container Runtime**. They do NOT exist in the pip-installed `snowflake-ml-python` package.
+
+```python
+# ❌ WRONG - This will fail locally with ModuleNotFoundError
+from snowflake.ml.modeling.tune import Tuner  # NOT available locally!
+
+# ✅ CORRECT - Launcher script (runs locally)
+from snowflake.ml.jobs import submit_file
+job = submit_file("train_hpo.py", "COMPUTE_POOL", stage_name="STAGE")
+
+# ✅ CORRECT - Training script (runs in Container Runtime)
+# train_hpo.py - this file is submitted and runs remotely
+from snowflake.ml.modeling.tune import Tuner, TunerConfig  # Available here!
+```
+
+### Default Approach: submit_file()
+
+**Use `submit_file()` as the default approach** for all training migrations because:
+- More robust across Python versions (avoids serialization issues)
+- Container Runtime uses Python 3.10 - if user's local Python differs, @remote will fail
+- Better for multi-file projects
+- Clearer separation of training code
+- Easier to debug and iterate
+
+```python
+from snowflake.ml.jobs import submit_file
+
+job = submit_file(
+    "train.py",
+    "<COMPUTE_POOL_FROM_CONFIG>",
+    stage_name="<STAGE_FROM_CONFIG>",
+    pip_requirements=["scikit-learn", "pandas"]
+)
+```
+
+### @remote Decorator (Use Only When)
+
+Only use `@remote` when ALL of these conditions are met:
+1. User explicitly requests it
+2. User confirms local Python version is 3.10 (matches Container Runtime)
+3. Single-function training with no external file dependencies
+4. Simple serializable return values
+
+### Model Saving - MANDATORY
+
+**Model persistence is REQUIRED, not optional.** With `submit_file()`, return values are NOT accessible.
+
+Every training script MUST include model registration:
+```python
+from snowflake.ml.registry import Registry
+registry = Registry(session, database_name="<DB>", schema_name="<SCHEMA>")
+mv = registry.log_model(model, model_name="<MODEL_NAME>", version_name="v1")
+```
+
+- **NEVER skip model persistence** - user will lose their trained model
+- **Use resources from config** - database, schema, stage must come from user's config
+
+### Code Conversion
+
+- **DO NOT modify** the core training logic (model architecture, loss functions, optimizers)
+- **DO modify** data loading, model saving, and environment variable usage
+- **Preserve** hyperparameter handling but convert to function arguments
+- **Keep** the original file as a reference (`original_train.py.bak`)
+
+### Data Loading
+
+- **NEVER assume** data is in a specific location
+- **ASK** which Snowflake table contains the training data
+- **Use DataConnector** for large datasets that don't fit in memory
+- For small datasets, `session.table().to_pandas()` is sufficient
+
+### Dependencies
+
+- **Extract** all dependencies from source (requirements.txt, environment.yaml, setup.py)
+- **Verify** packages are available in Container Runtime before assuming they need installation
+- **List** any packages that need to be added via the `pip_requirements` parameter
+
+### Hyperparameter Optimization (HPO)
+
+**⚠️ REMINDER: Tuner API runs in Container Runtime, NOT locally.**
+
+**MANDATORY: Before writing ANY HPO code:**
+
+1. Use ONLY the native Snowflake Tuner API (in submitted training script):
+   ```python
+   from snowflake.ml.modeling.tune import Tuner, TunerConfig, uniform, loguniform, randint, choice
+   from snowflake.ml.modeling.tune.search import BayesOpt, RandomSearch, GridSearch
+   ```
+
+2. **DO NOT use Optuna, Ray Tune, or Hyperopt patterns** - use native Snowflake APIs only
+
+3. **Understand search algorithm limitations:**
+   - `BayesOpt()` only supports `uniform()` and `loguniform()` - NO integer or categorical params
+   - `RandomSearch()` supports ALL parameter types including `randint()` and `choice()`
+   - `GridSearch()` requires explicit value lists
+
+4. **If migrating from a platform that uses Bayesian optimization with integer parameters:**
+   - Either switch to `RandomSearch()` in Snowflake
+   - Or use `uniform()` and cast to `int()` inside the training function
+
+### Validation
+
+- **ALWAYS validate** converted code compiles: `python -m py_compile`
+- **Suggest a test run** with limited data before full training
+- **Compare outputs** if possible - metrics should be similar between platforms
+- **Document any differences** in behavior between source and target

--- a/skills/ml-migration/SKILL.md
+++ b/skills/ml-migration/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: ml-migration
+title: ML Workload Migration
+summary: Migrate ML training and inference workloads from SageMaker, Azure ML, Vertex AI, or Databricks to Snowflake.
+description: Use when migrating ML models or training scripts from SageMaker, Azure ML, Vertex AI, or Databricks/MLflow into Snowflake Model Registry, SPCS, or ML Jobs. Triggers: migrate model, import model, deploy endpoint, convert training script, ML Jobs migration, sagemaker to snowflake, azureml to snowflake, vertex ai to snowflake, databricks to snowflake, mlflow migration.
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+prompt: Migrate my SageMaker training script in train.py to Snowflake ML Jobs.
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+# ML Workload Migration
+
+## Overview
+
+This skill migrates ML workloads from SageMaker, Azure ML, Vertex AI, or Databricks/MLflow into Snowflake. Two paths:
+
+- **Inference** — pretrained model files or live endpoints → Snowflake Model Registry (batch via warehouse) or SPCS service (real-time).
+- **Training** — training scripts, pipelines, or notebooks → Snowflake ML Jobs running on compute pools.
+
+Delegates to the bundled `machine-learning` skill for model registry, SPCS inference, and ML jobs workflows. Platform-specific patterns live under `references/platforms/<platform>/`.
+
+## When to Use
+
+- You have a model artifact (`.pkl`, `.pth`, `.h5`, `.tar.gz`) or live endpoint to bring into Snowflake.
+- You have a training script (`train.py`) that imports `sagemaker`, `azureml`, `aiplatform`, or `mlflow`.
+- You want SQL inference (`MODEL!PREDICT()`) instead of a remote endpoint.
+
+Skip if: the model is already in Snowflake Model Registry, or the workflow has no Snowflake target.
+
+## Workflow
+
+### Phase 0 — Initialize
+
+Create `migration-config.yaml` in the working directory. Read `RULES.md` and copy to `rules/migration-rule.md`.
+
+### Phase 1 — Mode
+
+Ask: generate code only, or generate and run?
+
+### Phase 2 — Detect platform and route
+
+Detect from imports / env vars / paths:
+
+| Pattern | Platform |
+|---|---|
+| `sagemaker` SDK, `SM_*`, `/opt/ml/*` | SageMaker |
+| `azureml.*`, `azure.ai.ml`, `MLClient` | Azure ML |
+| `google.cloud.aiplatform`, `AIP_*`, `gs://` | Vertex AI |
+| `mlflow.*`, `dbutils.*`, `spark.*` | Databricks |
+
+Read `references/platforms/<platform>/common.md`. Then route by asset type — endpoint or model file → **Inference (I1–I8)**; script, pipeline, notebook → **Training (T1–T9)**.
+
+### Inference path (I1–I8)
+
+1. Read `references/platforms/<platform>/inference.md`.
+2. For endpoints, ask: container lift-and-shift to SPCS, or extract model and register natively (enables `MODEL!PREDICT()`).
+3. Run `SHOW ROLES; SHOW DATABASES; SHOW WAREHOUSES; SHOW COMPUTE POOLS; SHOW IMAGE REPOSITORIES; SHOW EXTERNAL ACCESS INTEGRATIONS;` and ask user to pick — never guess.
+4. Generate full `migration-config.yaml`. ⚠️ STOPPING POINT: present config and wait for confirmation.
+5. Download artifacts using user-selected cloud profile (`aws configure list-profiles`, `az account list`, `gcloud auth list`, `databricks auth profiles`).
+6. Load model, identify framework (sklearn, XGBoost sklearn API, LightGBM, CatBoost, Prophet, PyTorch, TF/Keras, sentence-transformers, HF pipelines work directly; `xgb.core.Booster` needs `CustomModel`).
+7. Present plan. ⚠️ STOPPING POINT: wait for approval.
+8. Execute via the bundled `machine-learning` skill (model registry for batch, SPCS inference for real-time). Validate: `SELECT MODEL!PREDICT(col1, col2):prediction FROM test_table LIMIT 5;`.
+
+### Training path (T1–T9)
+
+1. Read `references/platforms/<platform>/training.md` and `references/training/frameworks.md`. Add `distributed.md` if `torch.distributed`/`horovod`/`DataParallel`/`MirroredStrategy` detected; add `hpo.md` for `optuna`/`HyperparameterTuner`.
+2. Run `SHOW COMPUTE POOLS; SHOW STAGES; SHOW EXTERNAL ACCESS INTEGRATIONS;`. Delegate to the bundled `machine-learning` skill for compute pool selection and EAI patterns. Ask user to pick.
+3. Generate `migration-config.yaml` with `compute_pool`, `stage_name`, `entry_point`, `pip_requirements`, model name/version. ⚠️ STOPPING POINT.
+4. Analyze source: data loading → `session.table()` or `DataConnector`; model saves → `registry.log_model()` or stage upload; env vars → function args; hyperparams → argparse.
+5. Present conversion plan. ⚠️ STOPPING POINT.
+6. Convert into `migrated_training/{train.py, launcher.py, requirements.txt, README.md}` using the bundled `machine-learning` skill for ML jobs patterns.
+7. Validate: `python -m py_compile`, submit small-data test, `SHOW MODELS IN SCHEMA <db>.<schema>;`.
+8. Output migration report.
+
+## Common Mistakes
+
+- **Assuming default role/database/warehouse/compute pool.** Always `SHOW` and ask.
+- **Skipping reference reads.** Wrong CLI, wrong auth, broken registration.
+- **Falling back silently when a resource fails.** Stop and report; never substitute.
+- **Re-asking for inputs already in `migration-config.yaml`.** Read the config.
+- **Wrapping built-in framework models in `CustomModel`.** Only `xgb.core.Booster` and unknown frameworks need it.
+- **Forgetting External Access Integration** for `pip_requirements` not in Container Runtime.
+- **Mixing inference and training configs** in one file. Separate runs, separate configs.
+
+## Red Flags
+
+Refuse these rationalizations:
+
+- "I'll just pick a warehouse to save time." → No. Ask the user.
+- "The reference file is long, I'll skim from memory." → No. Read it.
+- "If the configured stage doesn't exist, I'll create one." → No. Stop and report.
+- "I'll register with `CustomModel` since it's more flexible." → No. Use direct `log_model()` for supported frameworks.
+- "The user probably wants real-time, I'll deploy SPCS." → No. Ask batch vs real-time.
+- "I'll skip the stopping point since the config looks fine." → No. Always confirm.
+
+## Stopping Points
+
+- **Phase 2 — config generation (Inference I3 / Training T4):** present full `migration-config.yaml` and wait for confirmation before any execution.
+- **Inference I6 — migration plan:** present plan (stage, registration method, target, dependencies) and wait for approval.
+- **Inference I7 — execution:** confirm before running registration / SPCS deployment.
+- **Training T5 — code analysis:** confirm framework and complexity assessment before converting.
+- **Training T6 — conversion plan:** confirm entry point, data/model patterns, dependencies before code rewrite.
+
+## Error Handling
+
+| Error | Cause | Fix |
+|---|---|---|
+| `No compute pool found` | None created | `CREATE COMPUTE POOL ...` with right instance family |
+| `Package not available` | Not in Container Runtime | Add to `pip_requirements` + EAI |
+| `Permission denied` | Role/grants | Re-check `SHOW GRANTS`, update config |
+| `Model type not supported` | Unknown framework | Wrap in `CustomModel` |
+| `BIND SERVICE ENDPOINT` | Public ingress privilege missing | Grant or set internal-only |
+
+## Output
+
+- `migration-config.yaml`
+- `rules/migration-rule.md`
+- Registered Snowflake model (Model Registry)
+- SPCS service (if real-time)
+- `migrated_training/` (if training)
+- Migration report

--- a/skills/ml-migration/references/inference/source-access.md
+++ b/skills/ml-migration/references/inference/source-access.md
@@ -1,0 +1,88 @@
+# Source Platform Access Verification
+
+Verify ability to retrieve artifacts from source platform BEFORE detailed assessment.
+
+## AWS S3
+
+**Step 1: List available profiles**
+```bash
+aws configure list-profiles
+```
+
+**Step 2: Ask user which profile to use**
+```
+I found the following AWS profiles configured:
+- default
+- prod_account  
+- se_sandbox_contributor
+
+Which profile should I use for accessing s3://<bucket>/<path>?
+```
+
+**Step 3: Verify access with selected profile**
+```bash
+aws sts get-caller-identity --profile <selected_profile>
+aws s3 ls s3://bucket-name/path/ --profile <selected_profile>
+```
+
+**Step 4: Use profile for all subsequent AWS operations**
+```bash
+aws s3 cp s3://bucket/model.pkl ./model.pkl --profile <selected_profile>
+```
+
+## Azure Blob Storage
+
+**Step 1: List available subscriptions**
+```bash
+az account list --output table
+```
+
+**Step 2: Ask user which subscription to use**
+
+**Step 3: Set and verify access**
+```bash
+az account set --subscription <selected_subscription>
+az storage blob list --account-name <account> --container-name <container>
+```
+
+## GCP Cloud Storage
+
+**Step 1: List available configurations**
+```bash
+gcloud config configurations list
+```
+
+**Step 2: Ask user which configuration to use**
+
+**Step 3: Activate and verify access**
+```bash
+gcloud config configurations activate <selected_config>
+gsutil ls gs://bucket-name/path/
+```
+
+## Databricks / MLflow
+
+**Step 1: List available profiles**
+```bash
+databricks auth profiles
+```
+
+**Step 2: Ask user which profile to use**
+
+**Step 3: Verify access**
+```bash
+databricks auth describe --profile <selected_profile>
+```
+
+## If No Profiles Found
+
+Ask user:
+```
+No configured profiles found for <platform>. Options:
+1. Configure credentials now
+2. Provide credentials manually
+3. Download file yourself and provide local path
+4. Use a pre-signed URL
+```
+
+**⚠️ STOP if access fails:** Resolve before proceeding to assessment phase.

--- a/skills/ml-migration/references/inference/xgboost-booster.md
+++ b/skills/ml-migration/references/inference/xgboost-booster.md
@@ -1,0 +1,141 @@
+# XGBoost Booster to Snowflake Model Registry
+
+Migrating raw XGBoost Booster objects (not sklearn wrappers) to Snowflake.
+
+## Problem
+
+Raw `xgboost.core.Booster` objects cannot be registered directly to Snowflake Model Registry using `log_model()`. Only sklearn-style wrappers (`XGBClassifier`, `XGBRegressor`) have native support.
+
+## Detection
+
+```python
+import xgboost as xgb
+
+if isinstance(model, xgb.core.Booster):
+    # CustomModel wrapper REQUIRED - use pattern below
+    pass
+elif isinstance(model, (xgb.XGBClassifier, xgb.XGBRegressor)):
+    # Direct registration OK
+    registry.log_model(model=model, ...)
+```
+
+## Solution: CustomModel Wrapper
+
+```python
+from snowflake.ml.model import custom_model
+import xgboost as xgb
+import pandas as pd
+import pickle
+
+class XGBoostBoosterModel(custom_model.CustomModel):
+    """
+    CustomModel wrapper for raw XGBoost Booster objects.
+    Required because xgb.core.Booster lacks sklearn interface.
+    """
+    
+    def __init__(self, context: custom_model.ModelContext) -> None:
+        super().__init__(context)
+        with open(context.path('model.pkl'), 'rb') as f:
+            self.booster = pickle.load(f)
+    
+    @custom_model.inference_api
+    def predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        """Generate predictions using the XGBoost Booster."""
+        dmatrix = xgb.DMatrix(X, feature_names=self.booster.feature_names)
+        predictions = self.booster.predict(dmatrix)
+        return pd.DataFrame({'PREDICTION': predictions})
+```
+
+## Complete Registration Example
+
+```python
+# Step 1: Save booster to temp file for artifact
+artifact_path = '/tmp/model.pkl'
+with open(artifact_path, 'wb') as f:
+    pickle.dump(booster, f)
+
+# Step 2: Create ModelContext with artifact
+mc = custom_model.ModelContext(
+    artifacts={'model.pkl': artifact_path}
+)
+
+# Step 3: Instantiate custom model
+model = XGBoostBoosterModel(mc)
+
+# Step 4: Test locally before registration
+test_result = model.predict(sample_input)
+print(f"Local test:\n{test_result}")
+
+# Step 5: Register to Model Registry
+mv = registry.log_model(
+    model=model,
+    model_name='MY_XGB_MODEL',
+    version_name='V1',
+    sample_input_data=sample_df,
+    conda_dependencies=['xgboost>=2.0.0'],
+    comment='XGBoost Booster migrated with CustomModel wrapper'
+)
+```
+
+## Extracting Booster Metadata
+
+Critical for creating correct `sample_input_data`:
+
+```python
+import json
+
+# Feature information
+feature_names = booster.feature_names  # List[str]
+num_features = booster.num_features()
+
+# Model configuration
+config = json.loads(booster.save_config())
+objective = config['learner']['objective']['name']
+num_rounds = booster.num_boosted_rounds()
+
+print(f"Features: {num_features}")
+print(f"Feature names: {feature_names}")
+print(f"Objective: {objective}")
+print(f"Trees: {num_rounds}")
+```
+
+## Creating sample_input_data
+
+Use EXACT feature names from booster:
+
+```python
+import pandas as pd
+
+feature_names = booster.feature_names
+
+# Create sample with correct columns and types
+sample_data = {name: [1.0, 2.0] for name in feature_names}
+sample_input = pd.DataFrame(sample_data)
+
+# Verify column order matches
+assert list(sample_input.columns) == feature_names
+```
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Version warning on pickle load | Model saved with older XGBoost | Safe to ignore |
+| `sample_input_data required` | Missing sample data | Provide DataFrame with correct feature names |
+| Wrong predictions | Feature order mismatch | Use `feature_names` in DMatrix |
+| `Booster has no predict_proba` | Using raw Booster like sklearn | Booster's `predict()` returns probabilities |
+
+## When to Use This Pattern
+
+- Model type is `xgboost.core.Booster` (not sklearn wrapper)
+- Migrating XGBoost models trained with raw `xgb.train()` API
+- Models saved as pickle of Booster object
+- GPU-trained XGBoost models (often use Booster directly)
+
+## SQL Usage After Registration
+
+```sql
+SELECT 
+    MY_XGB_MODEL!PREDICT(feature1, feature2, feature3):PREDICTION::FLOAT as probability
+FROM my_table;
+```

--- a/skills/ml-migration/references/platforms/azure-ml/common.md
+++ b/skills/ml-migration/references/platforms/azure-ml/common.md
@@ -1,0 +1,119 @@
+# Azure ML: Common Reference
+
+Shared patterns and utilities for migrating from Azure Machine Learning to Snowflake.
+
+## Platform Detection
+
+### Indicators
+```python
+# File patterns
+"*.azureml"           # Azure ML config directories
+"azureml-*.yaml"      # Job/environment definitions
+"score.py"            # Azure scoring script convention
+"conda_dependencies.yml"
+
+# SDK imports
+from azure.ai.ml import MLClient
+from azure.ai.ml import command, Input, Output
+from azure.ai.ml.entities import Model, Environment
+from azure.identity import DefaultAzureCredential
+```
+
+### Detection Logic
+```python
+def detect_azure_ml():
+    indicators = [
+        glob.glob("**/.azureml", recursive=True),
+        grep_files("from azure.ai.ml"),
+        grep_files("MLClient"),
+        os.path.exists("score.py"),
+    ]
+    return any(indicators)
+```
+
+## Asset Mapping
+
+| Azure ML Asset | Snowflake Equivalent | Migration Path |
+|----------------|---------------------|----------------|
+| Workspace | Database/Schema | Map workspace to DB.SCHEMA |
+| Registered Model | Model Registry | Download → register |
+| Managed Endpoint | SPCS Service | Extract → deploy |
+| Compute Instance | ML Job | Convert to `@remote` |
+| Compute Cluster | Compute Pool | Map to CPU_X64/GPU_NV |
+| Pipeline | Tasks/Python | Convert orchestration |
+| Data Asset | Table/Stage | Load via connector |
+| Environment | Container Runtime | Extract packages |
+
+## Azure Authentication
+
+### SDK Client Setup
+```python
+from azure.ai.ml import MLClient
+from azure.identity import DefaultAzureCredential
+
+# Required credentials
+ml_client = MLClient(
+    DefaultAzureCredential(),
+    subscription_id="<subscription-id>",
+    resource_group="<resource-group>",
+    workspace_name="<workspace-name>"
+)
+```
+
+### Required Azure Permissions
+- `Azure ML Data Scientist` - Read models, endpoints
+- `Storage Blob Data Reader` - Access model artifacts
+- `Azure ML Workspace Reader` - List workspace resources
+
+## Environment Verification
+
+### Prerequisites Checklist
+- [ ] Azure CLI authenticated (`az login`)
+- [ ] Subscription ID available
+- [ ] Resource group name known
+- [ ] Workspace name confirmed
+- [ ] `azure-ai-ml` package installed
+
+### Validate Access
+```python
+# Test workspace connectivity
+try:
+    workspace = ml_client.workspaces.get(workspace_name)
+    print(f"Connected to: {workspace.name}")
+except Exception as e:
+    print(f"Access failed: {e}")
+```
+
+## Environment Migration
+
+### Export Environment
+```bash
+# From conda
+conda env export > environment.yml
+
+# From Azure ML environment
+az ml environment show --name my-env --version 1 > env.json
+```
+
+### Convert to Snowflake
+```python
+# Extract packages from environment.yml
+import yaml
+with open("environment.yml") as f:
+    env = yaml.safe_load(f)
+    
+pip_packages = [dep for dep in env.get("dependencies", []) 
+                if isinstance(dep, str) and not dep.startswith("python")]
+
+# Use in @remote or submit_file
+pip_requirements = pip_packages
+```
+
+## Data Source Migration
+
+| Azure Source | Snowflake Target | Method |
+|--------------|------------------|--------|
+| Blob Storage | External Stage | `azure://container/path` |
+| ADLS Gen2 | External Stage | Azure credentials |
+| Azure SQL | Table | Snowflake connector |
+| MLTable | Table | Convert to DataFrame → load |

--- a/skills/ml-migration/references/platforms/azure-ml/inference.md
+++ b/skills/ml-migration/references/platforms/azure-ml/inference.md
@@ -1,0 +1,204 @@
+# Azure ML: Inference Migration
+
+Migrating Azure ML models and managed endpoints to Snowflake for inference.
+
+## Model Discovery
+
+### List Registered Models
+```python
+from azure.ai.ml import MLClient
+from azure.identity import DefaultAzureCredential
+
+ml_client = MLClient(
+    DefaultAzureCredential(),
+    subscription_id="...",
+    resource_group="...",
+    workspace_name="..."
+)
+
+# List all models
+models = ml_client.models.list()
+for model in models:
+    print(f"{model.name} v{model.version}: {model.type}")
+```
+
+### Get Model Details
+```python
+model = ml_client.models.get(name="my-model", version="1")
+print(f"Path: {model.path}")
+print(f"Type: {model.type}")
+print(f"Framework: {model.properties.get('framework', 'unknown')}")
+```
+
+## Endpoint Discovery
+
+### List Managed Endpoints
+```python
+endpoints = ml_client.online_endpoints.list()
+for ep in endpoints:
+    print(f"{ep.name}: {ep.provisioning_state}")
+```
+
+### Get Deployment Details
+```python
+endpoint = ml_client.online_endpoints.get(name="my-endpoint")
+deployment = ml_client.online_deployments.get(
+    name="my-deployment", 
+    endpoint_name="my-endpoint"
+)
+
+# Model reference
+model_ref = deployment.model
+print(f"Model: {model_ref}")
+```
+
+## Model Download
+
+### From Model Registry
+```python
+ml_client.models.download(
+    name="my-model", 
+    version="1", 
+    download_path="./model"
+)
+```
+
+### Identify Framework
+| Azure ML Model Type | Framework | Detection |
+|--------------------|-----------|-----------|
+| `mlflow` | MLflow (various) | Check `MLmodel` file |
+| `custom` | Various | Inspect file patterns |
+| `triton` | Triton | ONNX/TensorRT files |
+
+## Scoring Script Analysis
+
+Azure uses `score.py` with:
+- `init()` - Model loading (runs once)
+- `run(data)` - Prediction logic (per request)
+
+### Extract Logic
+```python
+# Example Azure score.py
+def init():
+    global model
+    model_path = os.getenv("AZUREML_MODEL_DIR")
+    model = joblib.load(os.path.join(model_path, "model.pkl"))
+
+def run(raw_data):
+    data = json.loads(raw_data)
+    predictions = model.predict(data["input"])
+    return predictions.tolist()
+```
+
+## Snowflake Registration
+
+**⛔ For `log_model()` API patterns, see:** `../../../../model-registry/SKILL.md`
+
+The patterns below are platform-specific extraction and conversion logic.
+
+### Direct Registration (sklearn, xgboost, etc.)
+```python
+from snowflake.ml.registry import Registry
+
+registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+
+# Load downloaded model
+import joblib
+model = joblib.load("./model/model.pkl")
+
+# Register
+mv = registry.log_model(
+    model,
+    model_name="AZURE_MIGRATED_MODEL",
+    version_name="v1",
+    conda_dependencies=["scikit-learn"],
+    sample_input_data=sample_df
+)
+```
+
+### CustomModel for Unsupported Types
+```python
+from snowflake.ml.model import custom_model
+
+class AzureModelWrapper(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        import joblib
+        self.model = joblib.load(context.path("model.pkl"))
+    
+    @custom_model.inference_api
+    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
+        # Converted from Azure score.py run() logic
+        predictions = self.model.predict(input_df.values)
+        return pd.DataFrame({"prediction": predictions})
+
+# Register custom model
+mv = registry.log_model(
+    AzureModelWrapper,
+    model_name="AZURE_CUSTOM_MODEL",
+    version_name="v1",
+    artifacts={"model.pkl": "./model/model.pkl"}
+)
+```
+
+## SPCS Deployment
+
+### Service Specification
+```yaml
+spec:
+  containers:
+    - name: inference
+      image: /DB/SCHEMA/REPO/azure-migrated:v1
+      env:
+        MODEL_NAME: AZURE_MIGRATED_MODEL
+        MODEL_VERSION: v1
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: 2
+        limits:
+          nvidia.com/gpu: 1
+  endpoints:
+    - name: predict
+      port: 8080
+      public: true
+```
+
+### Build Container
+```dockerfile
+FROM python:3.10-slim
+
+# Install from Azure environment.yml
+COPY environment.yml .
+RUN pip install pyyaml && \
+    python -c "import yaml; deps=yaml.safe_load(open('environment.yml')); print(' '.join([d for d in deps.get('dependencies',[]) if isinstance(d,str)]))" | xargs pip install
+
+COPY inference_service.py .
+CMD ["python", "inference_service.py"]
+```
+
+## UDF Alternative
+
+For simpler models, convert to Snowflake UDF:
+```python
+from snowflake.snowpark.functions import udf
+
+@udf(packages=["scikit-learn", "joblib"])
+def predict_azure_model(input_data: dict) -> dict:
+    # Converted from Azure score.py
+    import joblib
+    model = joblib.load("@STAGE/model.pkl")
+    prediction = model.predict([list(input_data.values())])
+    return {"prediction": prediction[0]}
+```
+
+## Migration Checklist
+
+- [ ] Identify Azure model/endpoint
+- [ ] Download model artifacts
+- [ ] Analyze score.py for prediction logic
+- [ ] Export environment dependencies
+- [ ] Register in Snowflake Model Registry
+- [ ] Wrap with CustomModel if needed
+- [ ] Deploy to SPCS or create UDF
+- [ ] Validate inference results match

--- a/skills/ml-migration/references/platforms/azure-ml/training.md
+++ b/skills/ml-migration/references/platforms/azure-ml/training.md
@@ -1,0 +1,229 @@
+# Azure ML: Training Migration
+
+Migrating Azure ML training workflows to Snowflake ML Jobs.
+
+## Concept Mapping
+
+| Azure ML | Snowflake | Notes |
+|----------|-----------|-------|
+| Workspace | Database/Schema | Namespace mapping |
+| Compute Cluster | Compute Pool | CPU_X64_* / GPU_NV_* |
+| Environment | Container Runtime | + pip_requirements |
+| Command Job | @remote decorator | Or submit_file() |
+| Sweep Job | Snowflake Tuner | HPO migration |
+| Pipeline Job | Tasks or Python | Orchestration |
+| Data Asset | Table/Stage | Data access |
+| Model Registry | Snowflake Registry | Model storage |
+
+## Command Job Migration
+
+### Azure ML Command Job
+```python
+from azure.ai.ml import command, Input
+
+job = command(
+    code="./src",
+    command="python train.py --data ${{inputs.data}} --lr ${{inputs.lr}}",
+    environment="AzureML-pytorch-1.13@latest",
+    compute="gpu-cluster",
+    inputs={
+        "data": Input(type="uri_folder"),
+        "lr": 0.01
+    }
+)
+ml_client.jobs.create_or_update(job)
+```
+
+### Snowflake Equivalent
+```python
+from snowflake.ml.jobs import remote
+
+@remote(
+    compute_pool="GPU_NV_S",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["torch==1.13"]
+)
+def train(training_table: str, lr: float = 0.01):
+    from snowflake.snowpark import Session
+    session = Session.builder.getOrCreate()
+    
+    data = session.table(training_table).to_pandas()
+    model = train_model(data, lr)
+    return model
+```
+
+## Input/Output Mapping
+
+| Azure ML | Snowflake | Conversion |
+|----------|-----------|------------|
+| `Input(type="uri_folder")` | Stage path | `@STAGE/path/` |
+| `Input(type="uri_file")` | Stage file | `session.file.get()` |
+| `Input(type="mltable")` | Snowflake table | `session.table()` |
+| `Output(type="mlflow_model")` | Model Registry | `registry.log_model()` |
+| `${{inputs.param}}` | Function arg | Direct parameter |
+
+## Sweep Job Migration (HPO)
+
+### Azure ML Sweep
+```python
+from azure.ai.ml.sweep import Choice, Uniform
+
+sweep_job = command_job.sweep(
+    sampling_algorithm="random",
+    primary_metric="accuracy",
+    goal="maximize",
+    max_total_trials=20,
+    search_space={
+        "lr": Uniform(0.001, 0.1),
+        "batch_size": Choice([16, 32, 64])
+    }
+)
+```
+
+### Snowflake Tuner
+```python
+from snowflake.ml.modeling.tune import Tuner, TunerConfig
+from snowflake.ml.modeling.tune import uniform, randint
+from snowflake.ml.modeling.tune.search import RandomSearch
+
+# Define train function
+def train_func(config, dataset_map):
+    lr = config["lr"]
+    batch_size = config["batch_size"]
+    train_df = dataset_map["train"]
+    
+    model = train_model(train_df, lr=lr, batch_size=batch_size)
+    accuracy = evaluate(model)
+    return {"accuracy": accuracy}
+
+# Configure tuner
+search_space = {
+    "lr": uniform(0.001, 0.1),
+    "batch_size": randint(16, 64)
+}
+
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=RandomSearch(),
+    num_trials=20
+)
+
+tuner = Tuner(train_func, search_space, tuner_config)
+results = tuner.run(dataset_map={"train": train_df})
+```
+
+## Pipeline Migration
+
+### Azure ML Pipeline
+```python
+from azure.ai.ml import dsl
+
+@dsl.pipeline(name="training-pipeline")
+def pipeline(input_data: Input):
+    preprocess_step = preprocess_component(data=input_data)
+    train_step = train_component(data=preprocess_step.outputs.processed_data)
+    return {"model": train_step.outputs.model}
+```
+
+### Snowflake Orchestration
+```python
+from snowflake.ml.jobs import submit_file
+
+def run_pipeline(raw_table: str):
+    # Step 1: Preprocess
+    preprocess_job = submit_file(
+        "preprocess.py",
+        compute_pool="CPU_X64_M",
+        stage_name="TRAINING_STAGE",
+        args=["--input", raw_table, "--output", "PROCESSED_DATA"]
+    )
+    preprocess_job.wait()
+    
+    # Step 2: Train
+    train_job = submit_file(
+        "train.py",
+        compute_pool="GPU_NV_S",
+        stage_name="TRAINING_STAGE",
+        args=["--data", "PROCESSED_DATA"]
+    )
+    return train_job.result()
+```
+
+## MLflow Tracking Migration
+
+### Azure ML + MLflow
+```python
+import mlflow
+
+mlflow.log_param("lr", 0.01)
+mlflow.log_metric("accuracy", accuracy)
+mlflow.sklearn.log_model(model, "model")
+```
+
+### Snowflake Pattern
+```python
+from snowflake.ml.jobs import remote
+from snowflake.ml.registry import Registry
+
+@remote("CPU_X64_M", stage_name="TRAINING_STAGE")
+def train(training_table: str, lr: float = 0.01):
+    from snowflake.snowpark import Session
+    session = Session.builder.getOrCreate()
+    
+    # Train
+    model = train_model(lr=lr)
+    accuracy = evaluate(model)
+    
+    # Register (replaces mlflow.log_model)
+    registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+    registry.log_model(
+        model,
+        model_name="MODEL",
+        version_name="V1",
+        metrics={"accuracy": accuracy},
+        options={"params": {"lr": lr}}
+    )
+    
+    return {"model": model, "metrics": {"accuracy": accuracy}}
+```
+
+## Script Conversion Patterns
+
+### Argument Handling
+```python
+# BEFORE: Azure command line args
+# python train.py --data ${{inputs.data}} --lr ${{inputs.lr}}
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("--data", type=str)
+parser.add_argument("--lr", type=float)
+args = parser.parse_args()
+
+# AFTER: Snowflake function params (with submit_file)
+# Keep argparse for submit_file() compatibility
+# Or convert to @remote function parameters
+```
+
+### Data Loading
+```python
+# BEFORE: Azure URI input
+data_path = args.data  # uri_folder from input
+df = pd.read_parquet(data_path)
+
+# AFTER: Snowflake table
+from snowflake.snowpark import Session
+session = Session.builder.getOrCreate()
+df = session.table(training_table).to_pandas()
+```
+
+## Conversion Checklist
+
+- [ ] Map Azure compute to Snowflake compute pool
+- [ ] Replace `command()` with `@remote` or `submit_file()`
+- [ ] Convert `${{inputs.*}}` to function arguments
+- [ ] Replace environment with `pip_requirements`
+- [ ] Replace sweep job with Snowflake Tuner
+- [ ] Convert pipeline to Tasks or Python orchestration
+- [ ] Replace MLflow with return values + Registry
+- [ ] Update data access from URI to Snowflake tables

--- a/skills/ml-migration/references/platforms/databricks/common.md
+++ b/skills/ml-migration/references/platforms/databricks/common.md
@@ -1,0 +1,149 @@
+# Databricks/MLflow: Common Reference
+
+Shared patterns and utilities for migrating from Databricks and MLflow to Snowflake.
+
+## Platform Detection
+
+### Indicators
+```python
+# SDK imports
+import mlflow
+from pyspark.sql import SparkSession
+from databricks import feature_store
+from delta.tables import DeltaTable
+
+# File patterns
+"MLmodel"                  # MLflow model manifest
+"conda.yaml"               # MLflow environment
+"databricks.yml"           # Databricks asset bundles
+"*.dbc"                    # Databricks archive
+
+# Code patterns
+"spark.read.table("
+"dbutils.fs."
+"mlflow.autolog()"
+```
+
+### Detection Logic
+```python
+def detect_databricks():
+    indicators = [
+        grep_files("import mlflow"),
+        grep_files("from pyspark"),
+        grep_files("spark.read.table"),
+        grep_files("dbutils"),
+        os.path.exists("MLmodel"),
+    ]
+    return any(indicators)
+```
+
+## Asset Mapping
+
+| Databricks Asset | Snowflake Equivalent | Migration Path |
+|------------------|---------------------|----------------|
+| Workspace | Database/Schema | Map workspace to DB.SCHEMA |
+| MLflow Model | Model Registry | Export → register |
+| Model Serving Endpoint | SPCS Service | Extract → deploy |
+| Job (Training) | ML Job | Convert notebook/script |
+| Cluster | Compute Pool | CPU_X64/GPU_NV |
+| Feature Store | Feature Views | Recreate |
+| Delta Table | Snowflake Table | Migrate data |
+| Notebook | ML Job script | Convert code |
+| DBFS | Snowflake Stage | Stage operations |
+
+## MLflow Tracking URI
+
+### Setup for Export
+```python
+import mlflow
+
+# For Databricks-hosted MLflow
+mlflow.set_tracking_uri("databricks")
+
+# For Unity Catalog models
+mlflow.set_registry_uri("databricks-uc")
+
+# For self-hosted MLflow
+mlflow.set_tracking_uri("http://mlflow-server:5000")
+```
+
+## Environment Verification
+
+### Prerequisites Checklist
+- [ ] Databricks CLI configured (`databricks configure`)
+- [ ] Workspace URL available
+- [ ] Personal access token or OAuth configured
+- [ ] `mlflow` and `databricks-sdk` packages installed
+- [ ] Access to target workspace
+
+### Validate Access
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+clusters = w.clusters.list()
+print(f"Found {len(list(clusters))} clusters")
+```
+
+## Spark to Snowpark Conversion
+
+| Spark | Snowpark | Notes |
+|-------|----------|-------|
+| `spark.read.table("db.table")` | `session.table("DB.SCHEMA.TABLE")` | Case sensitivity |
+| `df.select("col")` | `df.select("COL")` | Upper case in Snowflake |
+| `df.filter(df.col > 5)` | `df.filter(col("COL") > 5)` | Import col() |
+| `df.groupBy("col").agg(...)` | `df.group_by("COL").agg(...)` | Snake case |
+| `df.toPandas()` | `df.to_pandas()` | Snake case |
+| `df.write.saveAsTable()` | `df.write.save_as_table()` | Snake case |
+
+## dbutils to Snowflake Stage
+
+| dbutils | Snowflake | Notes |
+|---------|-----------|-------|
+| `dbutils.fs.ls("path")` | `session.sql("LIST @STAGE")` | Stage listing |
+| `dbutils.fs.cp("src", "dst")` | `session.file.put() / get()` | File operations |
+| `dbutils.fs.rm("path")` | `session.sql("REMOVE @STAGE/path")` | Delete files |
+| `dbutils.fs.head("path")` | `session.file.get()` then read | Read file |
+| `dbutils.secrets.get()` | Snowflake secrets | Secret management |
+
+## Data Source Migration
+
+| Databricks Source | Snowflake Target | Method |
+|-------------------|------------------|--------|
+| Delta Lake | Iceberg or native | Delta sharing or export |
+| DBFS | Internal Stage | Upload files |
+| Unity Catalog | Snowflake catalog | Migrate tables |
+| S3/ADLS | External Stage | Direct access |
+
+### Create External Stage for Databricks Storage
+```sql
+CREATE STAGE dbx_stage
+  URL = 's3://databricks-bucket/path/'
+  CREDENTIALS = (AWS_KEY_ID='...' AWS_SECRET_KEY='...');
+```
+
+## MLmodel File Structure
+
+```yaml
+# MLmodel file - key for framework detection
+artifact_path: model
+flavors:
+  python_function:
+    env: conda.yaml
+    loader_module: mlflow.sklearn  # ← Framework indicator
+    model_path: model.pkl
+  sklearn:
+    pickled_model: model.pkl
+    sklearn_version: 1.2.0
+```
+
+## Framework Detection from MLflow
+
+| MLflow Flavor | Framework | Snowflake Registration |
+|---------------|-----------|------------------------|
+| `sklearn` | sklearn | Direct log_model() |
+| `xgboost` | XGBoost | Direct log_model() |
+| `lightgbm` | LightGBM | Direct log_model() |
+| `pytorch` | PyTorch | log_model() or CustomModel |
+| `tensorflow` | TensorFlow | log_model() or CustomModel |
+| `pyfunc` | Custom | Check underlying or SPCS |

--- a/skills/ml-migration/references/platforms/databricks/inference.md
+++ b/skills/ml-migration/references/platforms/databricks/inference.md
@@ -1,0 +1,228 @@
+# Databricks/MLflow: Inference Migration
+
+Migrating Databricks MLflow models and serving endpoints to Snowflake for inference.
+
+## Model Discovery
+
+### From MLflow Model Registry
+```python
+import mlflow
+
+mlflow.set_tracking_uri("databricks")
+
+# List registered models
+client = mlflow.MlflowClient()
+for model in client.search_registered_models():
+    print(f"{model.name}")
+    for version in model.latest_versions:
+        print(f"  v{version.version}: {version.current_stage}")
+```
+
+### From Unity Catalog
+```python
+mlflow.set_registry_uri("databricks-uc")
+
+# Unity Catalog model URI
+model_uri = "models:/catalog.schema.model_name/1"
+```
+
+## Model Export
+
+### Download Model Artifacts
+```python
+import mlflow
+
+# From Model Registry
+model_uri = "models:/my-model/Production"
+local_path = mlflow.artifacts.download_artifacts(model_uri)
+
+# From Run Artifacts
+run_id = "abc123..."
+artifact_path = mlflow.artifacts.download_artifacts(
+    run_id=run_id,
+    artifact_path="model"
+)
+```
+
+### Load Model for Inspection
+```python
+# Load as pyfunc
+model = mlflow.pyfunc.load_model(model_uri)
+
+# Get model info
+model_info = mlflow.models.get_model_info(model_uri)
+print(f"Flavors: {model_info.flavors}")
+```
+
+## Framework Detection
+
+Parse `MLmodel` file to identify framework:
+
+```python
+import yaml
+
+with open("MLmodel") as f:
+    mlmodel = yaml.safe_load(f)
+
+flavors = mlmodel.get("flavors", {})
+if "sklearn" in flavors:
+    framework = "sklearn"
+elif "xgboost" in flavors:
+    framework = "xgboost"
+elif "pytorch" in flavors:
+    framework = "pytorch"
+elif "tensorflow" in flavors:
+    framework = "tensorflow"
+else:
+    framework = "pyfunc"  # Custom model
+```
+
+| MLflow Flavor | Framework | Snowflake Registration |
+|---------------|-----------|------------------------|
+| `sklearn` | sklearn | Direct log_model() |
+| `xgboost` | XGBoost | Direct log_model() |
+| `lightgbm` | LightGBM | Direct log_model() |
+| `pytorch` | PyTorch | log_model() or CustomModel |
+| `tensorflow` | TensorFlow | log_model() or CustomModel |
+| `pyfunc` | Custom | CustomModel wrapper |
+
+## Snowflake Registration
+
+**⛔ For `log_model()` API patterns, see:** `../../../../model-registry/SKILL.md`
+
+The patterns below are platform-specific extraction and conversion logic.
+
+### Direct Registration (sklearn, xgboost, lightgbm)
+```python
+from snowflake.ml.registry import Registry
+import mlflow
+
+# Download and load model
+model_uri = "models:/my-model/Production"
+local_path = mlflow.artifacts.download_artifacts(model_uri)
+model = mlflow.sklearn.load_model(local_path)
+
+# Register in Snowflake
+registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+
+mv = registry.log_model(
+    model,
+    model_name="DBX_MIGRATED_MODEL",
+    version_name="v1",
+    conda_dependencies=["scikit-learn"],
+    sample_input_data=sample_df
+)
+```
+
+### CustomModel for pyfunc
+```python
+from snowflake.ml.model import custom_model
+import mlflow
+
+class MLflowPyfuncWrapper(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        self.model = mlflow.pyfunc.load_model(context.path("mlflow_model"))
+    
+    @custom_model.inference_api
+    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
+        predictions = self.model.predict(input_df)
+        return pd.DataFrame({"prediction": predictions})
+
+# Register
+mv = registry.log_model(
+    MLflowPyfuncWrapper,
+    model_name="DBX_PYFUNC_MODEL",
+    version_name="v1",
+    artifacts={"mlflow_model": local_path}
+)
+```
+
+### CustomModel for PyTorch/TensorFlow
+```python
+from snowflake.ml.model import custom_model
+import torch
+
+class PyTorchWrapper(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        self.model = torch.load(context.path("model.pt"))
+        self.model.eval()
+    
+    @custom_model.inference_api
+    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
+        with torch.no_grad():
+            inputs = torch.tensor(input_df.values, dtype=torch.float32)
+            outputs = self.model(inputs)
+        return pd.DataFrame({"prediction": outputs.numpy()})
+```
+
+## Serving Endpoint Migration
+
+### Get Endpoint Details
+```python
+from databricks.sdk import WorkspaceClient
+
+w = WorkspaceClient()
+endpoint = w.serving_endpoints.get("my-endpoint")
+
+for served_model in endpoint.config.served_models:
+    print(f"Model: {served_model.model_name}")
+    print(f"Version: {served_model.model_version}")
+```
+
+### SPCS Deployment
+```yaml
+spec:
+  containers:
+    - name: inference
+      image: /DB/SCHEMA/REPO/dbx-migrated:v1
+      env:
+        MODEL_NAME: DBX_MIGRATED_MODEL
+        MODEL_VERSION: v1
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: 2
+  endpoints:
+    - name: predict
+      port: 8080
+      public: true
+```
+
+## Feature Store Migration
+
+Databricks Feature Store → Snowflake Feature Views:
+
+1. Export feature definitions
+```python
+from databricks import feature_store
+
+fs = feature_store.FeatureStoreClient()
+features = fs.get_table("catalog.schema.features")
+```
+
+2. Recreate in Snowpark
+```python
+# Create feature engineering logic in Snowpark
+from snowflake.snowpark.functions import col, sum, avg
+
+features_df = session.table("RAW_DATA").group_by("ENTITY_ID").agg(
+    sum("AMOUNT").alias("TOTAL_AMOUNT"),
+    avg("AMOUNT").alias("AVG_AMOUNT")
+)
+
+# Register as Feature View (if using Snowflake Feature Store)
+```
+
+## Migration Checklist
+
+- [ ] Identify MLflow model/endpoint
+- [ ] Download model artifacts
+- [ ] Parse MLmodel for framework
+- [ ] Extract conda dependencies
+- [ ] Register in Snowflake Model Registry
+- [ ] Wrap with CustomModel if pyfunc/pytorch/tensorflow
+- [ ] Deploy to SPCS if real-time inference needed
+- [ ] Migrate Feature Store definitions if used
+- [ ] Validate inference results match

--- a/skills/ml-migration/references/platforms/databricks/training.md
+++ b/skills/ml-migration/references/platforms/databricks/training.md
@@ -1,0 +1,233 @@
+# Databricks/MLflow: Training Migration
+
+Migrating Databricks notebooks and MLflow training workflows to Snowflake ML Jobs.
+
+## Concept Mapping
+
+| Databricks | Snowflake | Notes |
+|------------|-----------|-------|
+| Workspace | Database/Schema | Namespace mapping |
+| Cluster | Compute Pool | CPU_X64_*/GPU_NV_* |
+| Notebook | ML Job script | Convert to Python |
+| MLflow experiment | Model Registry + returns | Manual tracking |
+| MLflow Model Registry | Snowflake Model Registry | Model storage |
+| Delta Lake table | Snowflake Table | Data storage |
+| DBFS | Snowflake Stage | File storage |
+| Spark DataFrame | Snowpark DataFrame | API conversion |
+| dbutils | Stage operations | File utilities |
+
+## MLflow Autologging Migration
+
+### Databricks + MLflow Autolog
+```python
+import mlflow
+
+mlflow.autolog()
+
+df = spark.read.table("catalog.schema.data").toPandas()
+model = RandomForestClassifier(n_estimators=100)
+model.fit(X_train, y_train)
+# MLflow auto-logs params, metrics, model
+```
+
+### Snowflake Manual Tracking
+```python
+from snowflake.ml.jobs import remote
+from snowflake.ml.registry import Registry
+
+@remote("CPU_X64_M", stage_name="TRAINING_STAGE", pip_requirements=["scikit-learn"])
+def train(training_table: str, n_estimators: int = 100):
+    from snowflake.snowpark import Session
+    
+    session = Session.builder.getOrCreate()
+    df = session.table(training_table).to_pandas()
+    
+    X_train, X_test, y_train, y_test = train_test_split(df)
+    
+    model = RandomForestClassifier(n_estimators=n_estimators)
+    model.fit(X_train, y_train)
+    accuracy = model.score(X_test, y_test)
+    
+    # Manual tracking via return + registry
+    registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+    registry.log_model(
+        model,
+        model_name="RF_MODEL",
+        version_name="V1",
+        metrics={"accuracy": accuracy}
+    )
+    
+    return {
+        "model": model,
+        "metrics": {"accuracy": accuracy},
+        "params": {"n_estimators": n_estimators}
+    }
+```
+
+## Hyperopt Migration
+
+### Databricks Hyperopt + SparkTrials
+```python
+from hyperopt import fmin, tpe, hp, SparkTrials
+
+search_space = {
+    "lr": hp.loguniform("lr", -5, -1),
+    "n_est": hp.quniform("n_est", 50, 500, 1)
+}
+
+spark_trials = SparkTrials(parallelism=4)
+
+best = fmin(
+    train_fn,
+    search_space,
+    algo=tpe.suggest,
+    max_evals=50,
+    trials=spark_trials
+)
+```
+
+### Snowflake Tuner
+```python
+from snowflake.ml.modeling.tune import Tuner, TunerConfig
+from snowflake.ml.modeling.tune import loguniform, randint
+from snowflake.ml.modeling.tune.search import RandomSearch
+
+def train_func(config, dataset_map):
+    lr = config["lr"]
+    n_est = config["n_est"]
+    train_df = dataset_map["train"]
+    
+    model = train_model(train_df, lr=lr, n_estimators=n_est)
+    accuracy = evaluate(model)
+    return {"accuracy": accuracy}
+
+search_space = {
+    "lr": loguniform(1e-5, 0.1),
+    "n_est": randint(50, 500)
+}
+
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=RandomSearch(),
+    num_trials=50,
+    max_concurrent_trials=4
+)
+
+tuner = Tuner(train_func, search_space, tuner_config)
+results = tuner.run(dataset_map={"train": train_df})
+```
+
+## TorchDistributor Migration
+
+### Databricks TorchDistributor
+```python
+from pyspark.ml.torch.distributor import TorchDistributor
+
+distributor = TorchDistributor(
+    num_processes=4,
+    local_mode=False,
+    use_gpu=True
+)
+
+result = distributor.run(train_fn)
+```
+
+### Snowflake + Ray
+```python
+from snowflake.ml.jobs import remote
+
+@remote(
+    compute_pool="GPU_NV_S",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["torch", "ray[train]"],
+    target_instances=4
+)
+def train_distributed(training_table: str):
+    import ray
+    from ray.train.torch import TorchTrainer
+    from ray.train import ScalingConfig
+    
+    ray.init()
+    
+    trainer = TorchTrainer(
+        train_fn,
+        scaling_config=ScalingConfig(
+            num_workers=4,
+            use_gpu=True
+        )
+    )
+    return trainer.fit()
+```
+
+## Notebook Conversion
+
+### Key Differences
+| Databricks Notebook | Snowflake ML Job |
+|--------------------|------------------|
+| `%sql SELECT ...` | `session.sql("SELECT ...")` |
+| `%python` cells | Python script |
+| `display(df)` | Return df or print |
+| `dbutils.widgets` | Function parameters |
+| `%run ./other_notebook` | Import module |
+
+### Example Conversion
+```python
+# BEFORE: Databricks notebook cells
+
+# Cell 1: %sql
+# CREATE TABLE features AS SELECT ...
+
+# Cell 2: %python
+df = spark.read.table("features")
+model = train(df)
+mlflow.log_model(model, "model")
+
+# AFTER: Snowflake ML Job
+from snowflake.ml.jobs import remote
+
+@remote("CPU_X64_M", stage_name="TRAINING_STAGE")
+def train_job(input_table: str):
+    from snowflake.snowpark import Session
+    from snowflake.ml.registry import Registry
+    
+    session = Session.builder.getOrCreate()
+    
+    # Create features table
+    session.sql("""
+        CREATE TABLE IF NOT EXISTS features AS SELECT ...
+    """).collect()
+    
+    # Train model
+    df = session.table("features").to_pandas()
+    model = train(df)
+    
+    # Log model
+    registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+    registry.log_model(model, model_name="MODEL", version_name="V1")
+    
+    return model
+```
+
+## MLflow Logging Conversion
+
+| MLflow | Snowflake | Notes |
+|--------|-----------|-------|
+| `mlflow.log_param("key", val)` | Return in dict | `{"params": {"key": val}}` |
+| `mlflow.log_metric("key", val)` | Return or Registry | `metrics={"key": val}` |
+| `mlflow.log_model(model)` | `registry.log_model()` | Model Registry |
+| `mlflow.log_artifact("path")` | Stage upload | `session.file.put()` |
+| `mlflow.autolog()` | Manual tracking | Must be explicit |
+
+## Conversion Checklist
+
+- [ ] Replace `spark.read.table()` with `session.table()`
+- [ ] Replace `mlflow.autolog()` with manual tracking
+- [ ] Replace `mlflow.log_model()` with `registry.log_model()`
+- [ ] Replace `mlflow.log_param/metric()` with return values
+- [ ] Replace `TorchDistributor` with Ray
+- [ ] Replace `SparkTrials` / Hyperopt with Snowflake Tuner
+- [ ] Replace `dbutils.fs.*` with stage operations
+- [ ] Convert `.toPandas()` to `.to_pandas()`
+- [ ] Convert notebook cells to Python script
+- [ ] Replace `display()` with return or logging

--- a/skills/ml-migration/references/platforms/sagemaker/common.md
+++ b/skills/ml-migration/references/platforms/sagemaker/common.md
@@ -1,0 +1,110 @@
+# AWS SageMaker - Common
+
+Shared patterns for SageMaker migrations to Snowflake.
+
+## Platform Detection
+
+**Indicators that source is SageMaker:**
+
+| Pattern | Example |
+|---------|---------|
+| SageMaker ARN | `arn:aws:sagemaker:us-west-2:123456789:endpoint/my-endpoint` |
+| SM_* environment variables | `SM_MODEL_DIR`, `SM_CHANNEL_TRAINING` |
+| SageMaker SDK imports | `import sagemaker`, `from sagemaker.pytorch import PyTorch` |
+| /opt/ml/* paths | `/opt/ml/model`, `/opt/ml/input/data` |
+| S3 model artifacts | `s3://sagemaker-*/model.tar.gz` |
+
+## Asset Mapping
+
+| SageMaker Asset | Snowflake Equivalent | Migration Method |
+|-----------------|---------------------|------------------|
+| Model artifact (S3) | Model Registry | Download → register via inference workflow |
+| Endpoint (real-time) | SPCS Service | Extract model → inference workflow |
+| Endpoint (batch) | Warehouse inference | Register with `target_platforms=[WAREHOUSE]` |
+| Training job | ML Job | Convert script → training workflow |
+| Processing job | Snowpark / SQL | Rewrite in Snowpark |
+| Feature Store | Feature Views | Recreate with Snowflake Feature Store |
+
+## Environment Verification
+
+**Step 1: Verify AWS CLI access**
+
+Ask the user which AWS profile to use, then verify:
+```bash
+aws configure list-profiles
+# User selects profile
+
+aws sts get-caller-identity --profile <selected-profile>
+```
+
+**Step 2: Verify Snowflake resources**
+
+```sql
+-- 1. Check current role and grants
+SELECT CURRENT_ROLE();
+SHOW GRANTS TO ROLE <your_role>;
+
+-- 2. Verify image repository exists (for SPCS)
+SHOW IMAGE REPOSITORIES IN SCHEMA <db>.<schema>;
+
+-- 3. Verify compute pool access
+SHOW COMPUTE POOLS;
+
+-- 4. Check external access integration
+SHOW EXTERNAL ACCESS INTEGRATIONS;
+```
+
+## Required Infrastructure
+
+| Resource | Purpose | Creation Command |
+|----------|---------|------------------|
+| Image Repository | Store container images for SPCS | `CREATE IMAGE REPOSITORY IF NOT EXISTS DB.SCHEMA.ML_IMAGES;` |
+| Compute Pool (CPU) | Run inference/training | Use `SYSTEM_COMPUTE_POOL_CPU` or create custom |
+| Compute Pool (GPU) | GPU workloads | Create custom GPU pool |
+| External Access | Install pip packages | `PYPI_ACCESS_INTEGRATION` |
+
+## AWS Authentication
+
+### Profile Selection
+```bash
+# List available profiles
+aws configure list-profiles
+
+# Verify selected profile works
+aws sts get-caller-identity --profile <profile>
+```
+
+### ECR Login (for container images)
+```bash
+# Get ECR login token
+aws ecr get-login-password --region <region> --profile <profile> | \
+  docker login --username AWS --password-stdin <account>.dkr.ecr.<region>.amazonaws.com
+```
+
+### S3 Access
+```bash
+# Download model artifacts
+aws s3 cp s3://bucket/path/model.tar.gz ./model.tar.gz --profile <profile>
+
+# Extract
+tar -xzf model.tar.gz
+```
+
+## Framework Detection from Artifacts
+
+| File Pattern | Framework | Notes |
+|--------------|-----------|-------|
+| `model.pkl`, `*.joblib` | sklearn | Built-in support |
+| `xgboost-model`, `*.ubj` | XGBoost | Check if Booster or sklearn API |
+| `model.pt`, `model.pth` | PyTorch | Need model class definition |
+| `saved_model.pb`, `variables/` | TensorFlow | Built-in support |
+| `inference.py` + custom files | Custom | Requires CustomModel wrapper |
+
+## Common Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `ExpiredToken` | AWS credentials expired | Run `aws sso login --profile <profile>` |
+| `AccessDenied` on S3 | Missing S3 permissions | Check IAM policy for s3:GetObject |
+| `No such bucket` | Wrong region | Verify bucket region matches profile region |
+| ECR login failed | Wrong account/region | Verify ECR URL matches your account |

--- a/skills/ml-migration/references/platforms/sagemaker/inference.md
+++ b/skills/ml-migration/references/platforms/sagemaker/inference.md
@@ -1,0 +1,193 @@
+# AWS SageMaker - Training Migration
+
+Migrating SageMaker training jobs to Snowflake ML Jobs.
+
+## Environment Variable Mapping
+
+| SageMaker | Snowflake Equivalent |
+|-----------|---------------------|
+| `SM_MODEL_DIR` | Return model or Registry |
+| `SM_CHANNEL_TRAINING` | `session.table(training_table)` |
+| `SM_CHANNEL_VALIDATION` | `session.table(validation_table)` |
+| `SM_OUTPUT_DATA_DIR` | Stage upload |
+| `SM_NUM_GPUS` | `torch.cuda.device_count()` |
+| `SM_HP_<NAME>` | Function parameter |
+
+## Script Mode → submit_file / @remote
+
+```python
+# BEFORE: SageMaker entry point
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epochs", type=int, default=10)
+    args = parser.parse_args()
+    
+    train_dir = os.environ["SM_CHANNEL_TRAINING"]
+    train_data = pd.read_csv(f"{train_dir}/train.csv")
+    model = train(train_data, args.epochs)
+    
+    model_dir = os.environ["SM_MODEL_DIR"]
+    joblib.dump(model, f"{model_dir}/model.pkl")
+
+# AFTER: Snowflake ML Job (using @remote for simple cases)
+@remote("CPU_X64_M", stage_name="TRAINING_STAGE", pip_requirements=["scikit-learn"])
+def train(training_table: str, epochs: int = 10):
+    from snowflake.snowpark import Session
+    from snowflake.ml.registry import Registry
+    
+    session = Session.builder.getOrCreate()
+    train_data = session.table(training_table).to_pandas()
+    model = train_model(train_data, epochs)
+    
+    # MANDATORY: Register model
+    registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+    registry.log_model(model, model_name="MY_MODEL", version_name="V1")
+    return model
+
+job = train("DB.SCHEMA.TRAINING_DATA", epochs=10)
+```
+
+**Preferred approach using submit_file:**
+```python
+# launcher.py (runs locally)
+from snowflake.ml.jobs import submit_file
+
+job = submit_file(
+    "train.py",
+    "CPU_X64_M",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["scikit-learn", "pandas"]
+)
+result = job.result()
+```
+
+## PyTorch Estimator → ML Jobs
+
+```python
+# BEFORE: SageMaker PyTorch
+from sagemaker.pytorch import PyTorch
+estimator = PyTorch(
+    entry_point="train.py",
+    instance_type="ml.p3.2xlarge",
+    instance_count=1,
+    hyperparameters={"epochs": 10, "batch-size": 32}
+)
+estimator.fit({"training": "s3://bucket/training"})
+
+# AFTER: Snowflake ML Job
+from snowflake.ml.jobs import submit_file
+
+# train.py contains the training logic
+job = submit_file(
+    "train.py",
+    "GPU_NV_S",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["torch"],
+    args=["--epochs", "10", "--batch-size", "32"]
+)
+```
+
+Or using @remote:
+```python
+@remote("GPU_NV_S", stage_name="TRAINING_STAGE", pip_requirements=["torch"])
+def train(training_table: str, epochs: int = 10, batch_size: int = 32):
+    import torch
+    from snowflake.snowpark import Session
+    
+    session = Session.builder.getOrCreate()
+    train_data = session.table(training_table).to_pandas()
+    
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    # Same training logic
+    return model
+```
+
+## SageMaker Distributed → Ray
+
+```python
+# BEFORE: SageMaker distributed
+estimator = PyTorch(
+    instance_count=4,
+    instance_type="ml.p3.16xlarge",
+    distribution={"pytorchddp": {"enabled": True}}
+)
+
+# AFTER: Snowflake + Ray
+@remote("GPU_NV_S", stage_name="TRAINING_STAGE", pip_requirements=["torch", "ray[train]"], target_instances=4)
+def train_distributed(training_table: str):
+    import ray
+    from ray.train.torch import TorchTrainer
+    from ray.train import ScalingConfig
+    
+    ray.init()
+    trainer = TorchTrainer(
+        train_func,
+        scaling_config=ScalingConfig(num_workers=4, use_gpu=True)
+    )
+    return trainer.fit()
+```
+
+## SageMaker HPO → Snowflake Tuner
+
+**⚠️ CRITICAL:** Tuner API only available in Container Runtime. Put this code in the training script, not the launcher.
+
+```python
+# BEFORE: SageMaker tuner
+from sagemaker.tuner import HyperparameterTuner, ContinuousParameter, IntegerParameter
+tuner = HyperparameterTuner(
+    estimator,
+    objective_metric_name="validation:accuracy",
+    hyperparameter_ranges={
+        "learning-rate": ContinuousParameter(0.001, 0.1),
+        "batch-size": IntegerParameter(16, 128)
+    },
+    max_jobs=20
+)
+
+# AFTER: Snowflake Tuner (in training script that runs in Container Runtime)
+from snowflake.ml.modeling.tune import Tuner, TunerConfig, loguniform, randint
+from snowflake.ml.modeling.tune.search import RandomSearch
+
+search_space = {
+    "learning_rate": loguniform(0.001, 0.1),
+    "batch_size": randint(16, 128)  # Use RandomSearch for integer params
+}
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=RandomSearch(),  # NOT BayesOpt - it doesn't support integers
+    num_trials=20
+)
+tuner = Tuner(train_func, search_space, tuner_config)
+results = tuner.run(dataset_map=dataset_map)
+```
+
+**HPO Parameter Type Mapping:**
+
+| SageMaker | Snowflake | Notes |
+|-----------|-----------|-------|
+| `ContinuousParameter(0.001, 0.1)` | `uniform(0.001, 0.1)` or `loguniform(0.001, 0.1)` | Use loguniform for learning rates |
+| `IntegerParameter(16, 128)` | `randint(16, 128)` | **Only with RandomSearch** |
+| `CategoricalParameter(["a", "b"])` | `choice(["a", "b"])` | **Only with RandomSearch** |
+
+**⚠️ BayesOpt limitation:** Only supports `uniform()` and `loguniform()`. If you need integers or categoricals, use `RandomSearch()`.
+
+## Conversion Checklist
+
+- [ ] Replace `SM_CHANNEL_*` with `session.table()`
+- [ ] Replace `SM_MODEL_DIR` with Registry `log_model()`
+- [ ] Convert argparse to function parameters (for @remote) or keep argparse (for submit_file)
+- [ ] Replace SageMaker distributed with Ray integration
+- [ ] Replace `HyperparameterTuner` with Snowflake Tuner (in training script)
+- [ ] Add model registration (MANDATORY - return values not accessible with submit_file)
+- [ ] Extract dependencies to `pip_requirements`
+- [ ] Select appropriate compute pool (CPU vs GPU)
+
+## Common Issues
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `ModuleNotFoundError: snowflake.ml.modeling.tune` | Trying to import Tuner locally | Tuner only available in Container Runtime - put in training script |
+| Model not saved | Missing registry.log_model() | Always register model - return values not accessible |
+| Python version mismatch | Local Python != 3.10 | Use submit_file instead of @remote |
+| `BayesOpt does not support Integer` | Using randint with BayesOpt | Switch to RandomSearch |

--- a/skills/ml-migration/references/platforms/sagemaker/training.md
+++ b/skills/ml-migration/references/platforms/sagemaker/training.md
@@ -1,0 +1,237 @@
+# AWS SageMaker - Inference Migration
+
+Migrating SageMaker endpoints and models to Snowflake Model Registry and SPCS.
+
+## Endpoint Discovery
+
+### Connect and Describe Endpoint
+```python
+import boto3
+
+client = boto3.client('sagemaker', region_name='us-west-2')
+
+# Get endpoint details
+endpoint = client.describe_endpoint(EndpointName='YOUR_ENDPOINT')
+config = client.describe_endpoint_config(
+    EndpointConfigName=endpoint['EndpointConfigName']
+)
+model = client.describe_model(
+    ModelName=config['ProductionVariants'][0]['ModelName']
+)
+
+# Get S3 artifact location
+model_data_url = model['PrimaryContainer']['ModelDataUrl']
+# e.g., s3://bucket/path/model.tar.gz
+```
+
+### Download and Extract Model
+```bash
+# Download model.tar.gz from S3
+aws s3 cp s3://bucket/path/model.tar.gz ./aws_models/model.tar.gz --profile <profile>
+
+# Extract to get model files
+cd ./aws_models
+tar -xzf model.tar.gz
+# Results: model.pth, model.pkl, or custom files
+```
+
+## Migration Strategy Decision
+
+| Strategy | When to Use | Pros | Cons |
+|----------|-------------|------|------|
+| **Docker lift-and-shift** | Preserve exact behavior, complex inference logic | True lift-and-shift, no code changes | No SQL integration, manual versioning |
+| **Model Registry + SPCS** | Want SQL integration, versioning, governance | Native `MODEL!PREDICT()`, built-in lineage | Requires model extraction |
+
+**Ask user:**
+```
+How would you like to migrate this endpoint?
+
+1. Container migration (lift-and-shift)
+   Pull existing container and deploy to SPCS as-is.
+
+2. Model extraction (native registration)
+   Extract model, register in Snowflake Model Registry.
+```
+
+## Deployment Decision Matrix
+
+| Use Case | Target Platform | Registration |
+|----------|-----------------|--------------|
+| Batch inference (SQL) | `WAREHOUSE` | Simple, SQL-integrated |
+| Real-time API endpoint | `SNOWPARK_CONTAINER_SERVICES` | Requires SPCS setup |
+| GPU acceleration | `SNOWPARK_CONTAINER_SERVICES` | GPU compute pool required |
+
+## Model Registration
+
+**⛔ For `log_model()` API patterns, see:** `../../../../model-registry/SKILL.md`
+
+The patterns below are platform-specific extraction and conversion logic.
+
+### Built-in Framework Registration (PyTorch Example)
+```python
+import torch
+from snowflake.ml.registry import Registry
+from snowflake.ml.model.target_platform import TargetPlatform
+
+# Load model (must define class matching training)
+class Net(torch.nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.fc = torch.nn.Linear(10, 1)
+    def forward(self, x):
+        return self.fc(x)
+
+model = Net()
+model.load_state_dict(torch.load("model.pth", map_location='cpu', weights_only=True))
+model.eval()
+
+# Register with SPCS target
+reg = Registry(session=session, database_name="DB", schema_name="SCHEMA")
+
+mv = reg.log_model(
+    model=model,
+    model_name="PYTORCH_SAGEMAKER_MODEL",
+    version_name="V1",
+    sample_input_data=torch.rand(5, 10),  # REQUIRED for schema inference
+    target_platforms=[TargetPlatform.SNOWPARK_CONTAINER_SERVICES],
+    comment="Migrated from SageMaker endpoint: <endpoint_name>"
+)
+```
+
+### CustomModel for Complex Logic
+
+When model has custom preprocessing or isn't natively supported:
+
+⚠️ **CRITICAL:** Use `artifacts` dict + `context.path()`, NOT `models` dict + `model_ref()`:
+
+```python
+from snowflake.ml.model import custom_model
+import pandas as pd
+import pickle
+
+class MyCustomModel(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        # Load model using context.path() - NOT model_ref
+        with open(context.path('model.pkl'), 'rb') as f:
+            self.model = pickle.load(f)
+    
+    @custom_model.inference_api
+    def predict(self, X: pd.DataFrame) -> pd.DataFrame:
+        # Custom preprocessing
+        processed = self._preprocess(X)
+        # Model inference
+        predictions = self.model.predict(processed)
+        # Custom postprocessing
+        return pd.DataFrame({'prediction': predictions})
+    
+    def _preprocess(self, X):
+        # Your preprocessing logic from inference.py
+        return X
+
+# Save model to file first
+with open('/tmp/model.pkl', 'wb') as f:
+    pickle.dump(loaded_model, f)
+
+# Create context with artifacts
+mc = custom_model.ModelContext(artifacts={'model.pkl': '/tmp/model.pkl'})
+model = MyCustomModel(mc)
+
+mv = reg.log_model(
+    model=model,
+    model_name="CUSTOM_SAGEMAKER_MODEL",
+    version_name="V1",
+    sample_input_data=sample_df,
+    target_platforms=[TargetPlatform.SNOWPARK_CONTAINER_SERVICES]
+)
+```
+
+## SPCS Deployment
+
+### Service Ingress Configuration
+
+**⚠️ STOPPING POINT: Ask user for ingress preference FIRST:**
+
+```
+How should the service be accessed?
+
+1. Public ingress - HTTP access from outside Snowflake
+   Requires BIND SERVICE ENDPOINT privilege on your role
+   
+2. Internal-only - Service only callable via SQL/Python within Snowflake
+   No additional privileges required
+
+Which do you prefer?
+```
+
+**If user chose Public ingress, CHECK privilege:**
+```sql
+SHOW GRANTS TO ROLE <user_role>;
+-- Look for: BIND SERVICE ENDPOINT on ACCOUNT
+```
+
+**⛔ If user chose Public but lacks privilege - DO NOT silently downgrade to internal.**
+
+### Deploy as Service
+
+```python
+mv.create_service(
+    service_name="MY_INFERENCE_ENDPOINT",
+    service_compute_pool="SYSTEM_COMPUTE_POOL_CPU",  # or custom GPU pool
+    image_repo="DB.SCHEMA.ML_IMAGES",
+    build_external_access_integration="PYPI_ACCESS_INTEGRATION",
+    ingress_enabled=True,  # Set to False ONLY if user explicitly chose internal-only
+    gpu_requests=None,      # Set for GPU models
+    max_instances=1
+)
+```
+
+### Monitor Deployment
+```sql
+-- Check service status
+SHOW SERVICES IN SCHEMA DB.SCHEMA;
+
+-- View service logs
+SELECT SYSTEM$GET_SERVICE_LOGS('DB.SCHEMA.MY_INFERENCE_ENDPOINT', 0, 'model-inference');
+```
+
+## Usage After Migration
+
+### Python (SPCS Endpoint)
+```python
+mv = reg.get_model("MODEL_NAME").version("V1")
+result = mv.run(
+    input_data, 
+    function_name="predict",  # or "forward" for PyTorch
+    service_name="MY_INFERENCE_ENDPOINT"
+)
+```
+
+### SQL (Warehouse)
+```sql
+SELECT MODEL_NAME!PREDICT(col1, col2, ...):prediction 
+FROM my_table;
+
+-- PyTorch forward
+SELECT MODEL_NAME!FORWARD(feature_array) 
+FROM my_table;
+```
+
+## Common Issues & Solutions
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `cloudpickle <=2.2.1 conflict` | Python 3.8/3.9 | **Use Python 3.11+** |
+| `image_repo required` | Missing repository | Create IMAGE REPOSITORY first |
+| `compute pool not authorized` | Pool access denied | Use SYSTEM_COMPUTE_POOL_CPU |
+| `BIND SERVICE ENDPOINT privilege` | Missing privilege | Get privilege or use internal-only |
+| `type not supported` | Wrong model wrapper | Use CustomModel with ModelContext |
+| Build timeout (10-15 min) | Large dependencies (PyTorch) | Wait, it's normal |
+| `sample_input_data required` | Schema inference fails | Always provide sample input |
+
+## Migration Timeline
+
+Based on production migrations:
+- **First migration**: ~2 hours (environment setup + learning)
+- **Subsequent migrations**: 15-30 minutes
+- **Build time for SPCS**: 5-15 minutes (PyTorch longer than sklearn)

--- a/skills/ml-migration/references/platforms/vertex-ai/common.md
+++ b/skills/ml-migration/references/platforms/vertex-ai/common.md
@@ -1,0 +1,106 @@
+# Vertex AI: Common Reference
+
+Shared patterns and utilities for migrating from Google Vertex AI to Snowflake.
+
+## Platform Detection
+
+### Indicators
+```python
+# SDK imports
+from google.cloud import aiplatform
+from google.cloud import storage
+from google.cloud.aiplatform import hyperparameter_tuning as hpt
+
+# File patterns
+"gs://"                    # GCS URIs in code
+"aiplatform.init("         # SDK initialization
+"us-docker.pkg.dev/vertex-ai/"  # Pre-built containers
+```
+
+### Detection Logic
+```python
+def detect_vertex_ai():
+    indicators = [
+        grep_files("from google.cloud import aiplatform"),
+        grep_files("aiplatform.init"),
+        grep_files(r"gs://"),
+        grep_files("CustomJob"),
+    ]
+    return any(indicators)
+```
+
+## Asset Mapping
+
+| Vertex AI Asset | Snowflake Equivalent | Migration Path |
+|-----------------|---------------------|----------------|
+| Project | Database | Map project to database |
+| Model Registry | Model Registry | Download → register |
+| Endpoint | SPCS Service | Extract → deploy |
+| CustomJob | @remote decorator | Convert script |
+| HyperparameterTuningJob | Snowflake Tuner | HPO migration |
+| Worker Pool | Compute Pool | CPU_X64/GPU_NV |
+| Pipeline | Tasks/Python | Orchestration |
+| Feature Store | Feature Views | Recreate |
+| Dataset | Table/Stage | Load via connector |
+
+## GCP Authentication
+
+### SDK Initialization
+```python
+from google.cloud import aiplatform
+
+aiplatform.init(
+    project="my-project",
+    location="us-central1"
+)
+```
+
+### Required GCP Permissions
+- `roles/aiplatform.user` - Access models, endpoints
+- `roles/storage.objectViewer` - Download from GCS
+- `roles/aiplatform.viewer` - List resources
+
+## Environment Verification
+
+### Prerequisites Checklist
+- [ ] GCP CLI authenticated (`gcloud auth login`)
+- [ ] Project ID available
+- [ ] Region/location confirmed
+- [ ] `google-cloud-aiplatform` package installed
+- [ ] Service account or user credentials configured
+
+### Validate Access
+```python
+from google.cloud import aiplatform
+
+aiplatform.init(project="my-project", location="us-central1")
+models = aiplatform.Model.list()
+print(f"Found {len(models)} models")
+```
+
+## Environment Variable Mapping
+
+| Vertex AI | Snowflake Equivalent | Notes |
+|-----------|---------------------|-------|
+| `AIP_MODEL_DIR` | Return model or Registry | Model output |
+| `AIP_TRAINING_DATA_URI` | `session.table()` | Training data |
+| `AIP_CHECKPOINT_DIR` | Stage path | Checkpointing |
+| `CLUSTER_SPEC` | Ray cluster config | Distributed |
+
+## Pre-built Container Mapping
+
+| Vertex AI Container | Snowflake pip_requirements |
+|--------------------|-----------------------------|
+| `pytorch-gpu.2-0` | `["torch==2.0"]` |
+| `tensorflow-gpu.2-12` | `["tensorflow==2.12"]` |
+| `sklearn-cpu.1-0` | sklearn pre-installed |
+| `xgboost-cpu.1-6` | xgboost pre-installed |
+
+## Data Source Migration
+
+| Vertex AI Source | Snowflake Target | Method |
+|------------------|------------------|--------|
+| GCS bucket | External Stage | `gcs://bucket/path` |
+| BigQuery | Table | BigQuery connector |
+| Cloud SQL | Table | ETL or connector |
+| Vertex Dataset | Table | Export → load |

--- a/skills/ml-migration/references/platforms/vertex-ai/inference.md
+++ b/skills/ml-migration/references/platforms/vertex-ai/inference.md
@@ -1,0 +1,209 @@
+# Vertex AI: Inference Migration
+
+Migrating Vertex AI models and endpoints to Snowflake for inference.
+
+## Model Discovery
+
+### List Models
+```python
+from google.cloud import aiplatform
+
+aiplatform.init(project="my-project", location="us-central1")
+
+models = aiplatform.Model.list()
+for model in models:
+    print(f"{model.display_name}: {model.resource_name}")
+```
+
+### Get Model Details
+```python
+model = aiplatform.Model(model_name="projects/.../models/...")
+print(f"Container: {model.container_spec}")
+print(f"Artifact URI: {model.artifact_uri}")
+print(f"Export formats: {model.supported_export_formats}")
+```
+
+## Endpoint Discovery
+
+### List Endpoints
+```python
+endpoints = aiplatform.Endpoint.list()
+for ep in endpoints:
+    print(f"{ep.display_name}: {ep.resource_name}")
+```
+
+### Get Deployed Models
+```python
+endpoint = aiplatform.Endpoint(endpoint_name="projects/.../endpoints/...")
+for deployed in endpoint.gca_resource.deployed_models:
+    print(f"Model: {deployed.model}")
+    print(f"Container: {deployed.private_endpoints}")
+```
+
+## Model Export
+
+### From Model Registry
+```python
+model = aiplatform.Model(model_name="projects/.../models/...")
+model.export_model(
+    export_format_id="tf-saved-model",  # or "custom-trained"
+    artifact_destination="gs://bucket/export/"
+)
+```
+
+### Download from GCS
+```bash
+gsutil cp -r gs://bucket/model/* ./model/
+```
+
+### Export Format Options
+- `tf-saved-model` - TensorFlow SavedModel
+- `custom-trained` - Original training artifacts
+- Check `model.supported_export_formats` for available options
+
+## Framework Detection
+
+| Vertex AI Container | Framework | Snowflake Registration |
+|--------------------|-----------|------------------------|
+| `us-docker.pkg.dev/.../sklearn-*` | sklearn | Direct log_model() |
+| `us-docker.pkg.dev/.../xgboost-*` | XGBoost | Direct log_model() |
+| `us-docker.pkg.dev/.../pytorch-*` | PyTorch | log_model() or CustomModel |
+| `us-docker.pkg.dev/.../tf-*` | TensorFlow | log_model() or CustomModel |
+| Custom container | Custom | SPCS deployment |
+
+## Snowflake Registration
+
+**⛔ For `log_model()` API patterns, see:** `../../../../model-registry/SKILL.md`
+
+The patterns below are platform-specific extraction and conversion logic.
+
+### Direct Registration (sklearn, xgboost)
+```python
+from snowflake.ml.registry import Registry
+
+registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+
+# Load exported model
+import joblib
+model = joblib.load("./model/model.pkl")
+
+# Register
+mv = registry.log_model(
+    model,
+    model_name="VERTEX_MIGRATED_MODEL",
+    version_name="v1",
+    conda_dependencies=["scikit-learn"],
+    sample_input_data=sample_df
+)
+```
+
+### CustomModel for Complex Types
+```python
+from snowflake.ml.model import custom_model
+import tensorflow as tf
+
+class VertexModelWrapper(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        self.model = tf.saved_model.load(context.path("saved_model"))
+    
+    @custom_model.inference_api
+    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
+        inputs = input_df.values
+        predictions = self.model.signatures["serving_default"](
+            tf.constant(inputs, dtype=tf.float32)
+        )
+        return pd.DataFrame({"prediction": predictions["output_0"].numpy()})
+
+# Register
+mv = registry.log_model(
+    VertexModelWrapper,
+    model_name="VERTEX_TF_MODEL",
+    version_name="v1",
+    artifacts={"saved_model": "./model/saved_model"}
+)
+```
+
+## Custom Prediction Routine Migration
+
+### Vertex CPR Pattern
+```python
+# Vertex predictor.py
+class Predictor:
+    def __init__(self):
+        pass
+    
+    def load(self, artifacts_dir):
+        self._model = joblib.load(os.path.join(artifacts_dir, "model.pkl"))
+    
+    def predict(self, instances):
+        return self._model.predict(instances).tolist()
+```
+
+### Snowflake CustomModel Equivalent
+```python
+from snowflake.ml.model import custom_model
+
+class VertexCPRWrapper(custom_model.CustomModel):
+    def __init__(self, context: custom_model.ModelContext):
+        super().__init__(context)
+        import joblib
+        # load() logic here
+        self._model = joblib.load(context.path("model.pkl"))
+    
+    @custom_model.inference_api
+    def predict(self, input_df: pd.DataFrame) -> pd.DataFrame:
+        # predict() logic here
+        instances = input_df.values.tolist()
+        predictions = self._model.predict(instances)
+        return pd.DataFrame({"prediction": predictions})
+```
+
+## SPCS Deployment
+
+### Service Specification
+```yaml
+spec:
+  containers:
+    - name: inference
+      image: /DB/SCHEMA/REPO/vertex-migrated:v1
+      env:
+        MODEL_NAME: VERTEX_MIGRATED_MODEL
+        MODEL_VERSION: v1
+      resources:
+        requests:
+          memory: 4Gi
+          cpu: 2
+  endpoints:
+    - name: predict
+      port: 8080
+      public: true
+```
+
+## AutoML Model Considerations
+
+AutoML models have limited export options:
+
+| AutoML Type | Export Support | Migration Path |
+|-------------|----------------|----------------|
+| Tables | TensorFlow SavedModel | Export → CustomModel |
+| Vision | Limited | May require re-training |
+| NLP | Limited | May require re-training |
+
+Check available formats:
+```python
+model = aiplatform.Model(model_name="...")
+print(model.supported_export_formats)
+```
+
+## Migration Checklist
+
+- [ ] Identify Vertex model/endpoint
+- [ ] Check supported export formats
+- [ ] Export model artifacts
+- [ ] Download from GCS
+- [ ] Detect framework from container
+- [ ] Register in Snowflake Model Registry
+- [ ] Wrap with CustomModel if needed (TF, PyTorch, CPR)
+- [ ] Deploy to SPCS if real-time inference needed
+- [ ] Validate inference results match

--- a/skills/ml-migration/references/platforms/vertex-ai/training.md
+++ b/skills/ml-migration/references/platforms/vertex-ai/training.md
@@ -1,0 +1,221 @@
+# Vertex AI: Training Migration
+
+Migrating Vertex AI custom training jobs to Snowflake ML Jobs.
+
+## Concept Mapping
+
+| Vertex AI | Snowflake | Notes |
+|-----------|-----------|-------|
+| Project | Database | Namespace |
+| CustomJob | @remote decorator | Or submit_file() |
+| HyperparameterTuningJob | Snowflake Tuner | HPO migration |
+| Worker Pool | Compute Pool | CPU_X64_*/GPU_NV_* |
+| Pre-built container | Container Runtime | + pip_requirements |
+| GCS bucket | Snowflake Stage | Data storage |
+| Vertex AI Model | Model Registry | Model storage |
+
+## CustomJob Migration
+
+### Vertex AI CustomJob
+```python
+from google.cloud import aiplatform
+
+job = aiplatform.CustomJob.from_local_script(
+    display_name="pytorch-training",
+    script_path="train.py",
+    container_uri="us-docker.pkg.dev/vertex-ai/training/pytorch-gpu.2-0:latest",
+    requirements=["pandas==2.0.0"],
+    args=["--epochs", "10", "--data-uri", "gs://bucket/data"],
+    machine_type="n1-standard-8",
+    accelerator_type="NVIDIA_TESLA_V100"
+)
+job.run()
+```
+
+### Snowflake Equivalent
+```python
+from snowflake.ml.jobs import remote
+
+@remote(
+    compute_pool="GPU_NV_S",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["torch", "pandas==2.0.0"]
+)
+def train(training_table: str, epochs: int = 10):
+    from snowflake.snowpark import Session
+    session = Session.builder.getOrCreate()
+    
+    train_df = session.table(training_table).to_pandas()
+    model = train_model(train_df, epochs)
+    return model
+```
+
+## HyperparameterTuningJob Migration
+
+### Vertex AI HPO
+```python
+from google.cloud.aiplatform import hyperparameter_tuning as hpt
+
+hp_job = aiplatform.HyperparameterTuningJob(
+    display_name="hp-tuning",
+    custom_job=job,
+    metric_spec={"accuracy": "maximize"},
+    parameter_spec={
+        "learning_rate": hpt.DoubleParameterSpec(min=0.001, max=0.1, scale="log"),
+        "n_estimators": hpt.IntegerParameterSpec(min=10, max=200),
+        "max_depth": hpt.DiscreteParameterSpec(values=[3, 5, 7, 10])
+    },
+    max_trial_count=20,
+    parallel_trial_count=4
+)
+hp_job.run()
+```
+
+### Snowflake Tuner
+```python
+from snowflake.ml.modeling.tune import Tuner, TunerConfig
+from snowflake.ml.modeling.tune import loguniform, randint, choice
+from snowflake.ml.modeling.tune.search import RandomSearch
+
+def train_func(config, dataset_map):
+    lr = config["learning_rate"]
+    n_estimators = config["n_estimators"]
+    max_depth = config["max_depth"]
+    train_df = dataset_map["train"]
+    
+    model = train_model(train_df, lr=lr, n_estimators=n_estimators, max_depth=max_depth)
+    accuracy = evaluate(model)
+    return {"accuracy": accuracy}
+
+search_space = {
+    "learning_rate": loguniform(0.001, 0.1),
+    "n_estimators": randint(10, 200),
+    "max_depth": choice([3, 5, 7, 10])
+}
+
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=RandomSearch(),
+    num_trials=20,
+    max_concurrent_trials=4
+)
+
+tuner = Tuner(train_func, search_space, tuner_config)
+results = tuner.run(dataset_map={"train": train_df})
+```
+
+## Distributed Training Migration
+
+### Vertex AI Distributed
+```python
+job = aiplatform.CustomJob(
+    worker_pool_specs=[
+        {
+            "machine_spec": {
+                "accelerator_type": "NVIDIA_TESLA_V100",
+                "accelerator_count": 2
+            },
+            "replica_count": 1
+        },
+        {
+            "machine_spec": {
+                "accelerator_type": "NVIDIA_TESLA_V100",
+                "accelerator_count": 2
+            },
+            "replica_count": 3
+        }
+    ]
+)
+```
+
+### Snowflake + Ray
+```python
+from snowflake.ml.jobs import remote
+
+@remote(
+    compute_pool="GPU_NV_S",
+    stage_name="TRAINING_STAGE",
+    pip_requirements=["torch", "ray[train]"],
+    target_instances=4
+)
+def train_distributed(training_table: str):
+    import ray
+    from ray.train.torch import TorchTrainer
+    from ray.train import ScalingConfig
+    
+    ray.init()
+    
+    trainer = TorchTrainer(
+        train_func,
+        scaling_config=ScalingConfig(
+            num_workers=4,
+            use_gpu=True,
+            resources_per_worker={"GPU": 2}
+        )
+    )
+    return trainer.fit()
+```
+
+## Script Conversion Patterns
+
+### GCS Data Access
+```python
+# BEFORE: Vertex AI GCS access
+from google.cloud import storage
+data_uri = os.environ.get("AIP_TRAINING_DATA_URI")
+client = storage.Client()
+bucket = client.bucket("my-bucket")
+blob = bucket.blob("data/train.csv")
+blob.download_to_filename("train.csv")
+df = pd.read_csv("train.csv")
+
+# AFTER: Snowflake table
+from snowflake.snowpark import Session
+session = Session.builder.getOrCreate()
+df = session.table(training_table).to_pandas()
+```
+
+### Model Output
+```python
+# BEFORE: Vertex AI model dir
+model_dir = os.environ.get("AIP_MODEL_DIR")
+joblib.dump(model, os.path.join(model_dir, "model.pkl"))
+
+# AFTER: Snowflake return or registry
+from snowflake.ml.registry import Registry
+
+# Option 1: Return model
+return model
+
+# Option 2: Register model
+registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+registry.log_model(model, model_name="MODEL", version_name="V1")
+```
+
+### Hypertune Reporting
+```python
+# BEFORE: Vertex AI hypertune
+import hypertune
+hpt = hypertune.HyperTune()
+hpt.report_hyperparameter_tuning_metric(
+    hyperparameter_metric_tag="accuracy",
+    metric_value=accuracy
+)
+
+# AFTER: Snowflake Tuner
+# Return metrics from train_func - Tuner handles reporting
+return {"accuracy": accuracy}
+```
+
+## Conversion Checklist
+
+- [ ] Map Vertex project to Snowflake database
+- [ ] Replace `CustomJob` with `@remote` or `submit_file()`
+- [ ] Replace GCS URIs with Snowflake tables/stages
+- [ ] Remove `google.cloud.storage` usage
+- [ ] Replace `AIP_MODEL_DIR` with return or Registry
+- [ ] Replace `HyperparameterTuningJob` with Tuner
+- [ ] Replace distributed worker pools with Ray
+- [ ] Replace `hypertune.report_*` with Tuner return values
+- [ ] Map pre-built containers to pip_requirements

--- a/skills/ml-migration/references/shared/authentication.md
+++ b/skills/ml-migration/references/shared/authentication.md
@@ -1,0 +1,129 @@
+# Snowflake Authentication
+
+Authentication setup for ML workloads in Snowflake.
+
+## Connection Methods
+
+### 1. Connection Name (Recommended)
+```python
+import os
+from snowflake.snowpark import Session
+
+# Set connection name
+os.environ["SNOWFLAKE_CONNECTION_NAME"] = "demo"
+
+# Session auto-discovers connection
+session = Session.builder.getOrCreate()
+```
+
+### 2. Snowflake Connector Config
+```python
+import snowflake.connector
+
+conn = snowflake.connector.connect(
+    connection_name="demo"  # Uses ~/.snowflake/connections.toml
+)
+```
+
+### 3. Explicit Parameters
+```python
+session = Session.builder.configs({
+    "account": "myaccount",
+    "user": "myuser",
+    "password": os.getenv("SNOWFLAKE_PASSWORD"),
+    "warehouse": "COMPUTE_WH",
+    "database": "MY_DB",
+    "schema": "MY_SCHEMA"
+}).create()
+```
+
+## Container Runtime Authentication
+
+Inside ML Jobs (Container Runtime), authentication is automatic:
+
+```python
+# Inside @remote or submit_file() script
+from snowflake.snowpark import Session
+
+# No credentials needed - auto-authenticated
+session = Session.builder.getOrCreate()
+```
+
+## Required Privileges
+
+### For Model Registry
+```sql
+-- Grant to your role
+GRANT CREATE MODEL ON SCHEMA DB.SCHEMA TO ROLE MY_ROLE;
+GRANT USAGE ON DATABASE DB TO ROLE MY_ROLE;
+GRANT USAGE ON SCHEMA DB.SCHEMA TO ROLE MY_ROLE;
+```
+
+### For ML Jobs
+```sql
+-- Compute pool access
+GRANT USAGE ON COMPUTE POOL CPU_X64_M TO ROLE MY_ROLE;
+GRANT USAGE ON COMPUTE POOL GPU_NV_S TO ROLE MY_ROLE;
+
+-- Stage access
+GRANT READ, WRITE ON STAGE TRAINING_STAGE TO ROLE MY_ROLE;
+```
+
+### For SPCS Services
+```sql
+-- Create service
+GRANT CREATE SERVICE ON SCHEMA DB.SCHEMA TO ROLE MY_ROLE;
+
+-- Public endpoints (optional)
+GRANT BIND SERVICE ENDPOINT ON ACCOUNT TO ROLE MY_ROLE;
+
+-- Image repository
+GRANT READ ON IMAGE REPOSITORY DB.SCHEMA.ML_IMAGES TO ROLE MY_ROLE;
+```
+
+### External Access (PyPI)
+```sql
+-- For downloading packages during training
+GRANT USAGE ON INTEGRATION PYPI_ACCESS_INTEGRATION TO ROLE MY_ROLE;
+```
+
+## Verify Permissions
+
+```sql
+-- Check your current role
+SELECT CURRENT_ROLE();
+
+-- List grants
+SHOW GRANTS TO ROLE MY_ROLE;
+
+-- Check specific privileges
+SHOW GRANTS ON COMPUTE POOL CPU_X64_M;
+SHOW GRANTS ON SCHEMA DB.SCHEMA;
+```
+
+## Common Authentication Issues
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| "Permission denied" | Missing grants | Request grants from admin |
+| "Compute pool not found" | Wrong pool name or no access | Check pool exists and grants |
+| "Cannot create model" | Missing CREATE MODEL | Grant CREATE MODEL on schema |
+| "Integration not accessible" | Missing PYPI access | Grant USAGE on integration |
+
+## Multi-Account Setup
+
+For cross-account migrations:
+
+```python
+# Source account connection
+source_session = Session.builder.configs({
+    "account": "source_account",
+    "connection_name": "source_conn"
+}).create()
+
+# Target account connection  
+target_session = Session.builder.configs({
+    "account": "target_account",
+    "connection_name": "target_conn"
+}).create()
+```

--- a/skills/ml-migration/references/shared/config-templates.md
+++ b/skills/ml-migration/references/shared/config-templates.md
@@ -1,0 +1,315 @@
+# Migration Config Templates
+
+Unified configuration file format for ML migrations.
+
+## Config File Location
+
+```
+migration-config.yaml
+```
+
+## ⛔ CRITICAL: Required Reads Tracking
+
+**The `required_reads` section is MANDATORY.** It ensures all reference files are actually read before proceeding.
+
+### How It Works
+
+1. **At each phase**, the skill specifies which files MUST be read
+2. **Before reading**, add the file to `required_reads` with `status: pending`
+3. **After reading** (using the Read tool), update to `status: read`
+4. **Before proceeding** to the next phase, verify ALL required files for that phase show `status: read`
+5. **NEVER proceed** if any required file shows `status: pending`
+
+### Required Reads Section
+
+```yaml
+required_reads:
+  # Phase 0 - Always required
+  - file: "RULES.md"
+    phase: "0"
+    status: pending  # → read (after using Read tool)
+    
+  # Phase 2 - Platform-specific (add based on detected platform)
+  - file: "references/platforms/<platform>/common.md"
+    phase: "2"
+    status: pending
+    
+  # Workflow-specific (add based on detected workflow)
+  # INFERENCE:
+  - file: "references/platforms/<platform>/inference.md"
+    phase: "I1"
+    status: pending
+  - file: "references/shared/config-templates.md"
+    phase: "I3"
+    status: pending
+  - file: "references/inference/source-access.md"
+    phase: "I4"
+    status: pending
+  - file: "../model-registry/SKILL.md"
+    phase: "I7"
+    status: pending
+  - file: "../spcs-inference/SKILL.md"
+    phase: "I7"
+    status: pending  # Only if SPCS deployment
+    
+  # TRAINING:
+  - file: "references/platforms/<platform>/training.md"
+    phase: "T1"
+    status: pending
+  - file: "references/training/frameworks.md"
+    phase: "T2"
+    status: pending
+  - file: "references/training/distributed.md"
+    phase: "T2"
+    status: pending  # Only if distributed/multi-GPU
+  - file: "../ml-jobs/SKILL.md"
+    phase: "T3"
+    status: pending
+  - file: "references/shared/config-templates.md"
+    phase: "T4"
+    status: pending
+```
+
+### Verification Before Phase Transition
+
+**MANDATORY CHECK** before moving to next phase:
+
+```python
+# Pseudocode - agent must verify this mentally
+def can_proceed_to_phase(target_phase, config):
+    required_for_phase = [r for r in config["required_reads"] 
+                          if r["phase"] == target_phase or r["phase"] < target_phase]
+    unread = [r for r in required_for_phase if r["status"] == "pending"]
+    
+    if unread:
+        print(f"⛔ BLOCKED: Must read these files first:")
+        for r in unread:
+            print(f"  - {r['file']}")
+        return False
+    return True
+```
+
+---
+
+## Full Template (with Required Reads)
+
+```yaml
+# migration-config.yaml
+version: "1.0"
+
+# ========================================
+# REQUIRED READS TRACKING
+# ========================================
+# ⛔ CRITICAL: Update status from "pending" to "read" ONLY AFTER 
+# actually reading each file with the Read tool.
+# DO NOT proceed to a phase until all files for that phase are "read".
+
+required_reads:
+  # Phase 0 - Rules (ALWAYS required)
+  - file: "RULES.md"
+    phase: "0"
+    status: pending
+    
+  # Phase 2 - Platform common (filled after platform detection)
+  # Example for SageMaker:
+  - file: "references/platforms/sagemaker/common.md"
+    phase: "2"
+    status: pending
+
+# Add workflow-specific reads as you proceed (see templates below)
+
+# ========================================
+# MIGRATION CONFIGURATION
+# ========================================
+
+migration_type: inference  # inference, training, or both
+
+source:
+  platform: sagemaker  # sagemaker, azure-ml, vertex-ai, databricks
+  
+  # For inference migrations
+  model:
+    type: endpoint      # endpoint, model-registry, artifact
+    endpoint_name: my-endpoint
+    
+  # For training migrations
+  training:
+    script_path: ./train.py
+    
+  # Cloud credentials profile
+  credentials:
+    profile: default
+
+target:
+  connection: demo
+  database: ML_MODELS
+  schema: PRODUCTION
+  
+  registry:
+    model_name: MIGRATED_MODEL
+    version: v1
+    
+  compute:
+    pool: CPU_X64_M
+    service_pool: GPU_NV_S
+
+inference:
+  target_platform: WAREHOUSE  # WAREHOUSE or SNOWPARK_CONTAINER_SERVICES
+  spcs:
+    service_name: MODEL_ENDPOINT
+    ingress: public
+    max_instances: 1
+
+training:
+  job_type: single  # single, distributed, hpo
+  
+dependencies:
+  pip:
+    - scikit-learn==1.2.2
+```
+
+---
+
+## Required Reads by Workflow
+
+### Inference Workflow Required Reads
+
+Add these to `required_reads` when inference workflow is detected:
+
+```yaml
+required_reads:
+  # Phase 0
+  - file: "RULES.md"
+    phase: "0"
+    status: pending
+    
+  # Phase 2 - Platform (replace <platform> with detected)
+  - file: "references/platforms/<platform>/common.md"
+    phase: "2"
+    status: pending
+    
+  # I1 - Platform inference patterns
+  - file: "references/platforms/<platform>/inference.md"
+    phase: "I1"
+    status: pending
+    
+  # I3 - Config templates
+  - file: "references/shared/config-templates.md"
+    phase: "I3"
+    status: pending
+    
+  # I4 - Source access
+  - file: "references/inference/source-access.md"
+    phase: "I4"
+    status: pending
+    
+  # I7 - Model Registry (ALWAYS for inference)
+  - file: "../model-registry/SKILL.md"
+    phase: "I7"
+    status: pending
+    
+  # I7 - SPCS (only if target_platform: SNOWPARK_CONTAINER_SERVICES)
+  - file: "../spcs-inference/SKILL.md"
+    phase: "I7"
+    status: pending
+    required_if: "inference.target_platform == SNOWPARK_CONTAINER_SERVICES"
+```
+
+### Training Workflow Required Reads
+
+Add these to `required_reads` when training workflow is detected:
+
+```yaml
+required_reads:
+  # Phase 0
+  - file: "RULES.md"
+    phase: "0"
+    status: pending
+    
+  # Phase 2 - Platform (replace <platform> with detected)
+  - file: "references/platforms/<platform>/common.md"
+    phase: "2"
+    status: pending
+    
+  # T1 - Platform training patterns
+  - file: "references/platforms/<platform>/training.md"
+    phase: "T1"
+    status: pending
+    
+  # T2 - Framework patterns
+  - file: "references/training/frameworks.md"
+    phase: "T2"
+    status: pending
+    
+  # T2 - Distributed (only if complexity: distributed or multi-gpu)
+  - file: "references/training/distributed.md"
+    phase: "T2"
+    status: pending
+    required_if: "training.job_type in [distributed, hpo]"
+    
+  # T3 - ML Jobs (ALWAYS for training)
+  - file: "../ml-jobs/SKILL.md"
+    phase: "T3"
+    status: pending
+    
+  # T4 - Config templates
+  - file: "references/shared/config-templates.md"
+    phase: "T4"
+    status: pending
+```
+
+---
+
+## Config Validation
+
+### Required Fields by Migration Type
+
+#### Inference
+- `source.platform`
+- `source.model.type`
+- `target.connection`
+- `target.database`
+- `target.schema`
+- `target.registry.model_name`
+- `required_reads` (with all phase reads marked as "read")
+
+#### Training
+- `source.platform`
+- `source.training.script_path`
+- `target.connection`
+- `target.database`
+- `target.schema`
+- `target.compute.pool`
+- `required_reads` (with all phase reads marked as "read")
+
+---
+
+## Config Loading
+
+```python
+import yaml
+
+def load_config(path: str = "migration-config.yaml") -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+def check_required_reads(config: dict, current_phase: str) -> list:
+    """Returns list of unread files that block proceeding to current_phase."""
+    unread = []
+    for read in config.get("required_reads", []):
+        # Check if this read is required for current or earlier phase
+        if read["status"] == "pending":
+            unread.append(read["file"])
+    return unread
+
+def mark_as_read(config: dict, filepath: str) -> None:
+    """Mark a file as read. Call ONLY after actually reading it."""
+    for read in config.get("required_reads", []):
+        if read["file"] == filepath:
+            read["status"] = "read"
+            break
+
+def save_config(config: dict, path: str = "migration-config.yaml") -> None:
+    with open(path, "w") as f:
+        yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+```

--- a/skills/ml-migration/references/shared/infrastructure.md
+++ b/skills/ml-migration/references/shared/infrastructure.md
@@ -1,0 +1,192 @@
+# Snowflake ML Infrastructure
+
+Infrastructure components for ML workloads.
+
+## Compute Pools
+
+### Available Pools
+
+| Pool | vCPUs | Memory | GPUs | Best For |
+|------|-------|--------|------|----------|
+| CPU_X64_S | 2 | 8 GB | - | Small sklearn jobs |
+| CPU_X64_M | 4 | 16 GB | - | Medium sklearn/xgboost |
+| CPU_X64_L | 8 | 32 GB | - | Large data processing |
+| GPU_NV_S | 4 | 16 GB | 1 | Single GPU training |
+| GPU_NV_M | 8 | 64 GB | 4 | Multi-GPU training |
+| GPU_NV_L | 16 | 128 GB | 8 | Large model training |
+
+### Pool Management
+```sql
+-- List available pools
+SHOW COMPUTE POOLS;
+
+-- Check pool status
+DESCRIBE COMPUTE POOL CPU_X64_M;
+
+-- Create custom pool (admin)
+CREATE COMPUTE POOL MY_POOL
+  MIN_NODES = 1
+  MAX_NODES = 4
+  INSTANCE_FAMILY = GPU_NV_S;
+```
+
+## Stages
+
+### Training Stage Setup
+```sql
+CREATE STAGE IF NOT EXISTS TRAINING_STAGE
+  DIRECTORY = (ENABLE = TRUE)
+  COMMENT = 'Stage for ML training artifacts';
+```
+
+### Upload Files
+```python
+# Python
+session.file.put("local_file.py", "@TRAINING_STAGE/", auto_compress=False)
+
+# SQL
+PUT file://./train.py @TRAINING_STAGE AUTO_COMPRESS=FALSE;
+```
+
+### List Stage Contents
+```sql
+LIST @TRAINING_STAGE;
+```
+
+## Model Registry
+
+### Database/Schema Setup
+```sql
+CREATE DATABASE IF NOT EXISTS ML_MODELS;
+CREATE SCHEMA IF NOT EXISTS ML_MODELS.REGISTRY;
+```
+
+### Registry Operations
+```python
+from snowflake.ml.registry import Registry
+
+registry = Registry(
+    session=session,
+    database_name="ML_MODELS",
+    schema_name="REGISTRY"
+)
+
+# List models
+models = registry.show_models()
+
+# Get model
+model = registry.get_model("MY_MODEL")
+mv = model.version("V1")
+```
+
+### SQL Operations
+```sql
+SHOW MODELS IN SCHEMA ML_MODELS.REGISTRY;
+DESC MODEL ML_MODELS.REGISTRY.MY_MODEL;
+```
+
+## SPCS Infrastructure
+
+### Image Repository
+```sql
+CREATE IMAGE REPOSITORY IF NOT EXISTS ML_IMAGES;
+
+-- List images
+SHOW IMAGES IN IMAGE REPOSITORY ML_IMAGES;
+```
+
+### Service Compute Pool
+```sql
+-- Check system pools
+SHOW COMPUTE POOLS LIKE 'SYSTEM%';
+
+-- Services typically use
+-- SYSTEM_COMPUTE_POOL_CPU for CPU inference
+-- GPU pools for GPU inference
+```
+
+### External Access Integration
+```sql
+-- Create integration for PyPI access (admin)
+CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION PYPI_ACCESS_INTEGRATION
+  ALLOWED_NETWORK_RULES = (pypi_network_rule)
+  ALLOWED_AUTHENTICATION_SECRETS = ()
+  ENABLED = TRUE;
+
+-- Grant to roles
+GRANT USAGE ON INTEGRATION PYPI_ACCESS_INTEGRATION TO ROLE ML_ROLE;
+```
+
+## Data Infrastructure
+
+### Tables for Training Data
+```sql
+CREATE TABLE IF NOT EXISTS TRAIN_DATA (
+    ID INT,
+    FEATURE1 FLOAT,
+    FEATURE2 FLOAT,
+    TARGET INT
+);
+```
+
+### External Stages (Cloud Storage)
+
+#### AWS S3
+```sql
+CREATE STAGE S3_STAGE
+  URL = 's3://bucket/path/'
+  CREDENTIALS = (AWS_KEY_ID='...' AWS_SECRET_KEY='...');
+```
+
+#### Azure Blob
+```sql
+CREATE STAGE AZURE_STAGE
+  URL = 'azure://account.blob.core.windows.net/container/'
+  CREDENTIALS = (AZURE_SAS_TOKEN='...');
+```
+
+#### GCS
+```sql
+CREATE STAGE GCS_STAGE
+  URL = 'gcs://bucket/path/'
+  STORAGE_INTEGRATION = gcs_int;
+```
+
+## Resource Monitoring
+
+### Check Compute Usage
+```sql
+-- Active jobs
+SHOW ML JOBS;
+
+-- Service status
+SHOW SERVICES IN SCHEMA DB.SCHEMA;
+
+-- Compute pool utilization
+SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.COMPUTE_POOL_USAGE
+WHERE COMPUTE_POOL_NAME = 'CPU_X64_M'
+ORDER BY START_TIME DESC
+LIMIT 10;
+```
+
+### Cost Management
+```sql
+-- ML job costs
+SELECT * FROM SNOWFLAKE.ACCOUNT_USAGE.MLTRAINING_HISTORY
+ORDER BY START_TIME DESC
+LIMIT 10;
+```
+
+## Infrastructure Checklist
+
+### For Training
+- [ ] Compute pool accessible (CPU_X64_* or GPU_NV_*)
+- [ ] Training stage created
+- [ ] PYPI_ACCESS_INTEGRATION available
+- [ ] Training data loaded to tables
+
+### For Inference
+- [ ] Model Registry schema created
+- [ ] Image repository created (SPCS only)
+- [ ] Service compute pool accessible
+- [ ] BIND SERVICE ENDPOINT granted (public endpoints only)

--- a/skills/ml-migration/references/training/distributed.md
+++ b/skills/ml-migration/references/training/distributed.md
@@ -1,0 +1,97 @@
+# Distributed Training Patterns
+
+Quick reference for migrating distributed and multi-GPU training to Snowflake ML Jobs.
+
+> **For complete distributed training patterns and code templates, see `../../ml-jobs/SKILL.md` Multi-Node Jobs section.**
+> This file contains platform migration mappings only.
+
+---
+
+## Options Overview
+
+| Type | Use Case | Configuration |
+|------|----------|---------------|
+| **Multi-GPU single node** | Medium models | `GPU_NV_M/L`, `target_instances=1` |
+| **Ray distributed** | Large scale | `GPU_NV_S/M`, `target_instances=2+` |
+| **PyTorch DDP** | Data parallelism | Via Ray TorchTrainer |
+
+---
+
+## Platform Migration Reference
+
+### SageMaker Distributed → Snowflake
+
+| SageMaker | Snowflake |
+|-----------|-----------|
+| `instance_count=4` | `target_instances=4` |
+| `smdistributed.dataparallel` | Ray TorchTrainer |
+| `smdistributed.modelparallel` | Ray TorchTrainer with FSDP |
+| `ml.p3.16xlarge` | `GPU_NV_M` or `GPU_NV_L` |
+| `ml.p4d.24xlarge` | `GPU_NV_L` |
+| `S3DataSource` | `session.table()` |
+| `SM_NUM_GPUS` | `torch.cuda.device_count()` |
+| `SM_HOSTS` / `SM_CURRENT_HOST` | Ray handles node discovery |
+
+### Azure ML Distributed → Snowflake
+
+| Azure ML | Snowflake |
+|----------|-----------|
+| `ResourceConfiguration(instance_count=2)` | `target_instances=2` |
+| `distribution={"type": "PyTorch"}` | Ray TorchTrainer |
+| `distribution={"type": "MPI"}` | Ray TorchTrainer |
+| `process_count_per_instance=4` | `ScalingConfig(num_workers=4)` |
+| `Standard_NC24ads_A100_v4` | `GPU_NV_L` |
+| `Standard_NC6s_v3` | `GPU_NV_S` |
+| `AZUREML_DATAREFERENCE_*` | `session.table()` |
+
+### Vertex AI Distributed → Snowflake
+
+| Vertex AI | Snowflake |
+|-----------|-----------|
+| `replica_count=4` | `target_instances=4` |
+| `machine_type="n1-standard-8"` | `CPU_X64_M` |
+| `accelerator_type="NVIDIA_TESLA_V100"` | `GPU_NV_M` |
+| `accelerator_count=4` | `ScalingConfig(num_workers=4, use_gpu=True)` |
+| `AIP_MODEL_DIR` | `MLRS_STAGE_RESULT_PATH` |
+
+### Databricks TorchDistributor → Snowflake
+
+| Databricks | Snowflake |
+|------------|-----------|
+| `TorchDistributor(num_processes=8)` | `ScalingConfig(num_workers=8)` |
+| `distributor.run(train_fn)` | `TorchTrainer(train_fn).fit()` |
+| `local_mode=True` | `target_instances=1` |
+| `num_gpus_per_node=4` | `GPU_NV_M` (4 GPUs per node) |
+| `spark.read.table(...)` | `session.table(...)` |
+
+---
+
+## Resource Selection Guide
+
+| Training Type | Compute Pool | target_instances |
+|--------------|--------------|------------------|
+| Single GPU | GPU_NV_S | 1 |
+| Multi-GPU single node | GPU_NV_M or GPU_NV_L | 1 |
+| Distributed (small) | GPU_NV_S | 2-4 |
+| Distributed (large) | GPU_NV_M | 4-8 |
+| Very large models | GPU_NV_L | 4+ |
+
+---
+
+## Key Conversion Notes
+
+| Source Pattern | Snowflake Approach |
+|----------------|-------------------|
+| `torch.distributed.init_process_group()` | Ray handles initialization |
+| `DistributedDataParallel(model)` | `ray.train.torch.prepare_model(model)` |
+| `DistributedSampler` | Ray `get_dataset_shard()` |
+| Manual checkpoint saving | Ray `Checkpoint` API |
+| Environment-based rank detection | Ray handles worker coordination |
+
+---
+
+## Next Steps
+
+For complete code templates and submission patterns:
+- **See `../../ml-jobs/SKILL.md`** - Multi-Node Jobs section for `target_instances` usage
+- **See `../../ml-jobs/SKILL.md`** - Step 6 templates for job submission

--- a/skills/ml-migration/references/training/frameworks.md
+++ b/skills/ml-migration/references/training/frameworks.md
@@ -1,0 +1,79 @@
+# Framework Conversion Patterns
+
+Quick reference for converting training scripts to Snowflake ML Jobs.
+
+> **For complete ML Jobs templates and submission patterns, see `../../ml-jobs/SKILL.md`.**
+> This file contains migration-specific mappings only.
+
+---
+
+## Common Conversion Patterns
+
+| Original Pattern | Snowflake Equivalent |
+|------------------|---------------------|
+| `pd.read_csv("file.csv")` | `session.table("TABLE").to_pandas()` |
+| `model.save("model.pkl")` | `registry.log_model(model, ...)` |
+| `torch.save(model.state_dict(), "model.pth")` | `registry.log_model(model, ...)` |
+| `model.save("model.keras")` | `registry.log_model(model, ...)` |
+| `model.save_model("model.ubj")` | `registry.log_model(model, ...)` |
+| `print(metrics)` | `return {"metrics": metrics}` |
+| Local file paths | Stage paths or Snowflake tables |
+| Environment variables | Function parameters |
+| `if __name__ == "__main__"` | `@remote` decorator |
+| Hardcoded credentials | `Session.builder.getOrCreate()` |
+
+---
+
+## Data Loading Comparison
+
+| Source Platform | Snowflake Equivalent |
+|-----------------|---------------------|
+| `pd.read_csv("s3://...")` | `session.table("TABLE").to_pandas()` |
+| `pd.read_csv("abfs://...")` | `session.table("TABLE").to_pandas()` |
+| `pd.read_csv("gs://...")` | `session.table("TABLE").to_pandas()` |
+| `spark.read.table(...)` | `session.table("TABLE")` |
+| `spark.read.parquet(...)` | `session.table("TABLE")` |
+| `tf.data.Dataset.from_...` | Convert from Snowpark DataFrame |
+| `torch.utils.data.DataLoader` | Load from `session.table().to_pandas()` |
+| Local files | Stage files via `session.file.get()` |
+
+---
+
+## Model Saving Comparison
+
+| Source Pattern | Snowflake Equivalent |
+|----------------|---------------------|
+| `pickle.dump(model, f)` | `registry.log_model(model, model_name=..., version_name=...)` |
+| `joblib.dump(model, path)` | `registry.log_model(model, ...)` |
+| `torch.save(model, path)` | `registry.log_model(model, sample_input_data=...)` |
+| `model.save(path)` (Keras) | `registry.log_model(model, sample_input_data=...)` |
+| `mlflow.log_model(model)` | `registry.log_model(model, ...)` |
+| S3/GCS/Azure upload | Model Registry handles storage |
+
+---
+
+## Framework-Specific Notes
+
+### sklearn / XGBoost / LightGBM
+- Use `CPU_X64_M` compute pool (no GPU needed)
+- Pre-installed in ML Runtime - no `pip_requirements` needed for core packages
+- Use sklearn API wrappers (e.g., `XGBClassifier`) for easier registry integration
+
+### PyTorch
+- Use `GPU_NV_S` or larger for GPU training
+- Add `.cuda()` calls for GPU tensors
+- Provide `sample_input_data` for `log_model()` schema inference
+- Return `model.cpu()` before registration
+
+### TensorFlow/Keras
+- Use `GPU_NV_S` or larger for GPU training
+- Pre-installed in ML Runtime
+- Provide `sample_input_data` for `log_model()` schema inference
+
+---
+
+## Next Steps
+
+For complete submission patterns, templates, and job management:
+- **See `../../ml-jobs/SKILL.md`** - Steps 5-7 for submission templates
+- **See `../../model-registry/SKILL.md`** - for `log_model()` parameters and verification

--- a/skills/ml-migration/references/training/hpo.md
+++ b/skills/ml-migration/references/training/hpo.md
@@ -1,0 +1,213 @@
+# Hyperparameter Optimization Patterns
+
+Converting HPO jobs to Snowflake ML Jobs using the **native Snowflake Tuner API**.
+
+## ⛔ CRITICAL: Execution Model
+
+**The Tuner API runs in Container Runtime, NOT locally.**
+
+| Script Type | Where it runs | Can import Tuner? |
+|-------------|---------------|-------------------|
+| **Launcher** (submits the job) | Local machine | ❌ NO - `ModuleNotFoundError` |
+| **Training** (submitted via `submit_file`) | Container Runtime | ✅ YES |
+
+```python
+# ❌ WRONG - launcher.py (local)
+from snowflake.ml.modeling.tune import Tuner  # ModuleNotFoundError!
+
+# ✅ CORRECT - launcher.py (local)
+from snowflake.ml.jobs import submit_file
+job = submit_file("train_hpo.py", "COMPUTE_POOL", stage_name="STAGE")
+
+# ✅ CORRECT - train_hpo.py (runs in Container Runtime)
+from snowflake.ml.modeling.tune import Tuner, TunerConfig  # Works here!
+```
+
+## ⚠️ CRITICAL: Use Native Snowflake Tuner
+
+**DO NOT use Optuna or Ray Tune patterns.** Use the native `snowflake.ml.modeling.tune.Tuner` API.
+
+**Before writing HPO code, fetch docs:** `https://docs.snowflake.com/en/developer-guide/snowpark-ml/reference/latest/container-runtime/tune.tuner`
+
+## Quick Reference
+
+| Component | Import |
+|-----------|--------|
+| Tuner | `from snowflake.ml.modeling.tune import Tuner, TunerConfig` |
+| Sampling | `from snowflake.ml.modeling.tune import uniform, loguniform, randint, choice` |
+| Context | `from snowflake.ml.modeling.tune import get_tuner_context` |
+| Search | `from snowflake.ml.modeling.tune.search import BayesOpt, RandomSearch, GridSearch` |
+
+## ⚠️ Search Algorithm Compatibility
+
+**BayesOpt only supports continuous parameters:**
+
+| Algorithm | `uniform()` | `loguniform()` | `randint()` | `choice()` |
+|-----------|-------------|----------------|-------------|------------|
+| **BayesOpt** | ✅ | ✅ | ❌ | ❌ |
+| **RandomSearch** | ✅ | ✅ | ✅ | ✅ |
+| **GridSearch** | ❌ | ❌ | ❌ | ✅ (lists only) |
+
+**If migrating from platform using Bayesian + integers:** Either switch to `RandomSearch()` or use `uniform()` and cast to `int` in `train_func`.
+
+## Basic Pattern
+
+```python
+from snowflake.ml.modeling.tune import Tuner, TunerConfig, uniform, loguniform, randint
+from snowflake.ml.modeling.tune import get_tuner_context
+from snowflake.ml.modeling.tune.search import RandomSearch
+from snowflake.ml.data import DataConnector
+from snowflake.ml.registry import Registry
+from snowflake.snowpark import Session
+
+session = Session.builder.getOrCreate()
+
+# Prepare data as DataConnectors
+train_df = session.table("DB.SCHEMA.TRAIN_DATA").to_pandas()
+test_df = session.table("DB.SCHEMA.TEST_DATA").to_pandas()
+
+dataset_map = {
+    "train": DataConnector.from_dataframe(session.create_dataframe(train_df)),
+    "test": DataConnector.from_dataframe(session.create_dataframe(test_df)),
+}
+
+# Define training function
+def train_func():
+    from sklearn.ensemble import GradientBoostingClassifier
+    from sklearn.metrics import accuracy_score
+    
+    tuner_context = get_tuner_context()
+    config = tuner_context.get_hyper_params()
+    dm = tuner_context.get_dataset_map()
+    
+    train_data = dm["train"].to_pandas()
+    test_data = dm["test"].to_pandas()
+    
+    X_train, y_train = train_data.drop("TARGET", axis=1), train_data["TARGET"]
+    X_test, y_test = test_data.drop("TARGET", axis=1), test_data["TARGET"]
+    
+    model = GradientBoostingClassifier(
+        n_estimators=config["n_estimators"],
+        max_depth=config["max_depth"],
+        learning_rate=config["learning_rate"]
+    )
+    model.fit(X_train, y_train)
+    
+    accuracy = accuracy_score(y_test, model.predict(X_test))
+    
+    # CRITICAL: Report metrics AND model
+    tuner_context.report(metrics={"accuracy": accuracy}, model=model)
+
+# Search space
+search_space = {
+    "n_estimators": randint(50, 500),
+    "max_depth": randint(3, 15),
+    "learning_rate": loguniform(0.01, 0.3),
+}
+
+# Config
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=RandomSearch(),
+    num_trials=50,
+    max_concurrent_trials=4,
+)
+
+# Run
+tuner = Tuner(train_func, search_space, tuner_config)
+results = tuner.run(dataset_map=dataset_map)
+
+# MANDATORY: Register best model
+registry = Registry(session, database_name="DB", schema_name="SCHEMA")
+registry.log_model(results.best_model, model_name="TUNED_MODEL", version_name="V1")
+```
+
+## BayesOpt with Integer Params (Workaround)
+
+```python
+# Use uniform() and cast in train_func
+search_space = {
+    "n_estimators": uniform(50, 500),  # NOT randint
+    "max_depth": uniform(3, 15),
+}
+
+def train_func():
+    config = get_tuner_context().get_hyper_params()
+    n_estimators = int(round(config["n_estimators"]))
+    max_depth = int(round(config["max_depth"]))
+    # ...
+
+tuner_config = TunerConfig(search_alg=BayesOpt(), ...)
+```
+
+## Multi-Node HPO
+
+```python
+from snowflake.ml.runtime_cluster import scale_cluster
+
+scale_cluster(2)  # Scale BEFORE running tuner
+results = tuner.run(dataset_map=dataset_map)
+```
+
+## GPU Allocation
+
+```python
+tuner_config = TunerConfig(
+    metric="accuracy",
+    mode="max",
+    search_alg=BayesOpt(),
+    num_trials=50,
+    resource_per_trial={"CPU": 2, "GPU": 1},
+)
+```
+
+## Platform Migration Reference
+
+### SageMaker HPO → Snowflake
+
+| SageMaker | Snowflake |
+|-----------|-----------|
+| `HyperparameterTuner` | `Tuner` |
+| `ContinuousParameter` | `uniform()` / `loguniform()` |
+| `IntegerParameter` | `randint()` (RandomSearch) or `uniform()` + cast (BayesOpt) |
+| `CategoricalParameter` | `choice()` (RandomSearch only) |
+
+### Azure ML HPO → Snowflake
+
+| Azure ML | Snowflake |
+|----------|-----------|
+| `sweep()` | `Tuner.run()` |
+| `uniform()` | `uniform()` |
+| `choice()` | `choice()` (RandomSearch) |
+
+### Optuna → Snowflake
+
+| Optuna | Snowflake |
+|--------|-----------|
+| `study.optimize()` | `tuner.run()` |
+| `trial.suggest_float()` | `uniform()` / `loguniform()` |
+| `trial.suggest_int()` | `randint()` |
+| `trial.suggest_categorical()` | `choice()` |
+
+## Common Errors
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `BayesOpt does not support Integer` | Using `randint()` with BayesOpt | Use `RandomSearch()` or `uniform()` + cast |
+| `Model not registered` | Missing `tuner_context.report(model=...)` | Always pass model to report() |
+| No results | Missing `dataset_map` | Pass dataset_map to `tuner.run()` |
+
+## Sampling Functions
+
+```python
+from snowflake.ml.modeling.tune import uniform, loguniform, randint, choice
+
+search_space = {
+    "dropout": uniform(0.1, 0.5),           # Continuous [0.1, 0.5]
+    "learning_rate": loguniform(1e-5, 1e-1), # Log-scale
+    "n_layers": randint(1, 10),              # Integer [1, 10)
+    "optimizer": choice(["adam", "sgd"]),    # Categorical
+    "batch_size": [16, 32, 64],              # Grid (GridSearch only)
+}
+```


### PR DESCRIPTION
## Summary

Promotes the `ml-migration` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
