### PR TITLE
fix(entity-resolution): YAML parse error in description

### DIFF
--- a/skills/entity-resolution/SKILL.md
+++ b/skills/entity-resolution/SKILL.md
@@ -2,7 +2,16 @@
 name: entity-resolution
 title: Resolve Entities
 summary: End-to-end entity resolution pipeline using Snowflake Cortex AI Functions to match, link, and dedupe records.
-description: Use when you need to match records across datasets, deduplicate within a dataset, build a golden record, or link source records to a reference corpus. Orchestrates profiling, normalization, blocking, multi-tier matching (deterministic, fuzzy, AI-judged, agentic, contrastive), human review, and operationalization via dynamic tables. Industry-agnostic with optional domain profiles for pharma, financial services, retail/CPG, healthcare, and insurance. Triggers: entity resolution, record matching, deduplication, record linkage, fuzzy matching, golden record, master data, MDM, merge records, match entities, link records, dedupe, duplicate detection, identity resolution.
+description: >-
+  Use when you need to match records across datasets, deduplicate within a
+  dataset, build a golden record, or link source records to a reference corpus.
+  Orchestrates profiling, normalization, blocking, multi-tier matching
+  (deterministic, fuzzy, AI-judged, agentic, contrastive), human review, and
+  operationalization via dynamic tables. Industry-agnostic with optional domain
+  profiles for pharma, financial services, retail/CPG, healthcare, and insurance.
+  Triggers: entity resolution, record matching, deduplication, record linkage,
+  fuzzy matching, golden record, master data, MDM, merge records, match
+  entities, link records, dedupe, duplicate detection, identity resolution.
 tools:
   - snowflake_sql_execute
   - Bash


### PR DESCRIPTION
## Summary

Fixes a YAML parse error in `skills/entity-resolution/SKILL.md`. The `description` field was a single line containing `Triggers:` — YAML parses internal `:` followed by space as a mapping key, breaking the frontmatter.

```
$ python3 -c "import yaml; yaml.safe_load(open('skills/entity-resolution/SKILL.md').read().split('---')[1])"
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<unicode string>", line 4, column 475
```

## Fix

Convert `description:` to a folded block scalar (`>-`). YAML treats the body as a single string regardless of internal `:`. No semantic change — the description text is identical when joined.

## Test plan

- [x] `python3 -c "import yaml, re; yaml.safe_load(re.match(r'^---\\\\s*\\\\n(.*?)\\\\n---', open('SKILL.md').read(), re.DOTALL).group(1))"` parses cleanly
- [x] All required frontmatter keys present: `author, description, language, name, prompt, status, summary, title, tools, type`
- [x] No body content changes
