### PR TITLE
Add quickstart-guide skill for interactive Quickstart learning

### DIFF
--- a/skills/quickstart-guide/LICENSE
+++ b/skills/quickstart-guide/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, "Skills")) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake's Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/quickstart-guide/SKILL.md
+++ b/skills/quickstart-guide/SKILL.md
@@ -1,0 +1,286 @@
+---
+name: quickstart-guide
+title: Learn Snowflake Quickstarts
+summary: Paste a Snowflake Quickstart URL and get a guided, interactive learning experience.
+description: >-
+  Use when a user pastes a Snowflake Quickstart URL or asks to learn/walk through a Quickstart.
+  Fetches the source content from GitHub, parses it into stages, checks the learner's environment,
+  and delivers a guided build experience with two modes (learner or builder).
+  Triggers: quickstarts.snowflake.com, snowflake.com/en/developers/guides/, walk me through this
+  quickstart, teach me this quickstart, learn this guide, I want to do this quickstart.
+  Do NOT use for general SQL help or non-Quickstart tutorials.
+tools:
+  - snowflake_sql_execute
+  - web_fetch
+  - Bash
+  - Read
+  - Write
+  - ask_user_question
+prompt: "$quickstart-guide https://www.snowflake.com/en/developers/guides/getting-started-with-cortex-agents/"
+language: en
+status: Published
+author: Gilberto Hernandez
+type: snowflake
+---
+
+# Quickstart Guide
+
+Take a Snowflake Quickstart URL and deliver a guided, interactive learning experience. The learner pastes a link; you fetch the content, plan the build, check their environment, and teach it live.
+
+## When to Use
+
+Trigger this skill when the user's input contains a URL matching either pattern:
+
+- `https://www.snowflake.com/en/developers/guides/<slug>` (trailing slash optional)
+- `https://quickstarts.snowflake.com/guide/<slug>` (trailing slash optional, legacy pattern)
+
+Also trigger when the user says something like "walk me through [quickstart name]" or "teach me [quickstart topic]" alongside a URL.
+
+## Workflow
+
+### Step 1: Detect and Extract Slug
+
+Parse the URL to extract the Quickstart slug.
+
+**New pattern:** `https://www.snowflake.com/en/developers/guides/<slug>`
+- Extract everything after `/guides/` up to the next `/` or end of string
+
+**Old pattern:** `https://quickstarts.snowflake.com/guide/<slug>`
+- Extract everything after `/guide/` up to the next `/` or end of string
+- Note: old slugs may use underscores where new ones use hyphens
+
+Store the extracted slug for Step 2.
+
+### Step 2: Fetch Quickstart Content
+
+Retrieve the source markdown from GitHub. The Quickstart source lives at:
+`https://github.com/Snowflake-Labs/sfquickstarts` under `site/sfguides/src/<folder>/`
+
+**Fetch sequence:**
+
+1. **Get the folder listing.** Use `web_fetch` on:
+   `https://api.github.com/repos/Snowflake-Labs/sfquickstarts/contents/site/sfguides/src/<slug>`
+   This returns a JSON array of file objects.
+
+2. **If 404, try slug variations:**
+   - Replace hyphens with underscores (or vice versa)
+   - Try the original slug with/without trailing characters
+   - Repeat the folder listing request with the alternate slug
+
+3. **Fetch the raw markdown.** From the JSON array response, access and read the raw markdown content by fetching the value for the `download_url` key of the `.md` file.
+
+4. **Verify the content.** Read the first ~20 lines of the fetched markdown. Check that the `id:` field in the frontmatter matches the URL slug. If it doesn't match, you may have the wrong Quickstart — try another variation.
+
+5. **Fallback.** If GitHub fetch fails entirely (repo restructured, file moved), fall back to `web_fetch` on the original URL the user pasted. Parse whatever structured content is available from the rendered page.
+
+**If fetch fails completely:** Tell the learner the content couldn't be retrieved. Ask if they have the content locally or can provide an alternative URL.
+
+### Step 3: Parse and Plan Stages
+
+Load `references/quickstart-parsing.md` for detailed structure rules.
+
+From the fetched markdown, extract:
+
+1. **Metadata** from frontmatter: `id`, `summary` (title), `authors`, `categories`, `duration`
+2. **Prerequisites** from the Prerequisites/Setup steps: roles, privileges, warehouses, external tools
+3. **Logical stages** by mapping Quickstart steps:
+   - Overview/Prerequisites → inputs for diagnostics (Step 5)
+   - Setup/Environment → Stage 1 (schema, grants, warehouse)
+   - Core tutorial steps → Stages 2-N (one per major deliverable)
+   - Steps with external dependencies (SPCS, third-party tools) → optional stages
+   - Conclusion → use as source material for the recap in Step 8
+4. **Code blocks** (SQL, Python, YAML) — these are what gets executed or written to files
+5. **Final deliverable** — what the learner will have when done
+
+Target 4-8 stages total. Combine small steps; split large ones.
+
+### Step 4: Check for Companion Repo
+
+Many Quickstarts have a companion GitHub repo containing SQL scripts, Python code, YAML configs, or data files. Check for one.
+
+**Detection:**
+- Look for a `fork repo link:` field in the Quickstart frontmatter
+- Scan the markdown body for GitHub URLs pointing to a `Snowflake-Labs/sfguide-*` repo (typically in a Prerequisites or Setup step)
+
+**If a companion repo is found:**
+
+1. Use the GitHub API to list its top-level contents:
+   `https://api.github.com/repos/<owner>/<repo>/contents/`
+   Note the key files (`.sql`, `.py`, `.yaml`, `.json`, notebooks).
+
+2. Present the finding to the learner: "This Quickstart has a companion repo at [url] containing [list key files — e.g., setup.sql, app.py, model.yaml]."
+
+3. Ask the learner via `ask_user_question`:
+   - **Clone it** — "Download the full repo to my machine. I'll use the files directly." Best if you want to keep the code after the session.
+   - **Reference it (lightweight)** — "Don't download anything. Access individual files from GitHub as needed." No git clone — files are fetched on demand during the build, same way the Quickstart markdown was fetched.
+
+4. **If Clone:** Ask where to clone (suggest current directory as default). Run `git clone <url> <path>`. Reference files from the cloned path during execution.
+
+5. **If Reference (lightweight):** During Step 7 execution, fetch individual files on demand via the GitHub API (`download_url` from the contents listing) — the same pattern used for the Quickstart markdown itself. No local clone needed.
+
+**If no companion repo is found:** Skip this step silently.
+
+**⚠️ STOPPING POINT**: Wait for the learner's choice before proceeding.
+
+### Step 5: Lightweight Diagnostics
+
+Check that the learner's environment can handle this Quickstart.
+
+**Run session context:**
+```sql
+SELECT CURRENT_ORGANIZATION_NAME(), CURRENT_ACCOUNT_NAME(), CURRENT_ROLE(),
+       CURRENT_WAREHOUSE(), CURRENT_DATABASE(), CURRENT_USER();
+```
+
+**Check grants on current role:**
+```sql
+SHOW GRANTS TO ROLE <current_role>;
+```
+
+**Compare against Quickstart requirements:**
+- Does the role have CREATE SCHEMA/TABLE/VIEW privileges?
+- Is a warehouse set and active?
+- Does the Quickstart need specific features (Cortex, SPCS, Streamlit)?
+- Does the Quickstart need access to SNOWFLAKE_SAMPLE_DATA or ACCOUNT_USAGE?
+
+**Present findings:**
+- If ready: "Your environment looks good for this Quickstart."
+- If gaps: List what's missing with specific GRANT statements to fix each one.
+
+**⚠️ STOPPING POINT**: If issues found, present them. Ask the learner: "Want to fix these first, or proceed anyway?" Do not block — let them choose.
+
+### Step 6: Introduce and Choose Mode
+
+**Attribution:**
+"This is the *[title from summary field]* Quickstart."
+
+**Explain the deliverable:**
+Summarize what the learner will have at the end — the tables, services, apps, or models they'll build.
+
+**Nudge (CLI/Desktop only):** Suggest opening Snowsight alongside the session, rendering their account URL from the diagnostics results: "You may want to open Snowsight to explore objects as we build them: https://app.snowflake.com/<org_name>/<account_name>"
+
+**Set up learning database:**
+```sql
+CREATE DATABASE IF NOT EXISTS LEARN_SNOWFLAKE_QUICKSTARTS;
+```
+Ask permission before creating. Then create a schema named after the slug:
+```sql
+CREATE SCHEMA IF NOT EXISTS LEARN_SNOWFLAKE_QUICKSTARTS.<slug_as_identifier>;
+```
+
+**Choose mode** using `ask_user_question`:
+- **Learner mode** — Step by step. I'll explain what we're building at each stage, execute it, recap, and check in before moving on.
+- **Builder mode** — Build everything at once. I'll execute all stages and give you a full summary at the end.
+
+Load `references/teaching-guide.md` for mode-specific behavior.
+
+**⚠️ STOPPING POINT**: Wait for mode selection before proceeding.
+
+### Step 7: Execute Learning Journey
+
+Execute each stage from the plan created in Step 3.
+
+**Detect the execution surface:**
+- If the working directory is under `/workspace/` → **Snowsight workspace**
+- Otherwise → **CLI**
+
+---
+
+**Learner mode (CLI):**
+
+For each stage:
+1. Explain what will be built and why
+2. Render the SQL/Python/code directly in the terminal with explanatory comments so the learner can read and understand it
+3. Use `ask_user_question` to give the learner agency before executing — e.g., "Run it", "Explain more", "I want to make changes"
+4. Execute via `sql_execute`
+5. Brief recap: what was created, key results (row counts, object status)
+6. **⚠️ STOPPING POINT** — pause between stages
+
+**Learner mode (Snowsight workspace):**
+
+For each stage:
+1. Explain what will be built and why
+2. Write code to `.sql` or `.py` files with explanatory comments
+3. Prompt the learner to run the file
+4. Brief recap after they've run it
+5. **⚠️ STOPPING POINT** — pause between stages
+
+**Builder mode (any surface):**
+- CLI: execute all stages directly via `sql_execute` without pausing
+- Snowsight: write all files and tell the learner to run them in sequence
+- Only stop for optional stages (ask include/skip)
+- Full summary at the end
+
+---
+
+**Handling outdated content:**
+If the Quickstart uses deprecated syntax or old patterns, flag it:
+"Note: This Quickstart uses [old pattern]. The current recommended approach is [new pattern]. I'll use the modern approach."
+Use the correct current approach — don't blindly replicate deprecated code.
+
+**Handling errors:**
+If a stage fails during execution:
+1. Read the error
+2. Diagnose the likely cause (permissions, missing prerequisites, syntax)
+3. Suggest a fix or workaround
+4. Ask the learner how to proceed
+
+### Step 8: Recap and Cleanup
+
+After all stages complete:
+
+**Recap:** Briefly congratulate the learner and summarize what they built — the key objects created, the concepts covered, and what they now have running in their account. Keep it concise (3-5 sentences). Draw from the Quickstart's Conclusion step if available.
+
+**Cleanup:** Then ask the learner: "Want to keep everything, or clean up?"
+- If cleaning up: drop the schema (which drops all objects within it)
+  ```sql
+  DROP SCHEMA IF EXISTS LEARN_SNOWFLAKE_QUICKSTARTS.<slug_as_identifier> CASCADE;
+  ```
+- Never drop the `LEARN_SNOWFLAKE_QUICKSTARTS` database itself
+- Never drop or alter any Snowflake-provided databases
+
+## Stopping Points
+
+- ⚠️ After companion repo detection (Step 4) — wait for clone/reference choice
+- ⚠️ After diagnostics (Step 5) if environment issues found
+- ⚠️ After mode selection (Step 6) — wait for learner's choice
+- ⚠️ Between stages (Step 7, learner mode only)
+- ⚠️ Before optional stages (both modes) — ask include/skip
+- ⚠️ Before cleanup (Step 8) — ask keep/remove
+
+## Troubleshooting
+
+**Quickstart not found on GitHub:**
+- Try alternate slug formats (hyphens ↔ underscores)
+- Check if the Quickstart was recently renamed or archived
+- Fall back to web_fetch on the original URL
+
+**Learner's role lacks privileges:**
+- Present specific GRANT statements
+- Suggest switching to a role with more access
+- Skip stages that require unavailable privileges and note what was skipped
+
+**Quickstart references external tools (Kafka, S3, third-party APIs):**
+- Mark those stages as optional
+- Explain what would happen if the tool were available
+- Offer to simulate or skip
+
+**Quickstart is very long (15+ steps):**
+- Chunk into logical phases (setup, core build, optional extensions)
+- In learner mode: add phase-level checkpoints
+- In builder mode: execute in phases with brief summaries between
+
+**Code execution fails:**
+- Read error message carefully
+- Common issues: wrong schema context, missing warehouse, object already exists
+- Fix and retry — don't ask the learner to debug unless the fix is unclear
+
+## Examples
+
+### Example 1: Basic usage
+User: $quickstart-guide https://www.snowflake.com/en/developers/guides/getting-started-with-cortex-agents/
+Assistant: Fetches the Cortex Agents Quickstart, checks environment, asks mode, and guides the learner through building a sales intelligence agent.
+
+### Example 2: Legacy URL
+User: $quickstart-guide https://quickstarts.snowflake.com/guide/getting_started_with_dataengineering_ml_using_snowpark_python
+Assistant: Detects legacy URL pattern, converts underscores to hyphens, fetches content, and delivers the Data Engineering with Snowpark experience.

--- a/skills/quickstart-guide/references/quickstart-parsing.md
+++ b/skills/quickstart-guide/references/quickstart-parsing.md
@@ -1,0 +1,83 @@
+# Quickstart Parsing Reference
+
+How to parse a Snowflake Quickstart markdown file into a staged learning plan.
+
+## Quickstart Markdown Structure
+
+### Frontmatter
+
+The first lines contain codefence-free metadata (not YAML fenced with `---`). Fields appear as `key: value` pairs before the first heading:
+
+```
+id: getting-started-with-cortex-agents
+summary: Build a sales intelligence agent with Cortex Agents
+categories: Getting Started
+environments: web
+status: Published
+feedback link: https://github.com/Snowflake-Labs/sfguides/issues
+tags: Cortex, Agents, AI
+authors: Author Name
+duration: 45
+```
+
+**Key fields:**
+- `id` — The canonical slug. This is the source of truth for matching to URLs. The folder name in the repo is usually the same but not always.
+- `summary` — The Quickstart title. Use this for attribution.
+- `categories` — Helps understand the domain (Getting Started, Data Engineering, Machine Learning, etc.)
+- `status` — Should be "Published" for live Quickstarts.
+- `duration` — Estimated minutes. Useful for setting learner expectations.
+- `tags` — Snowflake features and topics covered.
+
+### Step Structure
+
+Steps are delimited by markdown headings. Each step is a section starting with `## <Step Title>`. Within a step:
+
+- Prose explaining the concept
+- Code blocks (fenced with triple backticks and a language tag: `sql`, `python`, `yaml`, `json`, `bash`)
+- Images (ignore these — they're screenshots of UI flows)
+- Bullet lists of instructions
+
+### Common Step Patterns
+
+| Quickstart Step | Maps To |
+|-----------------|---------|
+| Overview | Skip — extract title and description for attribution |
+| Prerequisites | Diagnostics inputs — roles, privileges, features needed |
+| Setup / Environment | Stage 1 — create schema, grants, warehouse |
+| Core build steps (2-5 typically) | Stages 2-N — one per major deliverable |
+| Steps requiring external tools | Optional stages — flag dependency, skip if unavailable |
+| Conclusion / What You Learned | Skip — don't build anything. Use for summary content. |
+
+## Mapping Rules
+
+1. **Combine trivially small steps.** If two consecutive steps each do one SQL statement, merge them into one stage.
+2. **Split large steps.** If a single step creates 5+ objects or spans 3+ distinct operations, split into multiple stages.
+3. **Target 4-8 stages total.**
+4. **Stage 1 is always environment setup** — schema creation, grants, warehouse. Even if the Quickstart spreads this across multiple steps.
+5. **Optional stages get a clear marker** — note what external dependency is needed and what happens if you skip.
+6. **Preserve execution order** — stages build on previous stages. Don't reorder unless there's a clear dependency issue in the source.
+
+## Code Block Extraction
+
+- SQL blocks: these are what gets executed (CLI) or written to files (UI)
+- Python blocks: typically Snowpark, stored procedures, or UDFs — write to files
+- YAML blocks: often semantic models or config — write to files
+- Bash blocks: usually `snow` CLI commands or pip installs — adapt to the execution context
+
+## Companion Repos
+
+Many Quickstarts have a companion GitHub repo containing runnable code (SQL scripts, Python apps, YAML configs, notebooks). These are referenced in two places:
+
+- **Frontmatter field:** `fork repo link: https://github.com/Snowflake-Labs/sfguide-getting-started-with-cortex-agents`
+- **Inline in step content:** GitHub URLs in a "Clone this repo" or "Fork this repo" instruction, typically in the Prerequisites or Setup step
+
+**Common naming pattern:** `Snowflake-Labs/sfguide-<slug>` (though not all follow this convention).
+
+The companion repo may contain the actual SQL and Python code that the Quickstart's prose describes. When a companion repo exists, the code in it is often more complete and correct than code blocks extracted from the markdown steps.
+
+## Handling Incomplete Quickstarts
+
+Some Quickstarts are thin or poorly structured:
+- If a step has no code blocks, it may be conceptual — explain the concept, don't try to build something that isn't defined
+- If code blocks reference objects not created in earlier steps, the Quickstart assumes pre-existing data — check if SNOWFLAKE_SAMPLE_DATA or another common source is intended
+- If the Quickstart uses hardcoded database/schema names, replace them with the learning schema (`LEARN_SNOWFLAKE_QUICKSTARTS.<slug>`)

--- a/skills/quickstart-guide/references/teaching-guide.md
+++ b/skills/quickstart-guide/references/teaching-guide.md
@@ -1,0 +1,69 @@
+# Teaching Guide
+
+How to deliver the learning experience once a Quickstart has been fetched and parsed.
+
+## Core Principle: Active Learner
+
+The learner is an active participant, not a passive spectator. They build alongside you — they don't watch you build. Unless the learner explicitly asks you to "just build it" (which maps to Builder mode), involve them at every stage.
+
+## Two Modes
+
+### Learner Mode (step-by-step)
+
+Before each stage:
+- Explain what you're about to build and why it matters
+- If there's a design decision (e.g., "the Quickstart uses XS warehouse — do you want something larger?"), surface it with `ask_user_question`
+
+During each stage:
+- **CLI**: Render the code directly in the terminal with explanatory comments. Use `ask_user_question` to give the learner agency before executing — e.g., "Run it", "Explain more", "I want to make changes". Then execute via `sql_execute`.
+- **Snowsight workspace**: Write code to `.sql` or `.py` files with explanatory comments. Prompt the learner to run the file.
+
+After each stage:
+- Brief recap: what was created, key results (row counts, object status)
+- Do not move on until the learner signals readiness
+
+### Builder Mode (execute all)
+
+- **CLI**: Execute all stages directly via `sql_execute` without pausing
+- **Snowsight**: Write all files and tell the learner to run them in sequence
+- Only pause for optional stages (ask include/skip)
+- Full summary at the end with object names and key metrics
+
+## File-Based Code Delivery (UI Mode)
+
+When running in a Snowsight workspace:
+- Write SQL to `.sql` files named descriptively: `01_setup_environment.sql`, `02_create_tables.sql`, etc.
+- Add comments in the SQL explaining what each section does and why
+- For Python: write to `.py` files or Jupyter notebooks as appropriate
+- Prompt the learner: "I've created `02_create_tables.sql`. Open it and run it."
+- Never execute SQL directly — the learner runs the code
+
+## Tone
+
+- Friendly and concise — keep the joy in learning
+- Don't be a cheerleader — no excessive praise or emoji
+- Explain concepts naturally, as a colleague would
+- Technical accuracy matters more than enthusiasm
+
+## Ask Before Deciding
+
+When the Quickstart has implicit choices, surface them:
+- "The Quickstart uses warehouse size XS — that's fine for learning. Want to keep it, or use something different?"
+- "This creates sample data. Would you rather use your own data instead?"
+
+Don't ask about plumbing (stage names, role naming conventions). Ask about decisions that affect what the learner learns or what they'll maintain later.
+
+## Handling Outdated Content
+
+If you detect deprecated syntax, old UI references, or superseded patterns:
+- Flag it: "Note: this Quickstart uses [old thing]. The modern approach is [new thing]."
+- Use the correct current approach in your execution
+- Don't silently rewrite — the learner should know the source material is dated
+
+## Cleanup Semantics
+
+- Always ask before dropping anything
+- Only drop the schema created for this Quickstart
+- Never drop the `LEARN_SNOWFLAKE_QUICKSTARTS` database
+- Never touch Snowflake-provided databases (SNOWFLAKE, SNOWFLAKE_SAMPLE_DATA, etc.)
+- List objects being dropped: "This will remove: tables X, Y, Z; views A, B; the schema itself."


### PR DESCRIPTION
Skill that takes a Snowflake Quickstart URL, fetches the source markdown from GitHub, parses it into stages, checks the learner environment, and delivers a guided interactive learning experience with learner and builder modes.

## Skill submission checklist

Before submitting, please confirm the following:

### Folder structure
- [ ] My skill lives at `skills/<my-skill-id>/`
- [ ] The folder name matches the `id` field in `SKILL.md` (lowercase, hyphens only)
- [ ] `SKILL.md` is present in the skill folder
- [ ] `LICENSE` is present in the skill folder

### Frontmatter
- [ ] `name` field is filled in
- [ ] `description` field clearly explains what the skill does, when to use it, and what triggers it
- [ ] `id` field matches the folder name
- [ ] `authors` field includes the contributor's name
- [ ] `type` is set to `community` or `snowflake`
- [ ] `status` is set to `stable`, `beta`, or `draft`
- [ ] `categories` includes at least one relevant tag

### License
- [ ] Community contributors: LICENSE is Apache 2.0
- [ ] Snowflake employees: LICENSE is the Snowflake Skills License

### Testing
- [ ] I tested this skill in a Cortex Code session against my example prompt
- [ ] The skill behavior matches what is described in the `description` field

### Optional
- [ ] Supporting files (templates, examples) are organized into `templates/` or `references/` subdirectories
- [ ] I checked that my skill name does not conflict with a bundled Cortex Code skill (run `/skill` in a session to verify)

---

**Describe your skill:**

See README

**Example prompt that triggers it:**

See README