### PR TITLE
Promote openflow-spcs-privatelink from Snowflake-Solutions

### DIFF
--- a/skills/openflow-spcs-privatelink/LICENSE
+++ b/skills/openflow-spcs-privatelink/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/openflow-spcs-privatelink/SKILL.md
+++ b/skills/openflow-spcs-privatelink/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: setup-openflow-privatelink
+title: OpenFlow PrivateLink Setup
+summary: Set up AWS PrivateLink between OpenFlow on SPCS and private data sources like RDS or on-prem databases.
+description: |
+  Use when configuring private connectivity from Snowflake OpenFlow (running on SPCS) to AWS-hosted or on-premises data sources via AWS PrivateLink. Covers NLB + VPC Endpoint Service on AWS, then SYSTEM$PROVISION_PRIVATELINK_ENDPOINT, network rules, and External Access Integration on Snowflake. AWS only (Public Preview also exists on Azure but is out of scope here). Triggers: OpenFlow PrivateLink, SPCS private connectivity, NLB for OpenFlow, EAI for OpenFlow, SYSTEM$PROVISION_PRIVATELINK_ENDPOINT, OpenFlow RDS, OpenFlow MySQL, OpenFlow PostgreSQL, private ingestion OpenFlow, SPCS egress.
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - Read
+  - Write
+  - Edit
+prompt: Help me connect OpenFlow on SPCS to my private RDS MySQL instance using AWS PrivateLink.
+language: en
+status: Published
+author: Snowflake Solutions Team
+type: snowflake
+---
+
+## Overview
+
+Connect OpenFlow on SPCS to private data sources (RDS, on-prem DBs reachable via Direct Connect/VPN) through AWS PrivateLink. The flow:
+
+```
+OpenFlow (SPCS) → EAI → Network Rule (PRIVATE_HOST_PORT)
+                  → Outbound PrivateLink Endpoint
+                  → AWS VPC Endpoint Service → Internal NLB
+                  → Target Group(s) → RDS / on-prem DB (via TCP proxy if needed)
+```
+
+Each NLB listener uses a unique port (any port > 1024) so multiple instances sharing the same backend port (e.g., two MySQL on 3306) can be disambiguated.
+
+## Prerequisites
+
+- AWS permissions: NLB, target groups, endpoint services, security groups
+- Snowflake `ACCOUNTADMIN`
+- OpenFlow already deployed on SPCS
+- One or more data sources in a private VPC (or on-prem with VPC connectivity)
+
+## Phase 1 — AWS infrastructure
+
+1. **Target groups (IP type)** — one per database, TCP on the DB port, registered with the private IP of each instance (or a TCP proxy EC2 IP if the source is on-prem with non-RFC1918 addresses).
+2. **Internal NLB** — TCP listeners on unique custom ports (e.g., 3301, 3302), each forwarding to its target group. Enable cross-zone load balancing. Set `dns_record.client_routing_policy=any_availability_zone`.
+3. **VPC Endpoint Service** — fronts the NLB. Keep manual acceptance enabled (default).
+
+⚠️ STOPPING POINT: Confirm `describe-target-health` shows `healthy` and the NLB state is `active` before continuing. Record `nlb_dns_name`, `endpoint_service_name`, and listener ports.
+
+On-prem targets outside RFC1918/RFC6598 ranges require a single TCP proxy EC2 (NGINX/HAProxy/Envoy in TCP mode) registered into the target groups.
+
+## Phase 2 — Snowflake side
+
+1. Get Snowflake's account principal:
+   ```sql
+   SELECT key, value FROM TABLE(FLATTEN(INPUT => PARSE_JSON(SYSTEM$GET_PRIVATELINK_CONFIG())));
+   ```
+   Add the `privatelink-account-principal` ARN to the endpoint service's allowed principals via `aws ec2 modify-vpc-endpoint-service-permissions`.
+
+2. Provision the endpoint:
+   ```sql
+   USE ROLE ACCOUNTADMIN;
+   SELECT SYSTEM$PROVISION_PRIVATELINK_ENDPOINT('<endpoint_service_name>', '<nlb_dns_name>');
+   ```
+
+3. Accept the pending connection in AWS (`aws ec2 accept-vpc-endpoint-connections`).
+
+⚠️ STOPPING POINT: Run `SELECT SYSTEM$GET_PRIVATELINK_ENDPOINTS_INFO();` and wait until `status` is `available` (30–40s) before creating the network rule.
+
+4. Network rule + EAI:
+   ```sql
+   CREATE OR REPLACE NETWORK RULE <rule_name>
+     MODE = EGRESS
+     TYPE = PRIVATE_HOST_PORT
+     VALUE_LIST = ('<nlb_dns_name>:<port1>', '<nlb_dns_name>:<port2>');
+
+   CREATE OR REPLACE EXTERNAL ACCESS INTEGRATION <eai_name>
+     ALLOWED_NETWORK_RULES = (<rule_name>)
+     ENABLED = TRUE;
+   ```
+
+5. In OpenFlow UI: Runtime console → `...` → **Associate External Access Integration** → pick `<eai_name>`.
+
+6. Validate by pointing a connector at `<nlb_dns_name>:<listener_port>`.
+
+## Common Mistakes
+
+- **Reusing a backend port as the NLB listener port** when multiple instances share it — listeners must be unique.
+- **Uppercase letters in `VALUE_LIST`** — the NLB FQDN must be lowercase, otherwise `Invalid VALUE_LIST`.
+- **Forgetting to accept the AWS endpoint connection** — the endpoint stays in `pendingAcceptance` forever.
+- **Skipping the account-principal allowlist** — `SYSTEM$PROVISION_PRIVATELINK_ENDPOINT` will fail.
+- **Security group on RDS not allowing the NLB's SG** on the DB port — target health flips unhealthy.
+- **Deleting the NLB before deprovisioning** the Snowflake endpoint — leaves a dangling endpoint.
+- **On-prem IPs outside RFC1918/RFC6598** registered directly — NLB rejects; use a TCP proxy EC2 instead.
+- **Using `PRIVATE_HOST_PORT` against the DB hostname** — use the NLB DNS name, not the database's.
+
+## Troubleshooting quick reference
+
+| Symptom | Check |
+|---|---|
+| Endpoint stuck `pendingAcceptance` | Accept it in AWS VPC > Endpoint Services |
+| Targets unhealthy | RDS/proxy SG inbound from NLB SG on DB port |
+| `Invalid VALUE_LIST` | NLB DNS must be lowercase |
+| Endpoint `failed` | `SYSTEM$DEPROVISION_PRIVATELINK_ENDPOINT` then re-provision; `SYSTEM$RESTORE_PRIVATELINK_ENDPOINT` recovers within 7 days |
+| Traffic drops despite healthy targets | VPC NACLs: inbound listener ports, outbound 1024–65535 |
+
+## Cleanup
+
+⚠️ STOPPING POINT: Confirm with the user before running any `DROP` / `delete-*` commands below.
+
+Order matters — Snowflake first, then AWS:
+
+1. OpenFlow UI: disassociate EAI from runtime.
+2. `DROP EXTERNAL ACCESS INTEGRATION <eai_name>; DROP NETWORK RULE <rule_name>;`
+3. `SELECT SYSTEM$DEPROVISION_PRIVATELINK_ENDPOINT('<endpoint_service_name>');`
+4. `aws ec2 delete-vpc-endpoint-service-configurations`, then delete NLB, then target groups.
+
+## Stopping Points
+
+- Phase 1 — wait for healthy targets and active NLB before creating the endpoint service
+- Phase 2 step 3 — wait until `SYSTEM$GET_PRIVATELINK_ENDPOINTS_INFO()` returns `available` before creating the network rule
+- Cleanup — confirm with the user before running any destructive `DROP` / `delete-*` commands
+
+## Cost note
+
+NLB (hourly + LCU), VPC Endpoint Service (hourly), PrivateLink endpoint (hourly + per-GB), and cross-zone data transfer all incur AWS charges. Check current AWS pricing.

--- a/skills/openflow-spcs-privatelink/TROUBLESHOOTING.md
+++ b/skills/openflow-spcs-privatelink/TROUBLESHOOTING.md
@@ -1,0 +1,111 @@
+# Troubleshooting: OpenFlow SPCS PrivateLink
+
+## Network Rule `VALUE_LIST is not valid`
+
+This is the most common error during Phase 2 Step 5. Check the following in order:
+
+1. **Stray characters in the DNS name**: Ensure no extra characters like `>`, `<`, spaces, or trailing slashes exist in the value list entries. Example of a common typo:
+   ```sql
+   -- WRONG: stray '>' character
+   VALUE_LIST = ('my-nlb.elb.us-east-1.amazonaws.com>:3306')
+   -- CORRECT:
+   VALUE_LIST = ('my-nlb.elb.us-east-1.amazonaws.com:3306')
+   ```
+
+2. **Private endpoint not yet `available`**: The network rule with `TYPE = PRIVATE_HOST_PORT` requires the PrivateLink endpoint to be fully provisioned. Verify:
+   ```sql
+   SELECT SYSTEM$GET_PRIVATELINK_ENDPOINTS_INFO();
+   ```
+   Status must be `available`, not `pendingAcceptance` or `provisioning`.
+
+3. **DNS name mismatch**: The DNS name in `VALUE_LIST` must exactly match the `nlb_dns_name` passed to `SYSTEM$PROVISION_PRIVATELINK_ENDPOINT`. Compare against the `endpointHost` in the output of `SYSTEM$GET_PRIVATELINK_ENDPOINTS_INFO()`.
+
+4. **Wrong TYPE or MODE**: Must be exactly `TYPE = PRIVATE_HOST_PORT` (not `HOST_PORT`) and `MODE = EGRESS` (not `INGRESS`).
+
+5. **Incorrect format**: Each entry must be `'host:port'` — no protocol prefix, no quotes around the whole list:
+   ```sql
+   -- WRONG:
+   VALUE_LIST = ('tcp://my-nlb...:3306')
+   VALUE_LIST = ('10.0.1.5:3306')   -- IPs not allowed, must be DNS
+   -- CORRECT:
+   VALUE_LIST = ('my-nlb.elb.us-east-1.amazonaws.com:3306')
+   ```
+
+6. **Missing port**: Every entry must include a port. Use `:0` to allow any port on that host.
+
+---
+
+## NLB Target Group Unhealthy
+
+1. **RDS security group missing inbound rule**: The most common cause. Add an inbound rule to the RDS instance's security group:
+   - **Type**: MySQL/Aurora (or Custom TCP)
+   - **Protocol**: TCP
+   - **Port**: 3306 (or your database port)
+   - **Source**: The NLB's security group ID, or if the NLB has no security group (internal NLBs created before 2023), use the NLB's private subnet CIDRs
+
+2. **RDS IP address changed**: RDS private IPs can change after maintenance, failover, or reboot. Resolve the current IP and compare with the target group:
+   ```bash
+   nslookup <your-rds-endpoint>.rds.amazonaws.com
+   ```
+   If the IP changed, update the registered targets in the target group:
+   ```bash
+   # Deregister old IP
+   aws elbv2 deregister-targets \
+     --target-group-arn <target-group-arn> \
+     --targets Id=<old-ip>,Port=3306
+
+   # Register new IP
+   aws elbv2 register-targets \
+     --target-group-arn <target-group-arn> \
+     --targets Id=<new-ip>,Port=3306
+   ```
+
+3. **Health check misconfiguration**: Go to **EC2 > Target Groups > Health checks** and verify:
+   - **Protocol**: TCP
+   - **Port**: 3306 (or "traffic port")
+
+4. **VPC/AZ mismatch**: NLB subnets must be in the same VPC as the RDS instance and ideally in overlapping AZs.
+
+---
+
+## OpenFlow Connector Cannot Reach Data Source
+
+Walk through these checks in order:
+
+1. **Private endpoint available?**
+   ```sql
+   SELECT SYSTEM$GET_PRIVATELINK_ENDPOINTS_INFO();
+   ```
+
+2. **EAI properly associated?** Verify via the OpenFlow UI: navigate to the runtime, click **...** > **Associate External Access Integration**, and confirm your custom EAI is selected.
+
+3. **NLB targets healthy?** Check in AWS: **EC2 > Target Groups** — targets must show healthy.
+   ```bash
+   aws elbv2 describe-target-health \
+     --target-group-arn <target-group-arn>
+   ```
+
+4. **Connector using correct hostname and port?** The OpenFlow MySQL connector must use the **NLB DNS name** and **NLB listener port** (e.g., 3301), not the RDS endpoint or native port (3306) directly.
+
+5. **Database credentials correct?** Verify the MySQL username/password in the connector configuration are valid for the target RDS instance.
+
+---
+
+## `SYSTEM$PROVISION_PRIVATELINK_ENDPOINT` Fails
+
+1. **Snowflake account principal not authorized**: Retrieve the principal ARN:
+   ```sql
+   SELECT key, value FROM TABLE(FLATTEN(INPUT =>
+     PARSE_JSON(SYSTEM$GET_PRIVATELINK_CONFIG()))
+   );
+   ```
+   Add the `privatelink-account-principal` ARN to **VPC > Endpoint Services > Allow principals** in AWS.
+
+2. **Endpoint service name incorrect**: The service name must match exactly (e.g., `com.amazonaws.vpce.us-east-1.vpce-svc-0ea9e`). Copy it directly from the AWS console.
+
+3. **Region mismatch**: The Snowflake account and the VPC Endpoint Service must be in the same AWS region.
+
+4. **Missing ACCOUNTADMIN role**: This function requires ACCOUNTADMIN:
+   ```sql
+   USE ROLE ACCOUNTADMIN;
+   ```


### PR DESCRIPTION
## Summary

Promotes the `openflow-spcs-privatelink` skill from the internal `Snowflake-Solutions/cortex-code-skills` repo to public Labs, rewritten for an external builder audience (developers, data engineers).

Run through the v1.1.0 audit pipeline:
- Holistic LLM rewrite for builder audience
- All internal Snowflake references substituted with public equivalents (e.g., Snowhouse -> ACCOUNT_USAGE)
- `audience.no_internal_refs` check passes
- Sub-skills folded into `<sub>/INSTRUCTIONS.md` per the umbrella precedent (`manage-zerocopy-sapbdc`)

## Test plan

- [x] Audit `blocking_failures == 0`
- [x] `audience.no_internal_refs` passes
- [x] Frontmatter matches Labs conventions (snowflake-docs / manage-zerocopy-sapbdc precedents)
- [x] LICENSE present (Snowflake)
- [x] No `Snowflake-Solutions` repo path leakage
- [x] No nested SKILL.md in sub-skill dirs (all converted to INSTRUCTIONS.md)
