### PR TITLE
Promote dcr-v1-to-v2 from Snowflake-Solutions

### DIFF
--- a/skills/dcr-v1-to-v2/LICENSE
+++ b/skills/dcr-v1-to-v2/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/dcr-v1-to-v2/SKILL.md
+++ b/skills/dcr-v1-to-v2/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: dcr-v1-to-v2
+title: DCR V1 to V2 Migration
+summary: Migrate a Snowflake Data Clean Room from V1 SAMOOHA Provider/Consumer API to V2 Collaboration API.
+description: "Use when migrating a Snowflake Data Clean Room from V1 (SAMOOHA Provider/Consumer API) to V2 (Collaboration API). Discovers V1 setup via introspection queries, maps constructs to Collaboration API equivalents, converts JinjaSQL templates, and generates provider/consumer setup plus cleanup scripts. Output is local files only — no live DDL/DML. Triggers: DCR migration, V1 to V2, clean room upgrade, clean room migration, migrate DCR, upgrade clean room, SAMOOHA to Collaboration API."
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - Read
+  - Write
+  - Edit
+prompt: Migrate my V1 Data Clean Room to V2 Collaboration API.
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+# DCR V1 to V2 Migration
+
+## Overview
+
+Guides migration of a Snowflake Data Clean Room from **V1** (SAMOOHA Provider/Consumer API) to **V2** (Collaboration API). Produces local SQL scripts and reports — never executes DDL/DML against your accounts. Use this when you have an existing V1 clean room (calls into `samooha_by_snowflake_local_db.provider.*` / `consumer.*`) and want a generated V2 setup plus a side-by-side validation plan.
+
+**In scope:** V1 inventories, JinjaSQL template conversion (drops the `join_policy` filter), provider + consumer setup scripts, cleanup scripts, validation checklist.
+
+**Out of scope:** executing generated SQL, V0 direct-share setups, non-Snowflake clean rooms.
+
+## Prerequisites
+
+1. "Snowflake Data Clean Rooms" (SAMOOHA) installed on both accounts.
+2. Quick Start completed on both (`CHECK_MOUNT_STATUS()` returns TRUE).
+3. Access to the V1 provider account with `SAMOOHA_APP_ROLE` or `ACCOUNTADMIN`.
+
+## Workflow
+
+### Step 0 — Connection setup
+
+Run `cortex connections list`, identify the active connection, confirm with the user that it points to the V1 **provider** account, and store it as `provider_connection`.
+
+⚠️ STOPPING POINT: Do not run discovery queries until the user confirms the connection.
+
+### Step 1 — Discovery
+
+Load `discover/INSTRUCTIONS.md` and execute its workflow using `provider_connection`. Output: `discovery_report.md` (clean room name, linked datasets, join policies, templates, consumer accounts).
+
+⚠️ STOPPING POINT: Present the discovery report and confirm before mapping.
+
+### Step 2 — Mapping
+
+Map each V1 construct to V2. Reference `v1_v2_mapping.md` for the full table.
+
+- **Parties:** V1 provider → V2 owner (`COLLABORATION.INITIALIZE`); V1 consumer → V2 runner (`COLLABORATION.JOIN`, `COLLABORATION.RUN`).
+- **Datasets:** secure view → `REGISTRY.REGISTER_DATA_OFFERING` with `allowed_analyses: template_only`. Wrap raw tables in a secure view first. Data stays in the provider DB.
+- **Join policy:** V1 `set_join_policy` → V2 `schema_and_template_policies` per column (`passthrough` for join keys, `timestamp` for date columns).
+- **Templates:** keep SQL logic; **remove** `| join_policy` filter and replace with hardcoded join columns (e.g. `ON p.EMAIL_HASH = c.EMAIL_HASH`); keep `IDENTIFIER({{ source_table[0] }})` and bare `{{ param }}` unchanged; drop `provider_id`/`consumer_id` from analysis args. Version regex: `^[A-Za-z0-9_]{1,20}$`. Template ID: `name_version`.
+- **Consumer datasets:** V1 `link_datasets` → V2 `REGISTER_DATA_OFFERING` + `LINK_LOCAL_DATA_OFFERING`.
+
+⚠️ STOPPING POINT: Confirm mapping decisions before generating scripts.
+
+### Step 3 — Script generation
+
+Load `generate/INSTRUCTIONS.md`. Get today's date with `date +%Y%m%d` (never hardcode). Suggest output dir `YYYYMMDD_V1_to_V2_Output`.
+
+⚠️ STOPPING POINT: Confirm output directory before writing files.
+
+Generate: `v2_provider_setup.sql`, `v2_consumer_setup.sql`, `v2_cleanup.sql`, `mapping_report.md`.
+
+### Step 4 — Validation checklist
+
+Generate `validation_checklist.md` covering pre-migration baseline, provider setup (grants `USAGE + SELECT + REFERENCE_USAGE WITH GRANT OPTION`, registered offerings/templates, `INITIALIZE`), consumer setup (`USE SECONDARY ROLES NONE`, `LINK_LOCAL_DATA_OFFERING` before first `RUN`, 3-part IDs `ALIAS.OFFERING_ID.DATASET_ALIAS`), and per-template result comparison V1 vs V2.
+
+### Step 5 — Cleanup guidance
+
+Generate `cleanup_guidance.md`. Recommend a 2–4 week coexistence period. Include V1 teardown (`provider.drop_cleanroom`, `consumer.uninstall_cleanroom` — keep the provider DB) and V2 teardown using the **two-call async pattern**: first `COLLABORATION.LEAVE`/`TEARDOWN` → status `LEAVING`/`DROPPING` → wait ~60s → second call → `LEFT`/`DROPPED`.
+
+### Step 6 — Summary
+
+Print generated file list and next steps (run provider setup, run consumer setup, compare results, then cleanup).
+
+## Stopping Points
+
+- Step 0 — confirm provider connection before any query
+- Step 1 — confirm discovery inventory before mapping
+- Step 2 — confirm mapping decisions before generation
+- Step 3 — confirm output directory before writing files
+
+## Common Mistakes
+
+- **Executing generated SQL automatically.** Always hand off files for human review.
+- **Linking raw tables.** Wrap PII-bearing tables in a secure view first.
+- **Leaving `| join_policy` in converted templates.** Replace with the literal join column.
+- **Dots in version names.** Regex is `^[A-Za-z0-9_]{1,20}$` — use underscores.
+- **Missing role grants.** Without `USAGE + SELECT + REFERENCE_USAGE WITH GRANT OPTION` on `SAMOOHA_APP_ROLE`, `INITIALIZE`/`JOIN` fails.
+- **Forgetting `LINK_LOCAL_DATA_OFFERING`.** First `COLLABORATION.RUN` will fail without it.
+- **Skipping `USE SECONDARY ROLES NONE`** before Collaboration API calls.
+- **Calling `LEAVE`/`TEARDOWN` once.** They are two-call async — wait ~60s and call again.
+- **Querying `VIEW_REGISTERED_DATA_OFFERINGS` after `INITIALIZE`** and assuming the spec is broken. The spec consumes registry entries; use `COLLABORATION.VIEW_COLLABORATIONS()` post-JOIN.
+- **Calling `COLLABORATION.REVIEW` post-JOIN.** REVIEW is pre-JOIN only.
+
+## Sub-flows
+
+- `discover/INSTRUCTIONS.md` — V1 introspection queries
+- `generate/INSTRUCTIONS.md` — V2 Collaboration API script generation
+- `v1_v2_mapping.md` — reference mapping table

--- a/skills/dcr-v1-to-v2/discover/INSTRUCTIONS.md
+++ b/skills/dcr-v1-to-v2/discover/INSTRUCTIONS.md
@@ -1,0 +1,257 @@
+
+# Phase 1 — V1 Discovery
+
+## When to Use
+
+Load this sub-skill when executing **Step 1 — Discovery** of the `dcr-v1-to-v2` migration skill.
+Use it to:
+- Inventory an existing DCR V1 (SAMOOHA Provider/Consumer API) setup before migration
+- Document all linked datasets, join policies, templates, and consumer accounts
+- Produce a discovery report for user confirmation before mapping begins
+
+Runs read-only SAMOOHA API calls and SQL queries against the V1 provider account.
+
+## Prerequisites
+
+- Provider connection confirmed in **Step 0** (`provider_connection`)
+- All queries must use `connection: <provider_connection>`
+- Role with access to `SAMOOHA_APP_ROLE` (for SAMOOHA introspection) and `ACCOUNTADMIN` (for table/view DDL)
+
+## Workflow
+
+### Step 1 — List Clean Rooms
+
+```sql
+-- List all V1 clean rooms on this provider account
+USE ROLE SAMOOHA_APP_ROLE;
+CALL samooha_by_snowflake_local_db.provider.view_cleanrooms();
+```
+
+For each clean room, record:
+- Name
+- Provider account (org.account)
+- State (`CREATED` = active and published)
+- Consumer accounts
+- Is Published
+
+If no clean rooms are found, stop and inform the user — this account is not a V1 provider.
+If multiple clean rooms are found, ask the user which one to migrate.
+
+### Step 2 — Inventory Linked Datasets
+
+For the selected clean room:
+
+```sql
+USE ROLE SAMOOHA_APP_ROLE;
+CALL samooha_by_snowflake_local_db.provider.view_provider_datasets($cleanroom_name);
+```
+
+For each linked dataset, record the fully-qualified name (`database.schema.object`).
+
+Then determine whether each object is a secure view or a raw table:
+
+```sql
+USE ROLE ACCOUNTADMIN;
+-- Check if the object is a secure view
+SHOW VIEWS LIKE '<object_name>' IN SCHEMA <db>.<schema>;
+-- IS_SECURE = YES → secure view; not found in SHOW VIEWS → it is a table
+```
+
+For each **table**, capture column info:
+
+```sql
+DESCRIBE TABLE <db>.<schema>.<table_name>;
+```
+
+For each **secure view**, capture the definition:
+
+```sql
+SELECT GET_DDL('VIEW', '<db>.<schema>.<view_name>');
+```
+
+Record:
+- Column names and data types
+- Likely join key (typically hashed ID column: `EMAIL_HASH`, `CUSTOMER_ID`, etc.)
+- Whether it is a raw table (flag for secure view recommendation) or secure view (safe to link directly)
+
+### Step 3 — Inventory Join Policy
+
+```sql
+USE ROLE SAMOOHA_APP_ROLE;
+CALL samooha_by_snowflake_local_db.provider.view_join_policy($cleanroom_name);
+```
+
+Record for each entry:
+- Dataset FQN
+- Join column name
+
+This join column is what V2 templates will hardcode in place of the `join_policy` filter.
+
+### Step 4 — Inventory Templates
+
+```sql
+USE ROLE SAMOOHA_APP_ROLE;
+CALL samooha_by_snowflake_local_db.provider.view_added_templates($cleanroom_name);
+```
+
+This returns template names. To retrieve template bodies, attempt to query the clean room app package.
+The app package name follows the pattern `SAMOOHA_CLEANROOM_APP_<CLEANROOM_NAME>`:
+
+```sql
+USE ROLE ACCOUNTADMIN;
+SHOW TABLES IN APPLICATION SAMOOHA_CLEANROOM_APP_<CLEANROOM_NAME>;
+```
+
+Then try to read the custom SQL templates table (schema name may vary by SAMOOHA version):
+
+```sql
+SELECT * FROM SAMOOHA_CLEANROOM_APP_<CLEANROOM_NAME>.SHARED.CUSTOM_SQL_TEMPLATES LIMIT 50;
+-- If that fails, try:
+SELECT * FROM SAMOOHA_CLEANROOM_APP_<CLEANROOM_NAME>.TEMPLATES.CUSTOM_SQL_TEMPLATES LIMIT 50;
+```
+
+If the template body cannot be retrieved from the app package, ask the user:
+
+> "I could not retrieve the template bodies from the clean room app package. Please provide
+> the JinjaSQL body for each template: `<list_of_template_names>`. You can find them in
+> the original setup scripts used to create the clean room."
+
+For each template body, classify as:
+- **Auto-portable**: simple SELECT with `IDENTIFIER({{ source_table[N] }})` / `IDENTIFIER({{ my_table[N] }})` references — can be converted automatically
+- **Stub-required**: contains complex subqueries, JavaScript/Python UDFs, or procedural logic — generate stub with `-- TODO` markers
+
+Record for each template:
+- Template name
+- Full JinjaSQL body (or note if user must provide)
+- Parameters passed in `object_construct` (filter conditions like `segment`, `category`, etc.)
+- Tables referenced (`source_table[N]`, `my_table[N]`)
+- Join columns (from `join_policy` filter in the template body)
+- Portability classification
+
+### Step 5 — Identify Consumer Accounts
+
+From the `view_cleanrooms` output (Step 1), extract consumer account identifiers (org.account format).
+
+To check whether consumers have linked datasets:
+
+```sql
+-- On provider account — shows consumer-side linked datasets if available
+USE ROLE SAMOOHA_APP_ROLE;
+CALL samooha_by_snowflake_local_db.consumer.view_consumer_datasets($cleanroom_name);
+```
+
+If the user also has access to the consumer account, optionally gather consumer DB info:
+
+```sql
+-- On consumer account
+USE ROLE ACCOUNTADMIN;
+SHOW DATABASES;
+SHOW TABLES IN SCHEMA <consumer_db>.<schema>;
+```
+
+Record for each consumer:
+- Account identifier (org.account)
+- Consumer DB name (if known)
+- Consumer linked tables (from `view_consumer_datasets` or user input)
+
+### Step 6 — Provider DB Inventory
+
+```sql
+USE ROLE ACCOUNTADMIN;
+SHOW DATABASES;
+```
+
+Identify:
+- The provider data database (contains the source data referenced by linked datasets)
+- Any other databases referenced by the linked datasets
+
+For the provider data DB:
+
+```sql
+SHOW SCHEMAS IN DATABASE <provider_db>;
+SHOW TABLES IN SCHEMA <provider_db>.<schema>;
+SHOW VIEWS IN SCHEMA <provider_db>.<schema>;
+```
+
+Confirm all linked objects exist and are accessible.
+
+## Output
+
+Generate `discovery_report.md` with this structure:
+
+```markdown
+# DCR V1 Discovery Report
+
+Generated: <date>
+Provider account: <account>
+Connection: <connection_name>
+Clean room: <cleanroom_name>
+Distribution: EXTERNAL / INTERNAL
+State: <state>
+Published: Yes / No
+
+## Consumer Accounts
+
+| Account | Status |
+|---|---|
+| <org.account> | Added as consumer |
+
+## Linked Datasets (Provider)
+
+| Object FQN | Type | Join Column | Notes |
+|---|---|---|---|
+| DCR_V1_PROVIDER_DB.DATA.CUSTOMER_SPEND_V | Secure View | EMAIL_HASH | Pre-aggregated spend profile |
+| DCR_V1_PROVIDER_DB.DATA.TRANSACTIONS | Table | EMAIL_HASH | Raw transactions |
+
+## Join Policy
+
+| Dataset | Join Column |
+|---|---|
+| DCR_V1_PROVIDER_DB.DATA.CUSTOMER_SPEND_V | EMAIL_HASH |
+| DCR_V1_PROVIDER_DB.DATA.TRANSACTIONS | EMAIL_HASH |
+
+## Templates
+
+| Template Name | Portability | Parameters | Notes |
+|---|---|---|---|
+| overlap_analysis | Auto-portable | provider_id, consumer_id | Standard join template |
+| reach_analysis | Auto-portable | provider_id, consumer_id, segment | String filter param |
+| transaction_overlap | Auto-portable | provider_id, consumer_id | Aggregation by category |
+| spend_analysis | Auto-portable | provider_id, consumer_id | AVG/SUM aggregation |
+
+### Template Bodies
+
+For each template, include the full JinjaSQL body as found in the app package or provided by the user.
+
+## Provider Database
+
+| Database | Schema | Tables | Views |
+|---|---|---|---|
+| DCR_V1_PROVIDER_DB | DATA | CUSTOMERS, TRANSACTIONS | CUSTOMER_SPEND_V (secure) |
+
+## Consumer Datasets
+
+| Consumer Account | Consumer DB | Linked Table |
+|---|---|---|
+| SFPSCOGS.WLIN_AWS_W2 | DCR_V1_CONSUMER_DB | DATA.CUSTOMERS |
+```
+
+## Stopping Point
+
+Present the discovery report to the user. Ask:
+
+> "Here is the V1 inventory. Please confirm this is complete and correct before I
+> proceed with the V1→V2 mapping. Are there any objects missing or corrections needed?"
+
+Do not proceed to Step 2 (Mapping) until the user confirms.
+
+## Common Issues
+
+| Issue | Resolution |
+|---|---|
+| `view_cleanrooms` returns empty | Confirm you are on the provider account and using SAMOOHA_APP_ROLE |
+| Cannot retrieve template body from app package | Ask user to provide from original setup scripts |
+| Multiple clean rooms found | Ask user which one to migrate |
+| Template uses JavaScript/Python UDF | Mark as stub-required — cannot auto-convert |
+| Consumer datasets not visible | Optionally gather from consumer account or ask user |
+| Raw table linked (no secure view) | Flag in report — recommend creating a secure view before migration |

--- a/skills/dcr-v1-to-v2/generate/INSTRUCTIONS.md
+++ b/skills/dcr-v1-to-v2/generate/INSTRUCTIONS.md
@@ -1,0 +1,739 @@
+
+# Phase 3 — V2 Script Generation
+
+## When to Use
+
+Load this sub-skill when executing **Step 3 — Script Generation** of the `dcr-v1-to-v2`
+migration skill. Use it to:
+- Generate `v2_provider_setup.sql`, `v2_consumer_setup.sql`, and `v2_cleanup.sql` from a
+  confirmed V1→V2 mapping
+- Convert V1 JinjaSQL templates (with `join_policy` filter) to V2 Collaboration API format
+- Produce all output as local files — never execute DDL/DML
+
+## Prerequisites
+
+- Discovery report completed and confirmed (Phase 1)
+- Mapping report completed and confirmed (Phase 2)
+- User has confirmed the output directory
+- Output directory determined dynamically: `date +%Y%m%d` → format `YYYYMMDD_V1_to_V2_Output`
+
+## Input
+
+From the mapping report:
+- Provider account (org.account) and DB name
+- Consumer account (org.account) and DB name
+- Linked objects per DB, with join columns
+- Converted V2 templates (or stubs for complex logic)
+- Collaboration name (suggest `DCR_V2_COLLABORATION` or match V1 name)
+- Collaborator aliases for the YAML spec (suggest `owner_account` / `collab_account`)
+- Version string for offerings/templates (suggest `YYYYMMDD_V1` where YYYYMMDD is today's date)
+- Warehouse name
+
+
+## Workflow
+
+### Step 1 — Generate Provider Setup Script
+
+Write `v2_provider_setup.sql` with the following structure.
+
+#### Header
+
+```sql
+-- =============================================================================
+-- DCR V2 Provider Setup (Migrated from V1 — Collaboration API)
+-- Account  : <provider_account>
+-- Source   : Migrated from V1 clean room <v1_cleanroom_name>
+-- Generated: <date>
+-- =============================================================================
+--
+-- PREREQUISITES — Complete both steps below before running this file.
+--
+-- Step A: Install "Snowflake Data Clean Rooms" from Marketplace (do once per account)
+-- Step B: Run Quick Start (rename + mount — do once per account)
+--
+--   USE ROLE ACCOUNTADMIN;
+--   ALTER APPLICATION IF EXISTS Snowflake_Data_Clean_Rooms RENAME TO SAMOOHA_BY_SNOWFLAKE;
+--   CALL SAMOOHA_BY_SNOWFLAKE.APP_SCHEMA.PREPARE_MOUNT_SCRIPT();
+--   EXECUTE IMMEDIATE FROM @SAMOOHA_BY_SNOWFLAKE.APP_SCHEMA.MOUNT_CODE_STAGE/dcr_loader.sql;
+--   USE ROLE SAMOOHA_APP_ROLE;
+--   CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.LIBRARY.CHECK_MOUNT_STATUS();  -- must return TRUE
+--
+-- NOTE: All Collaboration API calls require USE SECONDARY ROLES NONE in the session.
+--
+-- =============================================================================
+
+SET collab_name    = '<collaboration_name>';  -- NOTE: DCR V2 names cannot contain spaces — use underscores
+SET owner_alias    = 'owner_account';          -- provider alias in YAML spec
+SET collab_alias   = 'collab_account';         -- consumer alias in YAML spec
+SET collab_account = '<consumer_org.account>';
+SET provider_db    = '<provider_db>';
+```
+
+#### Provider Step 1 — Warehouse
+
+```sql
+-- =============================================================================
+-- STEP 1: Warehouse Setup
+-- Run as: ACCOUNTADMIN
+-- =============================================================================
+
+USE ROLE ACCOUNTADMIN;
+
+CREATE WAREHOUSE IF NOT EXISTS <warehouse>
+    WAREHOUSE_SIZE = XSMALL
+    AUTO_SUSPEND   = 60
+    AUTO_RESUME    = TRUE
+    COMMENT        = 'Warehouse for DCR V2';
+
+GRANT USAGE ON WAREHOUSE <warehouse> TO ROLE SAMOOHA_APP_ROLE;
+```
+
+#### Provider Step 2 — Data Objects and SAMOOHA_APP_ROLE Grants
+
+Include this block in full — it replaces V1's `library.register_schema`:
+
+```sql
+-- =============================================================================
+-- STEP 2: Data Objects and SAMOOHA_APP_ROLE Grants
+-- Run as: ACCOUNTADMIN
+-- Data stays in the provider DB — no copies needed.
+-- V1's library.register_schema is replaced by explicit grants below.
+-- REFERENCE_USAGE WITH GRANT OPTION is required so the SAMOOHA backend can
+-- share data object references cross-account for the collaboration data layer.
+-- =============================================================================
+
+USE ROLE ACCOUNTADMIN;
+
+-- [If provider data objects need to be created or secure views need to be added,
+--  include CREATE TABLE / CREATE SECURE VIEW statements here.]
+-- If V1 already has the correct objects in the provider DB, skip creation.
+
+-- Grant SAMOOHA_APP_ROLE access to provider data (must be done before INITIALIZE).
+GRANT USAGE           ON DATABASE <provider_db>                       TO ROLE SAMOOHA_APP_ROLE;
+GRANT USAGE           ON SCHEMA   <provider_db>.<schema>              TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL TABLES IN SCHEMA <provider_db>.<schema>  TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL VIEWS  IN SCHEMA <provider_db>.<schema>  TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCES      ON ALL VIEWS  IN SCHEMA <provider_db>.<schema>  TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCE_USAGE ON DATABASE <provider_db>                       TO ROLE SAMOOHA_APP_ROLE WITH GRANT OPTION;
+```
+
+#### Provider Step 3 — Register Data Offerings
+
+For each V1 linked dataset, generate a `REGISTER_DATA_OFFERING` call:
+
+```sql
+-- =============================================================================
+-- STEP 3: Register Data Offerings
+-- Run as: SAMOOHA_APP_ROLE
+-- Version format: ^[A-Za-z0-9_]{1,20}$ — no dots; use underscores (e.g., YYYYMMDD_V1).
+-- Data offering ID = name_version (e.g., provider_customer_spend_v_YYYYMMDD_V1).
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE <warehouse>;
+USE SECONDARY ROLES NONE;
+
+-- Offering: <dataset_name>
+-- V1 equivalent: link_datasets(['<provider_db>.<schema>.<object>'])
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.REGISTER_DATA_OFFERING($$
+api_version: 2.0.0
+spec_type: data_offering
+name: <offering_name>             -- snake_case, e.g., provider_customer_spend_v
+version: <YYYYMMDD_V1>
+description: <description>
+datasets:
+  - alias: <dataset_alias>        -- short name used in 3-part RUN ID (ALIAS.OFFERING_ID.ALIAS)
+    data_object_fqn: <db>.<schema>.<object>
+    allowed_analyses: template_only
+    schema_and_template_policies:
+      <JOIN_COL>:
+        category: passthrough     -- for hashed/synthetic join keys
+      <DATE_COL>:
+        category: timestamp       -- for date/time columns
+      <OTHER_COL>:
+        category: passthrough
+$$);
+```
+
+Repeat for each linked dataset. After all offerings:
+
+```sql
+-- Verify all offerings registered
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.VIEW_REGISTERED_DATA_OFFERINGS();
+```
+
+#### Provider Step 4 — Register Templates
+
+For each V1 template, apply the conversion rules (see section below), then generate:
+
+```sql
+-- =============================================================================
+-- STEP 4: Register Analysis Templates
+-- Run as: SAMOOHA_APP_ROLE
+-- Template ID = name_version (e.g., overlap_analysis_YYYYMMDD_V1).
+-- Cannot re-register an existing version — use a bumped version string to update.
+-- =============================================================================
+
+USE ROLE SAMOOHA_APP_ROLE;
+USE WAREHOUSE <warehouse>;
+USE SECONDARY ROLES NONE;
+
+-- Template: <template_name>
+-- V1 equivalent: provider.add_custom_sql_template($cleanroom_name, '<template_name>', $$...$$)
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.REGISTER_TEMPLATE($$
+api_version: 2.0.0
+spec_type: template
+name: <template_name>
+version: <YYYYMMDD_V1>
+type: sql_analysis
+description: <description>
+template: |
+    <converted JinjaSQL body — see Template Conversion Reference>
+$$);
+```
+
+For stub templates that cannot be auto-converted:
+
+```sql
+-- WARNING: This template requires manual porting from V1.
+-- Original V1 template: <template_name>
+-- TODO: Replace the placeholder with the actual SQL body.
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.REGISTER_TEMPLATE($$
+api_version: 2.0.0
+spec_type: template
+name: <template_name>
+version: <YYYYMMDD_V1>
+type: sql_analysis
+description: <description> — STUB: requires manual port
+template: |
+    -- TODO: Port from V1 template <template_name>
+    -- Original logic:
+    --   <brief description of what the V1 template does>
+    -- Table references:
+    --   Provider: IDENTIFIER({{ source_table[0] }}) p
+    --   Consumer: IDENTIFIER({{ my_table[0] }}) c
+    --   Join:     ON p.<join_col> = c.<join_col>
+    SELECT 1 AS placeholder
+$$);
+```
+
+After all templates:
+
+```sql
+-- Verify all templates registered
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.VIEW_REGISTERED_TEMPLATES();
+```
+
+#### Provider Step 5 — Initialize Collaboration
+
+```sql
+-- =============================================================================
+-- STEP 5: Initialize Collaboration
+-- Run as: SAMOOHA_APP_ROLE
+-- The YAML spec declares all collaborators, data offerings, and templates.
+-- collaborator_identifier_aliases: alias → org.account
+-- analysis_runners: which account can run analyses, from which providers, using which templates
+-- Collaborator list is FIXED after INITIALIZE — cannot add or remove later.
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE <warehouse>;
+USE SECONDARY ROLES NONE;
+
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.INITIALIZE($$
+api_version: 2.0.0
+spec_type: collaboration
+name: <collaboration_name>
+owner: owner_account
+collaborator_identifier_aliases:
+    owner_account: <provider_org.account>
+    collab_account: <consumer_org.account>
+analysis_runners:
+    collab_account:
+        data_providers:
+            owner_account:
+                data_offerings:
+                    - id: <offering_id_1>    -- name_version, e.g., provider_customer_spend_v_YYYYMMDD_V1
+                    - id: <offering_id_N>
+        templates:
+            - id: <template_id_1>            -- name_version, e.g., overlap_analysis_YYYYMMDD_V1
+            - id: <template_id_N>
+$$, '<warehouse>');
+
+-- Verify collaboration was created
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.VIEW_COLLABORATIONS();
+
+-- Provider joins as owner (INITIALIZE schedules auto-join; explicit call ensures completion)
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.JOIN($collab_name);
+-- DCR joins can be slow — verify when ready:
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS($collab_name);
+-- Expected: JOINED for owner_account
+```
+
+#### Provider Step 6 — Validation
+
+```sql
+-- =============================================================================
+-- STEP 6: Validation
+-- Run as: SAMOOHA_APP_ROLE
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE <warehouse>;
+USE SECONDARY ROLES NONE;
+
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS($collab_name);
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.VIEW_UPDATE_REQUESTS($collab_name);
+-- NOTE: VIEW_REGISTERED_DATA_OFFERINGS / VIEW_REGISTERED_TEMPLATES return empty after
+-- COLLABORATION.INITIALIZE. COLLABORATION.REVIEW also fails post-JOIN ("already reviewed").
+-- Use VIEW_COLLABORATIONS to inspect the full spec after joining.
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.VIEW_COLLABORATIONS();
+
+-- =============================================================================
+-- STOP: Wait for consumer to complete Steps 1-5 of v2_consumer_setup.sql.
+-- =============================================================================
+```
+
+
+### Step 2 — Generate Consumer Setup Script
+
+Write `v2_consumer_setup.sql` with the following structure.
+
+#### Header
+
+```sql
+-- =============================================================================
+-- DCR V2 Consumer Setup (Migrated from V1 — Collaboration API)
+-- Account  : <consumer_account>
+-- Source   : Migrated from V1 — previously installed <v1_cleanroom_name>
+-- Generated: <date>
+-- =============================================================================
+-- NOTE: Run after provider completes v2_provider_setup.sql (Step 5 complete).
+--       USE SECONDARY ROLES NONE required before all Collaboration API calls.
+--
+-- NOTE: This setup only adds a new V2 collaboration. Existing V2 collaborations
+--       on this account are not affected.
+-- =============================================================================
+
+SET collab_name  = '<collaboration_name>';  -- NOTE: Must match provider exactly; DCR V2 names cannot contain spaces
+SET consumer_db  = '<consumer_db>';         -- TODO: replace with consumer database name (new or existing — see Step 2)
+SET consumer_wh  = '<warehouse>';           -- TODO: replace with warehouse name on this account
+                                            --       (if creating a new one, uncomment Step 1 below and match this name)
+```
+
+#### Consumer Step 1 — Warehouse
+
+```sql
+-- =============================================================================
+-- STEP 1: Warehouse Setup (OPTIONAL — skip if using an existing warehouse)
+-- Run as: ACCOUNTADMIN
+--
+-- If you already have a warehouse, set consumer_wh above to its name and skip
+-- this step. If you need a new warehouse, update consumer_wh above to match
+-- the name below, then uncomment and run this block.
+-- =============================================================================
+
+-- USE ROLE ACCOUNTADMIN;
+
+-- CREATE WAREHOUSE IF NOT EXISTS <warehouse>
+--     WAREHOUSE_SIZE = XSMALL
+--     AUTO_SUSPEND   = 60
+--     AUTO_RESUME    = TRUE
+--     COMMENT        = 'Warehouse for DCR V2';
+
+-- GRANT USAGE ON WAREHOUSE <warehouse> TO ROLE SAMOOHA_APP_ROLE;
+```
+
+#### Consumer Step 2 — Data and SAMOOHA_APP_ROLE Grants
+
+```sql
+-- =============================================================================
+-- STEP 2: Consumer Data and SAMOOHA_APP_ROLE Grants
+-- Run as: ACCOUNTADMIN
+-- If reusing the existing V1 consumer DB, skip CREATE/INSERT — only add grants.
+-- REFERENCE_USAGE WITH GRANT OPTION required before COLLABORATION.JOIN.
+-- =============================================================================
+
+USE ROLE ACCOUNTADMIN;
+
+-- [Include CREATE DATABASE / CREATE TABLE / INSERT if V2 uses new consumer data]
+-- [If reusing V1 consumer DB, skip to the grants block below]
+
+-- Grant SAMOOHA_APP_ROLE access to consumer data (must be done before JOIN)
+GRANT USAGE           ON DATABASE IDENTIFIER($consumer_db)                       TO ROLE SAMOOHA_APP_ROLE;
+GRANT USAGE           ON ALL SCHEMAS IN DATABASE IDENTIFIER($consumer_db)        TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL TABLES IN DATABASE IDENTIFIER($consumer_db)         TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCE_USAGE ON DATABASE IDENTIFIER($consumer_db)                       TO ROLE SAMOOHA_APP_ROLE WITH GRANT OPTION;
+```
+
+#### Consumer Step 3 — Review and Join
+
+```sql
+-- =============================================================================
+-- STEP 3: Review and Join Collaboration
+-- Run as: SAMOOHA_APP_ROLE
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE IDENTIFIER($consumer_wh);
+USE SECONDARY ROLES NONE;
+
+-- Optional: check what collaborations are available
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.VIEW_COLLABORATIONS();
+
+-- Review the collaboration spec before joining
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.REVIEW($collab_name, '<provider_org.account>');
+
+-- Join the collaboration as the analysis runner
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.JOIN($collab_name);
+
+-- DCR joins can be slow — verify when ready:
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS($collab_name);
+-- Expected: JOINED for collab_account
+```
+
+#### Consumer Step 4 — Register Consumer Data Offering and Link
+
+```sql
+-- =============================================================================
+-- STEP 4: Register Consumer Data Offering and Link
+-- Run as: SAMOOHA_APP_ROLE
+-- V1 equivalent: consumer.link_datasets + consumer.set_join_policy
+-- IMPORTANT: LINK_LOCAL_DATA_OFFERING must be called before the first RUN.
+--
+-- NOTE: REGISTER_DATA_OFFERING registers the consumer's OWN data with the SAMOOHA
+-- registry so the collaboration analysis engine can access it during RUN calls.
+-- This does NOT expose consumer data to the provider — the provider can only
+-- access results produced by registered templates, not the raw consumer table.
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE IDENTIFIER($consumer_wh);
+USE SECONDARY ROLES NONE;
+
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.REGISTER_DATA_OFFERING($$
+api_version: 2.0.0
+spec_type: data_offering
+name: <consumer_offering_name>    -- e.g., consumer_customers
+version: <YYYYMMDD_V1>
+description: <description>
+datasets:
+  - alias: <dataset_alias>        -- e.g., customers — used in 3-part RUN ID
+    data_object_fqn: <consumer_db>.<schema>.<table>
+    allowed_analyses: template_only
+    schema_and_template_policies:
+      <JOIN_COL>:
+        category: passthrough
+      <OTHER_COL>:
+        category: passthrough
+$$);
+
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.REGISTRY.VIEW_REGISTERED_DATA_OFFERINGS();
+
+-- Link consumer's data offering to the collaboration.
+-- Creates data access views in the collaboration-local DB used by the analysis engine.
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.LINK_LOCAL_DATA_OFFERING(
+    $collab_name,
+    '<consumer_offering_id>'    -- e.g., consumer_customers_YYYYMMDD_V1
+);
+```
+
+#### Consumer Step 5 — Run Analyses
+
+```sql
+-- =============================================================================
+-- STEP 5: Run Analyses
+-- Run as: SAMOOHA_APP_ROLE
+-- ID format: COLLABORATOR_ALIAS.DATA_OFFERING_ID.DATASET_ALIAS
+-- IMPORTANT: Arg order is (collab, template_id, source_tables[], my_tables[], args)
+--   source_tables = provider offerings (arg 3)   → populates source_table[] in template
+--   my_tables     = consumer offerings (arg 4)   → populates my_table[] in template
+-- NOTE: This is REVERSED from V1 run_analysis(cleanroom, template, [consumer], [provider], args)
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE IDENTIFIER($consumer_wh);
+USE SECONDARY ROLES NONE;
+```
+
+For each template, generate the `COLLABORATION.RUN` call with the comment showing the V1 equivalent:
+
+```sql
+-- Template: <template_name>
+-- V1 equivalent:
+--   CALL samooha_by_snowflake_local_db.consumer.run_analysis(
+--       $cleanroom_name, '<v1_template_name>',
+--       ['<consumer_table_fqn>'],    -- consumer was arg 3 in V1
+--       ['<provider_table_fqn>'],    -- provider was arg 4 in V1
+--       object_construct('provider_id', 'p.<col>', 'consumer_id', 'c.<col>', ...)
+--   );
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.RUN(
+    $collab_name,
+    '<template_id>',                                                -- name_version
+    ['<owner_alias>.<provider_offering_id>.<provider_dataset_alias>'],  -- provider first (arg 3)
+    ['<collab_alias>.<consumer_offering_id>.<consumer_dataset_alias>'], -- consumer second (arg 4)
+    OBJECT_CONSTRUCT(<param_name>, <value>, ...)   -- no provider_id/consumer_id needed
+);
+```
+
+#### Consumer Step 6 — Validation
+
+```sql
+-- =============================================================================
+-- STEP 6: Validation
+-- Run as: SAMOOHA_APP_ROLE
+-- =============================================================================
+
+USE ROLE      SAMOOHA_APP_ROLE;
+USE WAREHOUSE IDENTIFIER($consumer_wh);
+USE SECONDARY ROLES NONE;
+
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS($collab_name);
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.VIEW_UPDATE_REQUESTS($collab_name);
+```
+
+
+### Step 3 — Generate Cleanup Script
+
+Write `v2_cleanup.sql`:
+
+```sql
+-- =============================================================================
+-- DCR V2 Cleanup — Collaboration API
+-- Run to decommission the V2 collaboration from both accounts.
+-- =============================================================================
+-- LEAVE and TEARDOWN are two-call async operations:
+--   1st call → status becomes LEAVING (consumer) or DROPPING (provider)
+--   Wait ~60 seconds
+--   Check GET_STATUS → status becomes LOCAL_DROP_PENDING
+--   2nd call → completes cleanup (status: LEFT / DROPPED)
+-- Consumer must LEAVE before provider runs TEARDOWN.
+-- =============================================================================
+
+-- === CONSUMER ACCOUNT ===
+-- Run on: <consumer_account>
+
+USE ROLE SAMOOHA_APP_ROLE;
+USE SECONDARY ROLES NONE;
+
+-- First LEAVE call (async — moves to LEAVING)
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.LEAVE('<collaboration_name>');
+
+-- Verify status: expect LEAVING
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS('<collaboration_name>');
+
+-- Wait ~60 seconds, then check again.
+-- When status = LOCAL_DROP_PENDING, run the second LEAVE call:
+-- CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.LEAVE('<collaboration_name>');
+
+USE ROLE ACCOUNTADMIN;
+DROP DATABASE IF EXISTS <consumer_db>;  -- Only if created for V2 (not V1 reuse)
+
+
+-- === PROVIDER ACCOUNT ===
+-- Run on: <provider_account>
+-- Run only after consumer has fully LEFT.
+
+USE ROLE SAMOOHA_APP_ROLE;
+USE SECONDARY ROLES NONE;
+
+-- First TEARDOWN call (async — moves to DROPPING)
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.TEARDOWN('<collaboration_name>');
+
+-- Verify status: expect DROPPING
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.GET_STATUS('<collaboration_name>');
+
+-- Wait ~60 seconds, then check again.
+-- When status = LOCAL_DROP_PENDING, run the second TEARDOWN call:
+-- CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.TEARDOWN('<collaboration_name>');
+
+-- NOTE: Do NOT drop the provider DB — it contains the original data used by V1 and V2.
+-- Registry entries (data offerings and templates) are automatically cleaned up
+-- when the SAMOOHA app is uninstalled. Do not try to delete them individually —
+-- no DELETE_DATA_OFFERING or DELETE_TEMPLATE procedures exist in this version.
+```
+
+
+### Step 4 — Write Files
+
+Get today's date and confirm the output directory:
+
+```bash
+date +%Y%m%d
+```
+
+> "I will generate the following files in `<YYYYMMDD>_V1_to_V2_Output/`:
+> - `v2_provider_setup.sql` (Steps 1–6 + STOP)
+> - `v2_consumer_setup.sql` (Steps 1–6)
+> - `v2_cleanup.sql` (LEAVE/TEARDOWN)
+> - `mapping_report.md` (V1→V2 mapping decisions table)
+>
+> Shall I proceed?"
+
+After writing, list the files:
+
+```
+Files generated:
+  <output_dir>/v2_provider_setup.sql    — <N> lines
+  <output_dir>/v2_consumer_setup.sql    — <N> lines
+  <output_dir>/v2_cleanup.sql           — <N> lines
+  <output_dir>/mapping_report.md        — <N> lines
+```
+
+Also write `mapping_report.md` capturing all V1→V2 decisions from Phase 2 as a table.
+
+
+## Template Conversion Reference
+
+### V1 → V2 JinjaSQL Conversion Rules
+
+| V1 Pattern | V2 Replacement | Notes |
+|---|---|---|
+| `IDENTIFIER({{ source_table[0] }}) p` | `IDENTIFIER({{ source_table[0] }}) p` | Unchanged |
+| `IDENTIFIER({{ my_table[0] }}) c` | `IDENTIFIER({{ my_table[0] }}) c` | Unchanged |
+| `IDENTIFIER({{ source_table[N] }})` | `IDENTIFIER({{ source_table[N] }})` | Unchanged for N ≥ 1 |
+| `ON IDENTIFIER({{ provider_id \| join_policy }}) = IDENTIFIER({{ consumer_id \| join_policy }})` | `ON p.<join_col> = c.<join_col>` | Hardcode the join column from `view_join_policy` |
+| `WHERE p.COL = {{ param }}` | `WHERE p.COL = {{ param }}` | Unchanged — engine auto-quotes strings |
+| `'{{ param }}'` | `{{ param }}` | Remove outer quotes — they cause double-quoting in V2 |
+| `{{ param \| sqlsafe }}` | `{{ param }}` | Remove `sqlsafe` — incompatible with V2 Snowpark binding |
+| `GROUP BY`, `HAVING`, `ORDER BY` | Keep as-is | Aggregation logic unchanged |
+| `DIV0`, `SHA2`, `COUNT DISTINCT` | Keep as-is | Snowflake functions unchanged |
+
+### Critical Conversion Notes
+
+1. **Remove the `join_policy` filter.** V1 templates use `{{ provider_id | join_policy }}` and
+   `{{ consumer_id | join_policy }}` to enforce which column the consumer must join on. V2 has
+   no `join_policy` filter. Replace the entire `IDENTIFIER({{ ... | join_policy }}) = IDENTIFIER({{ ... | join_policy }})`
+   expression with the actual column name discovered in `view_join_policy`:
+   ```sql
+   -- V1: join_policy filter (runtime-enforced column lookup)
+   ON IDENTIFIER({{ provider_id | join_policy }}) = IDENTIFIER({{ consumer_id | join_policy }})
+
+   -- V2: hardcoded column (discovered from view_join_policy)
+   ON p.EMAIL_HASH = c.EMAIL_HASH
+   ```
+
+2. **Remove `provider_id` and `consumer_id` from RUN args.** V1 callers passed
+   `'provider_id', 'p.EMAIL_HASH', 'consumer_id', 'c.EMAIL_HASH'` in `object_construct`.
+   V2 `COLLABORATION.RUN` does not use these — omit them entirely.
+
+3. **Bare `{{ param }}` for string filters.** Both V1 and V2 use bare `{{ param }}`. The V2 Jinja
+   engine auto-quotes string values during substitution. Do **not** add outer quotes
+   (`'{{ param }}'` causes double-quoting `''value''`) or use `| sqlsafe` (breaks Snowpark binding).
+
+4. **Arg 3/4 are reversed between V1 and V2.** This is the most error-prone migration step:
+   - V1 `run_analysis`: arg 3 = consumer tables → `my_table[]`, arg 4 = provider tables → `source_table[]`
+   - V2 `COLLABORATION.RUN`: arg 3 = provider source_tables, arg 4 = consumer my_tables
+
+5. **Template ID format.** V1 template name is plain (`overlap_analysis`). V2 template ID is
+   `name_version` (`overlap_analysis_YYYYMMDD_V1`), returned by `REGISTER_TEMPLATE`.
+
+6. **3-part RUN ID format.** V2 `source_tables` and `my_tables` args use:
+   `COLLABORATOR_ALIAS.DATA_OFFERING_ID.DATASET_ALIAS`
+   Example: `'owner_account.provider_customer_spend_v_YYYYMMDD_V1.customer_spend_v'`
+
+### Example: overlap_analysis V1 → V2
+
+**V1 template body (`add_custom_sql_template`):**
+```sql
+SELECT
+    p.SEGMENT, p.AGE_GROUP, p.REGION,
+    COUNT(DISTINCT p.EMAIL_HASH) AS OVERLAP_COUNT
+FROM IDENTIFIER({{ source_table[0] }}) p
+INNER JOIN IDENTIFIER({{ my_table[0] }}) c
+    ON IDENTIFIER({{ provider_id | join_policy }}) = IDENTIFIER({{ consumer_id | join_policy }})
+GROUP BY p.SEGMENT, p.AGE_GROUP, p.REGION
+ORDER BY p.SEGMENT, p.AGE_GROUP, p.REGION
+```
+
+**V2 template body (`REGISTER_TEMPLATE` YAML `template:` field):**
+```sql
+SELECT
+    p.SEGMENT, p.AGE_GROUP, p.REGION,
+    COUNT(DISTINCT p.EMAIL_HASH) AS OVERLAP_COUNT
+FROM IDENTIFIER({{ source_table[0] }}) p
+JOIN IDENTIFIER({{ my_table[0] }}) c
+    ON p.EMAIL_HASH = c.EMAIL_HASH
+GROUP BY p.SEGMENT, p.AGE_GROUP, p.REGION
+HAVING COUNT(DISTINCT p.EMAIL_HASH) >= 1
+```
+
+**V1 `run_analysis` call:**
+```sql
+CALL samooha_by_snowflake_local_db.consumer.run_analysis(
+    $cleanroom_name, 'overlap_analysis',
+    ['DCR_V1_CONSUMER_DB.DATA.CUSTOMERS'],       -- consumer = arg 3 in V1
+    ['DCR_V1_PROVIDER_DB.DATA.CUSTOMER_SPEND_V'], -- provider = arg 4 in V1
+    object_construct('provider_id', 'p.EMAIL_HASH', 'consumer_id', 'c.EMAIL_HASH')
+);
+```
+
+**V2 `COLLABORATION.RUN` call:**
+```sql
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.RUN(
+    $collab_name,
+    'overlap_analysis_YYYYMMDD_V1',
+    ['owner_account.provider_customer_spend_v_YYYYMMDD_V1.customer_spend_v'],  -- provider = arg 3 in V2
+    ['collab_account.consumer_customers_YYYYMMDD_V1.customers'],               -- consumer = arg 4 in V2
+    OBJECT_CONSTRUCT()   -- no provider_id/consumer_id
+);
+```
+
+### Example: reach_analysis V1 → V2 (with string param)
+
+**V1 template body:**
+```sql
+SELECT
+    p.SEGMENT,
+    COUNT(DISTINCT p.EMAIL_HASH) AS TOTAL_PROVIDER,
+    COUNT(DISTINCT CASE WHEN c.EMAIL_HASH IS NOT NULL THEN p.EMAIL_HASH END) AS REACHABLE,
+    DIV0(...) AS REACH_RATE
+FROM IDENTIFIER({{ source_table[0] }}) p
+LEFT JOIN IDENTIFIER({{ my_table[0] }}) c
+    ON IDENTIFIER({{ provider_id | join_policy }}) = IDENTIFIER({{ consumer_id | join_policy }})
+WHERE p.SEGMENT = {{ segment }}
+GROUP BY p.SEGMENT
+```
+
+**V2 template body:**
+```sql
+SELECT
+    p.SEGMENT,
+    COUNT(DISTINCT p.EMAIL_HASH) AS TOTAL_PROVIDER,
+    COUNT(DISTINCT CASE WHEN c.EMAIL_HASH IS NOT NULL THEN p.EMAIL_HASH END) AS REACHABLE,
+    DIV0(...) AS REACH_RATE
+FROM IDENTIFIER({{ source_table[0] }}) p
+LEFT JOIN IDENTIFIER({{ my_table[0] }}) c
+    ON p.EMAIL_HASH = c.EMAIL_HASH
+WHERE p.SEGMENT = {{ segment }}    -- bare param unchanged; engine auto-quotes the string value
+GROUP BY p.SEGMENT
+```
+
+**V2 `COLLABORATION.RUN` call:**
+```sql
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.RUN(
+    $collab_name,
+    'reach_analysis_YYYYMMDD_V1',
+    ['owner_account.provider_customer_spend_v_YYYYMMDD_V1.customer_spend_v'],
+    ['collab_account.consumer_customers_YYYYMMDD_V1.customers'],
+    OBJECT_CONSTRUCT('segment', 'Premium')  -- no provider_id/consumer_id
+);
+```
+
+
+## Common Issues
+
+| Issue | Resolution |
+|---|---|
+| Collaboration name has spaces | DCR V2 names cannot contain spaces — replace with underscores in `collab_name` SET and YAML spec |
+| `$var` in GRANT fails with "unexpected '$var'"  | Use `IDENTIFIER($var)` in GRANT statements and `USE WAREHOUSE IDENTIFIER($var)` |
+| Template uses `\| join_policy` | Replace with hardcoded column: `ON p.<col> = c.<col>` |
+| Template has `\| sqlsafe` | Remove filter entirely — `{{ param }}` is the correct V2 pattern |
+| Template has `'{{ param }}'` (quoted) | Remove outer quotes — causes double-quoting `''value''` |
+| V2 template version already registered | Bump version string (e.g., `YYYYMMDD_V2`); or use `ADD_TEMPLATE_REQUEST` + `APPROVE_UPDATE_REQUEST` for a live collaboration |
+| Multiple consumer accounts in V1 | Add all consumers in `collaborator_identifier_aliases` and `analysis_runners` (one entry per runner) |
+| Consumer reusing existing V1 DB | Skip CREATE/INSERT in Step 2; only add SAMOOHA_APP_ROLE grants |
+| `LINK_LOCAL_DATA_OFFERING` fails | Confirm consumer has successfully JOINED before calling |
+| `COLLABORATION.RUN` returns `Object does not exist` | Call `LINK_LOCAL_DATA_OFFERING` first |
+| `InvalidDataOfferingIdFormat` on RUN | Verify 3-part ID format: `ALIAS.OFFERING_ID.DATASET_ALIAS` |
+| `COLLABORATION.INITIALIZE` fails | Confirm REFERENCE_USAGE WITH GRANT OPTION is granted before calling |

--- a/skills/dcr-v1-to-v2/user_guide.md
+++ b/skills/dcr-v1-to-v2/user_guide.md
@@ -1,0 +1,282 @@
+# DCR V1 → V2 Migration Skill — User Guide
+
+## What This Skill Does
+
+This Cortex Code Skill automates the migration of a Snowflake Data Clean Room from
+**V1** (SAMOOHA Provider/Consumer API) to **V2** (Collaboration API). It walks you through
+discovery, mapping, script generation, validation, and cleanup — producing local SQL files
+you review and run yourself. The skill never executes DDL or DML.
+
+---
+
+## What "V1" and "V2" Mean in This Skill
+
+Both V1 and V2 use the same SAMOOHA app (`SAMOOHA_BY_SNOWFLAKE` + `SAMOOHA_BY_SNOWFLAKE_LOCAL_DB`).
+The difference is which API schema they call:
+
+| Version | API | Provider example | Consumer example |
+|---|---|---|---|
+| **V1** | SAMOOHA Provider/Consumer API | `samooha_by_snowflake_local_db.provider.cleanroom_init(...)` | `samooha_by_snowflake_local_db.consumer.run_analysis(...)` |
+| **V2** | Collaboration API | `SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.INITIALIZE(...)` | `SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.RUN(...)` |
+
+> **Note:** This skill migrates V1 → V2. If your setup uses raw Snowflake shares
+> (no SAMOOHA app), that is a different migration path not covered here.
+
+---
+
+## Installation
+
+Copy the skill directory into your Cortex Code skills folder:
+
+```bash
+cp -r DCR_V1_to_V2/ ~/.snowflake/cortex/skills/dcr-v1-to-v2/
+```
+
+Verify it appears:
+
+```bash
+ls ~/.snowflake/cortex/skills/dcr-v1-to-v2/
+# Expected: SKILL.md  discover/  generate/  v1_v2_mapping.md  user_guide.md
+```
+
+The skill is available in your next Cortex Code session.
+
+---
+
+## Trigger Phrases
+
+Say any of the following to invoke the skill (do not trigger yet):
+
+- `/dcr-v1-to-v2`
+- `Migrate my DCR from V1 to V2`
+- `Upgrade my clean room from Provider/Consumer API to Collaboration API`
+- `Convert my cleanroom to the Collaboration API`
+- `DCR V1 to V2 migration`
+- `Migrate from SAMOOHA Provider/Consumer to Collaboration API`
+
+---
+
+## Prerequisites
+
+Before starting:
+
+1. **V1 provider account access** — SAMOOHA_APP_ROLE or ACCOUNTADMIN to run discovery queries
+   > **Note:** Connecting to the V1 provider account may require MFA. Check your device for an
+   > authentication prompt when establishing the connection.
+2. **"Snowflake Data Clean Rooms" (SAMOOHA) installed** on both provider and consumer accounts
+3. **Quick Start completed** on both accounts:
+   ```sql
+   USE ROLE ACCOUNTADMIN;
+   ALTER APPLICATION IF EXISTS Snowflake_Data_Clean_Rooms RENAME TO SAMOOHA_BY_SNOWFLAKE;
+   CALL SAMOOHA_BY_SNOWFLAKE.APP_SCHEMA.PREPARE_MOUNT_SCRIPT();
+   EXECUTE IMMEDIATE FROM @SAMOOHA_BY_SNOWFLAKE.APP_SCHEMA.MOUNT_CODE_STAGE/dcr_loader.sql;
+   USE ROLE SAMOOHA_APP_ROLE;
+   CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.LIBRARY.CHECK_MOUNT_STATUS();  -- must return TRUE
+   ```
+4. **The V1 clean room is active and functional** — capture baseline analysis results before migrating
+
+> **Important:** This skill runs entirely from the **V1 provider account**. You do not need to run
+> it from the consumer account. The generated consumer setup file (`v2_consumer_setup.sql`) is
+> handed off to the consumer to run on their account separately.
+
+---
+
+## How It Works
+
+The skill runs in **7 steps (0–6)** with 4 stopping points where you confirm before proceeding.
+
+### Step 0 — Connection Setup
+
+The skill checks the active Snowflake connection and asks you to confirm it is your V1
+**provider** account. All discovery queries run against the confirmed connection.
+
+**You confirm:** Which connection to use.
+
+### Step 1 — Discovery
+
+Read-only SAMOOHA introspection calls build a complete V1 inventory:
+
+- `provider.view_cleanrooms()` — clean room name, state, consumer accounts
+- `provider.view_provider_datasets()` — linked data objects (tables and secure views)
+- `provider.view_join_policy()` — join columns per dataset
+- `provider.view_added_templates()` — template names
+- Template body retrieval from clean room app package (or user-provided from original scripts)
+- Provider DB table and column structures
+
+**You review:** A `discovery_report.md`. Confirm before continuing.
+
+### Step 2 — Mapping
+
+Each V1 construct maps to its V2 equivalent:
+
+| V1 | V2 |
+|---|---|
+| `library.register_schema` | Explicit SAMOOHA_APP_ROLE grants (USAGE + SELECT + REFERENCE_USAGE WITH GRANT OPTION) |
+| `provider.cleanroom_init` | `COLLABORATION.INITIALIZE` (YAML spec) |
+| `provider.link_datasets` | `REGISTRY.REGISTER_DATA_OFFERING` |
+| `provider.set_join_policy` | `schema_and_template_policies` in data offering YAML |
+| `provider.add_custom_sql_template` | `REGISTRY.REGISTER_TEMPLATE` (YAML with template body) |
+| `provider.add_consumers` + `create_or_update_cleanroom_listing` | `collaborator_identifier_aliases` in INITIALIZE spec |
+| `consumer.install_cleanroom` | `COLLABORATION.JOIN` |
+| `consumer.link_datasets` | `REGISTRY.REGISTER_DATA_OFFERING` + `COLLABORATION.LINK_LOCAL_DATA_OFFERING` |
+| `consumer.run_analysis(name, tmpl, [consumer], [provider], args)` | `COLLABORATION.RUN(name, tmpl_id, [provider], [consumer], args)` |
+| `provider.drop_cleanroom` | `COLLABORATION.TEARDOWN` (two-call async) |
+| `consumer.uninstall_cleanroom` | `COLLABORATION.LEAVE` (two-call async) |
+
+Each template is classified as **auto-portable** or **stub-required**.
+
+**You review:** A mapping table. Confirm before continuing.
+
+### Step 3 — Script Generation
+
+Three SQL files are generated:
+
+| File | Contents |
+|---|---|
+| `v2_provider_setup.sql` | Warehouse, SAMOOHA_APP_ROLE grants, data offerings, templates, COLLABORATION.INITIALIZE, JOIN, validation |
+| `v2_consumer_setup.sql` | Warehouse, SAMOOHA_APP_ROLE grants, COLLABORATION.JOIN, data offering, LINK_LOCAL_DATA_OFFERING, RUN calls, validation |
+| `v2_cleanup.sql` | COLLABORATION.LEAVE (consumer, two calls) and COLLABORATION.TEARDOWN (provider, two calls) |
+
+**You review:** Confirm the output directory before files are written.
+
+### Step 4 — Validation Checklist
+
+A `validation_checklist.md` covers:
+- Prerequisites (SAMOOHA install, Quick Start, SAMOOHA_APP_ROLE grants)
+- Provider and consumer setup verification
+- LINK_LOCAL_DATA_OFFERING confirmation
+- Result comparison (V1 vs V2 for each template)
+- Cutover readiness
+
+### Step 5 — Cleanup Guidance
+
+A `cleanup_guidance.md` covers:
+- V1 archive recommendations (keep for rollback during validation period)
+- V1 cleanup SQL (`provider.drop_cleanroom`, `consumer.uninstall_cleanroom`)
+- V2 cleanup SQL (LEAVE/TEARDOWN two-call async pattern)
+
+### Step 6 — Summary
+
+Lists all generated files and the next steps to execute the migration.
+
+---
+
+## Output Files
+
+```
+<output_dir>/
+  discovery_report.md       — V1 inventory
+  mapping_report.md         — V1→V2 construct mapping
+  v2_provider_setup.sql     — V2 provider setup (Collaboration API)
+  v2_consumer_setup.sql     — V2 consumer setup (Collaboration API)
+  v2_cleanup.sql            — V2 cleanup (LEAVE/TEARDOWN two-call pattern)
+  validation_checklist.md   — Pre/post migration checklist
+  cleanup_guidance.md       — V1 archive and V2 decommission steps
+```
+
+---
+
+## Key Concepts
+
+### SAMOOHA_APP_ROLE Grants
+
+V1 used `library.register_schema` to grant privileges automatically. V2 requires explicit grants
+on both provider and consumer DBs before `INITIALIZE` or `JOIN`. The critical grant is:
+
+```sql
+GRANT REFERENCE_USAGE ON DATABASE <db> TO ROLE SAMOOHA_APP_ROLE WITH GRANT OPTION;
+```
+
+This enables the SAMOOHA backend to share data object references cross-account.
+Without it, `INITIALIZE` and `JOIN` will fail.
+
+### USE SECONDARY ROLES NONE
+
+All Collaboration API calls require `USE SECONDARY ROLES NONE` in the session before calling:
+`INITIALIZE`, `JOIN`, `RUN`, `LEAVE`, `TEARDOWN`, `LINK_LOCAL_DATA_OFFERING`.
+Forgetting this causes permission errors even when SAMOOHA_APP_ROLE is active.
+
+### join_policy Filter Removal
+
+V1 templates use `{{ provider_id | join_policy }}` / `{{ consumer_id | join_policy }}` to
+enforce the join column at runtime. V2 has no `join_policy` filter — the join column is
+hardcoded in the template body:
+
+```sql
+-- V1 template body
+ON IDENTIFIER({{ provider_id | join_policy }}) = IDENTIFIER({{ consumer_id | join_policy }})
+
+-- V2 template body (column name from view_join_policy)
+ON p.EMAIL_HASH = c.EMAIL_HASH
+```
+
+Also: remove `provider_id` and `consumer_id` from the `OBJECT_CONSTRUCT()` in `COLLABORATION.RUN`.
+
+### Arg Order Reversal
+
+**V1 `run_analysis`:** consumer tables (arg 3) → provider tables (arg 4)
+**V2 `COLLABORATION.RUN`:** provider source_tables (arg 3) → consumer my_tables (arg 4)
+
+This is reversed. Swapping these two args is one of the most common migration errors.
+
+### LINK_LOCAL_DATA_OFFERING
+
+After joining and registering their data offering, the consumer must call
+`COLLABORATION.LINK_LOCAL_DATA_OFFERING` before the first `COLLABORATION.RUN`. This creates
+data access views in the collaboration-local database. Without this step, `RUN` fails
+with "Object does not exist."
+
+### LEAVE/TEARDOWN Two-Call Pattern
+
+V2 cleanup is asynchronous:
+1. First call → status changes to LEAVING (consumer) or DROPPING (provider)
+2. Wait ~60 seconds
+3. Check `GET_STATUS` — when status is `LOCAL_DROP_PENDING`, call again
+4. Second call completes cleanup (LEFT / DROPPED)
+
+The consumer must complete LEAVE before the provider runs TEARDOWN.
+
+### Version Naming
+
+V2 offering and template versions must match `^[A-Za-z0-9_]{1,20}$`:
+- No dots, hyphens, or spaces
+- Max 20 characters
+- Recommended format: `YYYYMMDD_V1` (13 chars)
+
+Once a version is registered, it is immutable. Use bumped version strings for updates.
+
+---
+
+## Limitations
+
+- **No live execution.** The skill generates files — you run the SQL yourself.
+- **Complex template logic requires manual porting.** The skill generates stubs for templates
+  containing UDFs or procedural logic.
+- **Collaborator list is fixed after INITIALIZE.** All participants must be known before
+  creating the collaboration.
+- **Template versions are immutable.** Once registered, a version cannot be overridden.
+- **Non-standard V1 implementations** are out of scope.
+
+---
+
+## Skill File Structure
+
+```
+dcr-v1-to-v2/
+  SKILL.md                   — Main entry point (7-step workflow)
+  skill_evidence.yaml        — Skill metadata
+  discover/SKILL.md          — Sub-skill: V1 SAMOOHA introspection queries
+  discover/skill_evidence.yaml
+  generate/SKILL.md          — Sub-skill: V2 Collaboration API script generation
+  generate/skill_evidence.yaml
+  v1_v2_mapping.md           — Reference: V1→V2 mapping tables and conversion rules
+  user_guide.md              — This file
+```
+
+| File | Lines | Role |
+|---|---|---|
+| `SKILL.md` | ~307 | Orchestrates the full 7-step workflow; handles Steps 2/4/5/6 inline |
+| `discover/SKILL.md` | ~262 | Step 1: V1 SAMOOHA introspection discovery |
+| `generate/SKILL.md` | ~741 | Step 3: Collaboration API script generation with template conversion |
+| `v1_v2_mapping.md` | ~293 | Reference mapping tables (used by Steps 2 and 3) |
+| `user_guide.md` | — | This user-facing guide |

--- a/skills/dcr-v1-to-v2/v1_v2_mapping.md
+++ b/skills/dcr-v1-to-v2/v1_v2_mapping.md
@@ -1,0 +1,292 @@
+# DCR V1 → V2 Migration Mapping Reference
+
+Quick-reference for translating V1 (SAMOOHA Provider/Consumer API) constructs
+to V2 (Collaboration API).
+
+---
+
+## Architecture Overview
+
+| | V1 | V2 |
+|---|---|---|
+| **API schema** | `samooha_by_snowflake_local_db.provider.*` / `consumer.*` | `SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.*` / `REGISTRY.*` |
+| **Clean room unit** | Clean room (app package per clean room) | Collaboration (shared compute layer) |
+| **Data registration** | `link_datasets` (array of FQNs) | `REGISTRY.REGISTER_DATA_OFFERING` (YAML spec) |
+| **Policy enforcement** | `set_join_policy` (TABLE:COLUMN pairs) | `schema_and_template_policies` in offering YAML |
+| **Template registration** | `add_custom_sql_template` (raw JinjaSQL string) | `REGISTRY.REGISTER_TEMPLATE` (YAML spec with `template:` body) |
+| **Consumer onboarding** | `add_consumers` + `create_or_update_cleanroom_listing` | Declared in `COLLABORATION.INITIALIZE` YAML |
+| **Consumer setup** | `consumer.install_cleanroom` | `COLLABORATION.JOIN` |
+| **Session requirement** | None | `USE SECONDARY ROLES NONE` before all Collaboration API calls |
+| **DB grants** | `library.register_schema` (automatic) | Explicit SAMOOHA_APP_ROLE grants (manual) |
+
+---
+
+## API Call Mapping
+
+### Provider
+
+| V1 Call | V2 Equivalent |
+|---|---|
+| `samooha_by_snowflake_local_db.library.register_schema([...])` | `GRANT USAGE, SELECT, REFERENCES, REFERENCE_USAGE WITH GRANT OPTION` to `SAMOOHA_APP_ROLE` |
+| `samooha_by_snowflake_local_db.provider.cleanroom_init($name, 'EXTERNAL')` | `COLLABORATION.INITIALIZE($$...YAML...$$, '<warehouse>')` |
+| `samooha_by_snowflake_local_db.provider.link_datasets($name, [...])` | `REGISTRY.REGISTER_DATA_OFFERING($$...YAML...$$)` |
+| `samooha_by_snowflake_local_db.provider.set_join_policy($name, [...])` | `schema_and_template_policies` embedded in `REGISTER_DATA_OFFERING` YAML |
+| `samooha_by_snowflake_local_db.provider.add_custom_sql_template($name, 'tmpl', $$...$$)` | `REGISTRY.REGISTER_TEMPLATE($$...YAML...$$)` |
+| `samooha_by_snowflake_local_db.provider.add_consumers($name, $locator, $account)` | `collaborator_identifier_aliases` in `COLLABORATION.INITIALIZE` YAML |
+| `samooha_by_snowflake_local_db.provider.set_default_release_directive($name, 'V1_0', '0')` | Not needed in V2 |
+| `samooha_by_snowflake_local_db.provider.create_or_update_cleanroom_listing($name)` | Implicit in `COLLABORATION.INITIALIZE` |
+| `samooha_by_snowflake_local_db.provider.view_cleanrooms()` | `COLLABORATION.VIEW_COLLABORATIONS()` |
+| `samooha_by_snowflake_local_db.provider.view_provider_datasets($name)` | `REGISTRY.VIEW_REGISTERED_DATA_OFFERINGS()` |
+| `samooha_by_snowflake_local_db.provider.view_join_policy($name)` | Per-column policies in offering YAML |
+| `samooha_by_snowflake_local_db.provider.view_added_templates($name)` | `REGISTRY.VIEW_REGISTERED_TEMPLATES()` |
+| `samooha_by_snowflake_local_db.provider.view_cleanroom_scan_status($name)` | Not needed — no security scan in V2 |
+| `samooha_by_snowflake_local_db.provider.drop_cleanroom($name)` | `COLLABORATION.TEARDOWN($name)` — two-call async |
+
+### Consumer
+
+| V1 Call | V2 Equivalent |
+|---|---|
+| `samooha_by_snowflake_local_db.library.register_schema([...])` | Explicit SAMOOHA_APP_ROLE grants |
+| `samooha_by_snowflake_local_db.consumer.install_cleanroom($name, $provider_locator)` | `COLLABORATION.JOIN($name)` |
+| `samooha_by_snowflake_local_db.consumer.link_datasets($name, [...])` | `REGISTRY.REGISTER_DATA_OFFERING` + `COLLABORATION.LINK_LOCAL_DATA_OFFERING($name, $offering_id)` |
+| `samooha_by_snowflake_local_db.consumer.set_join_policy($name, [...])` | `schema_and_template_policies` in consumer offering YAML |
+| `samooha_by_snowflake_local_db.consumer.run_analysis($name, tmpl, [consumer], [provider], args)` | `COLLABORATION.RUN($name, tmpl_id, [provider], [consumer], args)` — **args 3 and 4 reversed** |
+| `samooha_by_snowflake_local_db.consumer.view_cleanrooms()` | `COLLABORATION.VIEW_COLLABORATIONS()` |
+| `samooha_by_snowflake_local_db.consumer.is_enabled($name)` | `COLLABORATION.GET_STATUS($name)` |
+| `samooha_by_snowflake_local_db.consumer.uninstall_cleanroom($name)` | `COLLABORATION.LEAVE($name)` — two-call async |
+
+---
+
+## Template Conversion Rules
+
+### Pattern Mapping
+
+| V1 JinjaSQL Pattern | V2 Replacement | Reason |
+|---|---|---|
+| `IDENTIFIER({{ source_table[0] }}) p` | `IDENTIFIER({{ source_table[0] }}) p` | Unchanged |
+| `IDENTIFIER({{ my_table[0] }}) c` | `IDENTIFIER({{ my_table[0] }}) c` | Unchanged |
+| `IDENTIFIER({{ source_table[N] }})` | `IDENTIFIER({{ source_table[N] }})` | Unchanged for N ≥ 1 |
+| `ON IDENTIFIER({{ provider_id \| join_policy }}) = IDENTIFIER({{ consumer_id \| join_policy }})` | `ON p.<join_col> = c.<join_col>` | `join_policy` filter not supported in V2; hardcode column |
+| `{{ param }}` | `{{ param }}` | Engine auto-quotes strings; no change needed |
+| `'{{ param }}'` | `{{ param }}` | Remove outer quotes — causes double-quoting `''value''` in V2 |
+| `{{ param \| sqlsafe }}` | `{{ param }}` | `sqlsafe` is incompatible with V2 Snowpark parameterized binding |
+
+### How the Join Policy Changes
+
+**V1:** The `join_policy` filter validates at runtime that the caller-supplied column reference
+(`provider_id`, `consumer_id`) matches the registered join policy. The template body is generic —
+it does not name the actual join column.
+
+**V2:** There is no `join_policy` filter. Security is enforced by `allowed_analyses: template_only`
+in the data offering (prevents direct data access) and by `schema_and_template_policies` (declares
+which columns are available). The template body hardcodes the join column name.
+
+**Migration:** Replace the `join_policy` expression using the column discovered in `view_join_policy`:
+
+```sql
+-- V1 template body
+ON IDENTIFIER({{ provider_id | join_policy }}) = IDENTIFIER({{ consumer_id | join_policy }})
+
+-- V2 template body (EMAIL_HASH discovered from view_join_policy)
+ON p.EMAIL_HASH = c.EMAIL_HASH
+```
+
+Also remove `'provider_id'` and `'consumer_id'` from the `COLLABORATION.RUN` `OBJECT_CONSTRUCT()` args.
+
+---
+
+## run_analysis → COLLABORATION.RUN Arg Order
+
+**This is the most error-prone migration step.** Args 3 and 4 are swapped.
+
+**V1 `consumer.run_analysis`:**
+```sql
+CALL samooha_by_snowflake_local_db.consumer.run_analysis(
+    $cleanroom_name,           -- arg 1: clean room name
+    'template_name',           -- arg 2: plain template name
+    ['consumer_table_fqn'],    -- arg 3: CONSUMER tables → populates my_table[]
+    ['provider_table_fqn'],    -- arg 4: PROVIDER tables → populates source_table[]
+    object_construct(...)      -- arg 5: includes provider_id, consumer_id, other params
+);
+```
+
+**V2 `COLLABORATION.RUN`:**
+```sql
+CALL SAMOOHA_BY_SNOWFLAKE_LOCAL_DB.COLLABORATION.RUN(
+    $collab_name,              -- arg 1: collaboration name
+    'template_id',             -- arg 2: name_version (e.g., overlap_analysis_YYYYMMDD_V1)
+    ['provider_3part_id'],     -- arg 3: PROVIDER offerings → source_tables (REVERSED from V1)
+    ['consumer_3part_id'],     -- arg 4: CONSUMER offerings → my_tables   (REVERSED from V1)
+    OBJECT_CONSTRUCT(...)      -- arg 5: other params only; no provider_id/consumer_id
+);
+```
+
+**Migration checklist:**
+- Swap arg 3 (V1 consumer) → arg 4 in V2
+- Swap arg 4 (V1 provider) → arg 3 in V2
+- Change table FQNs to 3-part IDs: `ALIAS.DATA_OFFERING_ID.DATASET_ALIAS`
+- Remove `provider_id` and `consumer_id` from `OBJECT_CONSTRUCT`
+- Change template name to composite ID: `name_version`
+
+---
+
+## V2 Data Offering YAML Structure
+
+```yaml
+api_version: 2.0.0
+spec_type: data_offering
+name: <offering_name>               # snake_case, e.g., provider_customer_spend_v
+version: <YYYYMMDD_V1>             # must match ^[A-Za-z0-9_]{1,20}$ — no dots
+description: <text>
+datasets:
+  - alias: <short_name>             # used as DATASET_ALIAS in 3-part RUN ID
+    data_object_fqn: <db.schema.object>
+    allowed_analyses: template_only
+    schema_and_template_policies:
+      <COLUMN_NAME>:
+        category: passthrough       # for hashed/synthetic columns
+      <DATE_COL>:
+        category: timestamp         # for date/time columns
+```
+
+Data offering ID (returned by `REGISTER_DATA_OFFERING`) = `name_version`
+(e.g., `provider_customer_spend_v_YYYYMMDD_V1`)
+
+---
+
+## V2 Template YAML Structure
+
+```yaml
+api_version: 2.0.0
+spec_type: template
+name: <template_name>               # e.g., overlap_analysis
+version: <YYYYMMDD_V1>             # must match ^[A-Za-z0-9_]{1,20}$
+type: sql_analysis
+description: <text>
+template: |
+    SELECT ...
+    FROM IDENTIFIER({{ source_table[0] }}) p
+    JOIN IDENTIFIER({{ my_table[0] }})     c  ON p.<join_col> = c.<join_col>
+    WHERE p.COL = {{ param }}              -- bare param; engine auto-quotes strings
+    GROUP BY ...
+```
+
+Template ID (returned by `REGISTER_TEMPLATE`) = `name_version`
+(e.g., `overlap_analysis_YYYYMMDD_V1`)
+
+**Note:** Template versions are immutable. To update a template on a running collaboration:
+1. Register a new version with a bumped version string
+2. `COLLABORATION.ADD_TEMPLATE_REQUEST(collab, new_template_id, [runner_alias])`
+3. Both owner and runner call `COLLABORATION.APPROVE_UPDATE_REQUEST(collab, request_id)`
+4. Wait for request to reach COMPLETED status before using the new template ID
+
+---
+
+## V2 COLLABORATION.INITIALIZE YAML Structure
+
+```yaml
+api_version: 2.0.0
+spec_type: collaboration
+name: <COLLABORATION_NAME>
+owner: owner_account                # must match an alias below
+collaborator_identifier_aliases:
+    owner_account: <provider_org.account>    # e.g., SFPSCOGS.WLIN_DCR_AWS_W2
+    collab_account: <consumer_org.account>   # e.g., SFPSCOGS.WLIN_AWS_W2
+analysis_runners:
+    collab_account:                 # consumer/runner alias
+        data_providers:
+            owner_account:          # provider alias supplies data
+                data_offerings:
+                    - id: <offering_id_1>   # name_version
+                    - id: <offering_id_N>
+        templates:
+            - id: <template_id_1>           # name_version
+            - id: <template_id_N>
+```
+
+**Note:** Collaborator list is fixed after `INITIALIZE` — you cannot add or remove
+participants later. All parties must be declared upfront.
+
+---
+
+## SAMOOHA_APP_ROLE Grants (V2 Requirement)
+
+V1 used `library.register_schema` to grant privileges automatically. V2 requires explicit grants
+on both provider and consumer DBs before `COLLABORATION.INITIALIZE` / `COLLABORATION.JOIN`.
+
+```sql
+-- Provider DB (run before COLLABORATION.INITIALIZE)
+GRANT USAGE           ON DATABASE <provider_db>                           TO ROLE SAMOOHA_APP_ROLE;
+GRANT USAGE           ON SCHEMA   <provider_db>.<schema>                  TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL TABLES IN SCHEMA <provider_db>.<schema>      TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL VIEWS  IN SCHEMA <provider_db>.<schema>      TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCES      ON ALL VIEWS  IN SCHEMA <provider_db>.<schema>      TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCE_USAGE ON DATABASE <provider_db>  TO ROLE SAMOOHA_APP_ROLE WITH GRANT OPTION;
+
+-- Consumer DB (run before COLLABORATION.JOIN)
+GRANT USAGE           ON DATABASE <consumer_db>                           TO ROLE SAMOOHA_APP_ROLE;
+GRANT USAGE           ON SCHEMA   <consumer_db>.<schema>                  TO ROLE SAMOOHA_APP_ROLE;
+GRANT SELECT          ON ALL TABLES IN SCHEMA <consumer_db>.<schema>      TO ROLE SAMOOHA_APP_ROLE;
+GRANT REFERENCE_USAGE ON DATABASE <consumer_db>  TO ROLE SAMOOHA_APP_ROLE WITH GRANT OPTION;
+```
+
+`REFERENCE_USAGE WITH GRANT OPTION` is required so the SAMOOHA backend can share data object
+references cross-account for the collaboration data access layer.
+
+---
+
+## LEAVE / TEARDOWN Two-Call Pattern
+
+V2 collaboration cleanup is asynchronous. Each side requires two calls with a wait:
+
+```
+Consumer (first):
+  COLLABORATION.LEAVE($name)    → status: LEAVING
+  [wait ~60s]
+  GET_STATUS($name)             → status: LOCAL_DROP_PENDING
+  COLLABORATION.LEAVE($name)    → status: LEFT
+
+Provider (after consumer is LEFT):
+  COLLABORATION.TEARDOWN($name) → status: DROPPING
+  [wait ~60s]
+  GET_STATUS($name)             → status: LOCAL_DROP_PENDING
+  COLLABORATION.TEARDOWN($name) → status: DROPPED
+```
+
+---
+
+## Key Gotchas
+
+1. **`USE SECONDARY ROLES NONE` is mandatory.** All Collaboration API calls require this in
+   the session. Forgetting it causes permission errors even when the correct role is active.
+
+2. **Arg 3/4 reversed between V1 and V2.** V1 `run_analysis`: consumer first (arg 3), provider
+   second (arg 4). V2 `COLLABORATION.RUN`: provider first (arg 3), consumer second (arg 4).
+
+3. **Template versions are immutable.** Cannot re-register an existing version. Use unique
+   version strings (e.g., `YYYYMMDD_V1`, `YYYYMMDD_V2`) and the update-request workflow for live collaborations.
+
+4. **Version naming regex `^[A-Za-z0-9_]{1,20}$`.** No dots, hyphens, or spaces. Max 20 chars.
+   Use `YYYYMMDD_V1` format (13 chars, safe).
+
+5. **`LINK_LOCAL_DATA_OFFERING` must precede first `RUN`.** The consumer must call this after
+   joining and registering their data offering. Without it, `RUN` fails with "Object does not exist."
+
+6. **Grants must be in place before INITIALIZE/JOIN.** SAMOOHA_APP_ROLE must have
+   REFERENCE_USAGE WITH GRANT OPTION on the data DB before these calls. If grants are
+   added after INITIALIZE, call `COLLABORATION.JOIN` explicitly — the auto-join task may
+   have already fired and failed.
+
+7. **Collaborator list is fixed after INITIALIZE.** All participants must be declared in
+   the INITIALIZE YAML upfront.
+
+8. **No `DELETE_DATA_OFFERING` or `DELETE_TEMPLATE` procedures.** Registry entries cannot be
+   individually deleted. They are cleaned up automatically when the SAMOOHA app is uninstalled.
+
+9. **3-part RUN ID format.** Table IDs in `COLLABORATION.RUN` must use
+   `ALIAS.DATA_OFFERING_ID.DATASET_ALIAS`. Using a plain FQN or offering ID alone fails
+   with `InvalidDataOfferingIdFormat`.
+
+10. **No security scan wait.** V1 `EXTERNAL` clean rooms required waiting for
+    `view_cleanroom_scan_status` to return `SUCCEEDED` before publishing. V2 has no security
+    scan — `COLLABORATION.INITIALIZE` completes without a scan wait.


### PR DESCRIPTION
## Summary

Promotes the `dcr-v1-to-v2` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
