### PR TITLE
Add manage-authentication-policy skill

### DIFF
--- a/skills/manage-authentication-policy/LICENSE
+++ b/skills/manage-authentication-policy/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License 
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, “Skills”)) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake’s Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/). 
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+* Extract from the Service or retain copies of the Skills outside use with the Service;
+* Reproduce or copy the Skills , except for temporary copies created automatically during authorized use of the Service;
+* Create derivative works based on the Skills; 
+* Distribute, sublicense, or transfer the Skills to any third party;
+* Make, offer to sell, sell, or import any inventions embodied in the Skills; nor, 
+* Reverse engineer, decompile, or disassemble the Skills. 
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED “AS IS,” WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/manage-authentication-policy/SKILL.md
+++ b/skills/manage-authentication-policy/SKILL.md
@@ -4,13 +4,11 @@ title: Manage Authentication Policy
 summary: Create, modify, view, attach, detach, drop, or recommend Snowflake authentication policies.
 description: >-
   Use when a request involves Snowflake authentication policies — create,
-  modify, view, attach, detach, drop, or recommend. Covers restricting
-  authentication methods (PASSWORD, SAML, OAUTH, KEYPAIR), enforcing MFA, PAT
-  expiry and network policy, workload identity federation, client type
-  restrictions, minimum driver versions, and security integration controls.
-  Triggers: authentication policy, auth policy, MFA policy, PAT policy, client
-  types, workload identity, keypair only, SAML only, require MFA, harden
-  authentication, lock down authentication.
+  modify, view, attach, detach, drop, or recommend. Covers AUTHENTICATION_METHODS
+  (PASSWORD, SAML, OAUTH, KEYPAIR), MFA enforcement, PAT_POLICY, workload
+  identity federation, CLIENT_TYPES, and minimum driver versions. Triggers:
+  authentication policy, auth policy, MFA policy, PAT policy, workload identity,
+  keypair only, SAML only, require MFA, harden authentication.
 tools:
   - snowflake_sql_execute
   - snowflake_object_search

--- a/skills/manage-authentication-policy/SKILL.md
+++ b/skills/manage-authentication-policy/SKILL.md
@@ -3,17 +3,14 @@ name: manage-authentication-policy
 title: Manage Authentication Policy
 summary: Create, modify, view, attach, detach, drop, or recommend Snowflake authentication policies.
 description: >-
-  Use for requests about Snowflake authentication policies. Create, modify, view,
-  attach, detach, drop, OR recommend authentication policies. Covers: restricting
-  authentication methods (PASSWORD, SAML, OAUTH, KEYPAIR), enforcing MFA,
-  configuring PAT expiry and network policy, workload identity federation, client
-  type restrictions, minimum driver versions, and security integration controls.
-  Triggers: authentication policy, auth policy, MFA policy, MFA enrollment, PAT
-  policy, client types, workload identity, driver version policy, keypair only,
-  SAML only, require MFA, block password login, restrict client access, service
-  account authentication, show/list authentication policies, recommend/suggest
-  authentication policies, help me set up auth policies, audit my authentication,
-  harden authentication, lock down authentication.
+  Use when a request involves Snowflake authentication policies — create,
+  modify, view, attach, detach, drop, or recommend. Covers restricting
+  authentication methods (PASSWORD, SAML, OAUTH, KEYPAIR), enforcing MFA, PAT
+  expiry and network policy, workload identity federation, client type
+  restrictions, minimum driver versions, and security integration controls.
+  Triggers: authentication policy, auth policy, MFA policy, PAT policy, client
+  types, workload identity, keypair only, SAML only, require MFA, harden
+  authentication, lock down authentication.
 tools:
   - snowflake_sql_execute
   - snowflake_object_search

--- a/skills/manage-authentication-policy/SKILL.md
+++ b/skills/manage-authentication-policy/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: manage-authentication-policy
+title: Manage Authentication Policy
+summary: Create, modify, view, attach, detach, drop, or recommend Snowflake authentication policies.
+description: >-
+  Use for requests about Snowflake authentication policies. Create, modify, view,
+  attach, detach, drop, OR recommend authentication policies. Covers: restricting
+  authentication methods (PASSWORD, SAML, OAUTH, KEYPAIR), enforcing MFA,
+  configuring PAT expiry and network policy, workload identity federation, client
+  type restrictions, minimum driver versions, and security integration controls.
+  Triggers: authentication policy, auth policy, MFA policy, MFA enrollment, PAT
+  policy, client types, workload identity, driver version policy, keypair only,
+  SAML only, require MFA, block password login, restrict client access, service
+  account authentication, show/list authentication policies, recommend/suggest
+  authentication policies, help me set up auth policies, audit my authentication,
+  harden authentication, lock down authentication.
+tools:
+  - snowflake_sql_execute
+  - snowflake_object_search
+  - Read
+  - Write
+  - Edit
+prompt: "$manage-authentication-policy recommend authentication policies for my account based on recent login activity"
+language: en
+status: Published
+author: Snowflake
+type: snowflake
+demo-url: ""
+---
+
+# Authentication Policy
+
+Manage Snowflake authentication policies — controls for how users authenticate, which clients they use, MFA requirements, PAT restrictions, and workload identity federation.
+
+## When to Use
+
+- User wants to create, modify, view, attach, detach, or drop an authentication policy
+- User asks about restricting authentication methods or client types
+- User wants to enforce MFA, configure PAT expiry, or set up workload identity
+- User asks about minimum driver version enforcement
+- User asks for a recommendation, audit, or starting-point set of policies for their account ("help me set up auth policies", "what should I do?", "harden authentication")
+
+## When NOT to Use
+
+This skill is scoped to **authentication** policies. Do NOT load it for:
+
+- **Session policies** — `CREATE SESSION POLICY`, `SESSION_IDLE_TIMEOUT_MINS`, etc. Different SQL surface, different attachment semantics.
+- **Network policies** — `CREATE NETWORK POLICY`, IP allowlists / blocklists. Use the network-security skill.
+- **Password policies** — `CREATE PASSWORD POLICY`, password length / rotation / history rules. Different DDL.
+- **Row access / masking / aggregation policies** — those are data-governance concerns; route to the data-governance skill.
+- **`GRANT` / `REVOKE` of privileges** — RBAC plumbing, not authentication-policy operations. Use the access-troubleshooter or general SQL author skill.
+- **Login troubleshooting for a single user** ("why can't user X log in?") — that's a diagnostic flow, not a policy operation. Route to the access-troubleshooter or security-investigation skill; come back here only if the diagnosis points at an attached authentication policy.
+
+## Workflows
+
+| Workflow | Description |
+|----------|-------------|
+| `workflows/create.md` | Create a new authentication policy |
+| `workflows/modify.md` | Modify an existing authentication policy |
+| `workflows/view.md` | View or describe authentication policies |
+| `workflows/attach-detach.md` | Attach or detach a policy from account or users |
+| `workflows/drop.md` | Drop an authentication policy |
+| `workflows/recommend.md` | **Recommend** policies based on actual `LOGIN_HISTORY` activity (start here when user is unsure what to do) |
+
+## References
+
+Load [references/property-reference.md](references/property-reference.md) on-demand for detailed syntax, valid values, and examples for all 8 policy properties.
+
+---
+
+## Agent Behavior Rules (Apply to ALL Workflows)
+
+1. **Safety protocols** — Never run DDL/DML without explicit user approval. When modifying or dropping an existing policy, capture current state (`DESC` + `GET_DDL`) before changes — skip this for create (no existing policy). Warn about account-level impact. Provide revert instructions after changes. Execute SQL in presented order.
+
+2. **Follow step order** — Execute steps sequentially as defined. Do not skip steps, pre-select options, or jump ahead based on the user's opening message. Route based on AskUserQuestion selections, not inferred intent.
+
+3. **Hard stops are mandatory** — Steps marked ⚠️ are gates. Do not proceed until the required user input is received. Once approved, proceed directly without re-asking.
+
+4. **Choices vs. free text** — When the user must choose between options (routing, conflict resolution, selecting from query results like databases or policies), use AskUserQuestion with a selectable list. Only collect as plain free text when creating new names (policy name, comment).
+
+5. **Handling "Something else" or free text responses** — When the user selects "Something else" or replies with free text instead of choosing a presented option, try to map their intent to one of the existing options. If the mapping is clear, treat it as that selection and proceed. If the intent doesn't match any option, re-present the menu and ask the user to pick the closest one.
+
+---
+
+## Canonical Sources of Truth (Anti-Hallucination)
+
+⚠️ **Strict rule:** Every SHOW command, table function, or `ACCOUNT_USAGE` view used to discover authentication-policy data MUST come from the **Canonical Sources of Truth** section in [references/property-reference.md](references/property-reference.md). That section also lists commonly-hallucinated names that are **not** valid (e.g. `SYSTEM$GET_ACCOUNT_AUTHENTICATION_POLICY_DETAILS()`, `ACCOUNT_USAGE.AUTHENTICATION_POLICIES`).
+
+Load `references/property-reference.md` on-demand from any workflow before issuing discovery queries.
+
+---
+
+## Main Workflow
+### Step 1: Determine Intent
+
+Ask what the user wants to do. **Do NOT load any workflow file yet** — just record the selection for Step 3.
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "What would you like to do with authentication policies?",
+        "header": "Operation",
+        "multiSelect": false,
+        "options": [
+            {"label": "Create a new policy", "description": "Create a new authentication policy from scratch"},
+            {"label": "Modify an existing policy", "description": "Update properties of an existing authentication policy"},
+            {"label": "Show/describe a policy", "description": "Show details of existing authentication policies"},
+            {"label": "Attach/detach a policy", "description": "Apply policy to account/users or remove it"},
+            {"label": "Drop a policy", "description": "Delete an authentication policy"},
+            {"label": "Recommend policies for me", "description": "Analyze recent LOGIN_HISTORY and recommend policies tailored to my account (use this if unsure where to start)"}
+        ]
+    }]
+)
+```
+
+Record the selection, then proceed to **Step 2**.
+
+---
+
+### Step 2: Privilege Check
+
+Tell the user: *"Checking your current role to verify you have the required privileges."* Then run:
+
+```sql
+SELECT CURRENT_ROLE() AS active_role;
+```
+
+Present the active role and the required privileges for the selected operation:
+
+| Operation | Required Privilege(s) | Notes |
+|-----------|----------------------|-------|
+| Recommend policies | Read access to `SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY` and `SNOWFLAKE.ACCOUNT_USAGE.USERS` (typically via `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE` or `ACCOUNTADMIN`) | Read-only — generates recommendations as copy-paste SQL; no DDL until user routes to create/attach |
+| SHOW policies | `OWNERSHIP` on the policy **OR** `USAGE` on the schema | Only returns objects the current role has at least one access privilege on
+| DESC policy | `APPLY AUTHENTICATION POLICY` on Account **OR** `OWNERSHIP` on the policy | |
+| Create policy | `CREATE AUTHENTICATION POLICY` on the schema | |
+| Modify policy | `OWNERSHIP` on the policy | |
+| Drop policy | `OWNERSHIP` on the policy | |
+| Attach/detach (account-level) | `APPLY AUTHENTICATION POLICY` on Account | |
+| Attach/detach (user-level) | `APPLY AUTHENTICATION POLICY` on Account (global) **OR** `APPLY AUTHENTICATION POLICY` on the specific user | |
+
+> **Note:** All operations require at least one privilege on the parent database and schema.
+
+Then ask:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Active role: [ROLE]. Required: [privileges for selected operation]. Good to continue?",
+        "header": "Privilege Check",
+        "multiSelect": false,
+        "options": [
+            {"label": "Yes, continue", "description": "Proceed with current role"},
+            {"label": "Switch role first", "description": "I need to USE ROLE — help me switch"}
+        ]
+    }]
+)
+```
+
+**If "Switch role first":** Ask which role, run `USE ROLE <role>;`, then re-present the check.
+**If "Yes, continue":** Proceed immediately to **Step 3**.
+
+Do NOT hard-block on privilege concerns. Proceed and handle permission errors if they occur. **On permission error:** present the error, suggest the appropriate `GRANT` or `USE ROLE`, and retry once. If it fails again, stop and ask for guidance.
+
+#### ⚠️ Role Persistence Rule (Critical — read every time)
+
+`USE ROLE` issued in one `sql_execute` call **does not necessarily persist** to subsequent `sql_execute` calls in this environment. If you switch role here OR at any later point in any workflow, the role is **not guaranteed** to carry forward.
+
+**Required pattern for every state-changing statement (`CREATE`, `ALTER`, `DROP`, `GRANT`, `REVOKE`, `USE DATABASE`, `USE SCHEMA`):**
+
+1. Track the role chosen in this step as `<chosen_role>` and carry it through the rest of the workflow.
+2. Whenever you present SQL that mutates state, prepend `USE ROLE <chosen_role>;` and execute the role-set + the operative statement(s) as a **single multi-statement `sql_execute` call** (semicolon-separated).
+3. Do the same for `USE DATABASE` / `USE SCHEMA` set in workflow A1 — re-issue them alongside the operative DDL.
+
+**Example — correct:**
+```sql
+USE ROLE SECURITYADMIN;
+USE DATABASE MY_DB;
+USE SCHEMA MY_SCHEMA;
+CREATE AUTHENTICATION POLICY my_policy
+  AUTHENTICATION_METHODS = ('SAML', 'OAUTH');
+```
+(All four statements submitted in one `sql_execute` call.)
+
+**Example — incorrect (causes the role-reverting bug seen in past sessions):**
+- Call 1: `USE ROLE SECURITYADMIN;`
+- Call 2: `CREATE AUTHENTICATION POLICY ...;` ← may run under the original session role and fail with permission errors
+
+If a permission error occurs anyway, **do not** start adding `GRANT` statements — re-issue the failed statement with `USE ROLE` prepended in a single call. Only consider grants after that pattern has been tried.
+
+---
+
+### Step 3: Load and Execute Workflow
+
+**⚠️ CRITICAL — DO NOT SKIP THIS STEP. DO NOT AD-LIB THE WORKFLOW.**
+
+You MUST read the relevant workflow file below and then follow it step by step. The workflow files contain the full procedure.
+
+| Step 1 Selection | File to read (use Read tool) |
+|-----------|--------|
+| **Recommend policies for me** | `workflows/recommend.md` |
+| **Create a new policy** | `workflows/create.md` |
+| **Modify an existing policy** | `workflows/modify.md` |
+| **Show/describe a policy** | `workflows/view.md` |
+| **Attach/detach a policy** | `workflows/attach-detach.md` |
+| **Drop a policy** | `workflows/drop.md` |
+
+**If you proceed without reading the file, the workflow will be wrong.**
+
+Once the workflow completes its final step, proceed to **Step 4**.
+
+---
+
+### Step 4: Repeat or Done
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "What would you like to do next?",
+        "header": "Next Step",
+        "multiSelect": false,
+        "options": [
+            {"label": "Start another operation", "description": "Return to the authentication policy main menu"},
+            {"label": "Done", "description": "Exit"}
+        ]
+    }]
+)
+```
+
+| Selection | Action |
+|-----------|--------|
+| **Start another operation** | Go back to **Step 1** and present its exact AskUserQuestion again (the 5-option menu above). Do NOT infer the next operation, do NOT run any other commands or tools — just show Step 1's menu. |
+| **Done** | Workflow complete — stop. Do not suggest further actions. |
+
+---
+
+## Quick Reference
+
+### All Parameters
+
+| Parameter | Purpose | Default |
+|-----------|---------|---------|
+| `AUTHENTICATION_METHODS` | Which auth methods allowed | `ALL` |
+| `CLIENT_TYPES` | Which clients can connect | `ALL` |
+| `CLIENT_POLICY` | Minimum driver versions | None |
+| `SECURITY_INTEGRATIONS` | Allowed SAML/OAuth integrations | `ALL` |
+| `MFA_ENROLLMENT` | MFA requirement level | `OPTIONAL` |
+| `MFA_POLICY` | MFA method restrictions and SSO enforcement | None |
+| `PAT_POLICY` | PAT expiry, network policy, role restrictions | See defaults |
+| `WORKLOAD_IDENTITY_POLICY` | Cloud provider restrictions | `ALL` |
+
+### Compatibility Rules
+
+See [references/property-reference.md](references/property-reference.md) **Compatibility Rules** section for the full list. Key rule: only `PASSWORD` and `SAML` work through `SNOWFLAKE_UI` — but this only applies when `SNOWFLAKE_UI` is **explicitly** listed in `CLIENT_TYPES`, not when `CLIENT_TYPES = ALL`.
+
+### Policy Precedence (Fixed Hierarchy)
+
+1. **User-level policy** (highest) — `ALTER USER <name> SET AUTHENTICATION POLICY`
+2. **Account user-type policy** (middle) — `ALTER ACCOUNT SET ... FOR ALL PERSON/SERVICE USERS`
+3. **Account-level policy** (lowest) — `ALTER ACCOUNT SET AUTHENTICATION POLICY`
+
+The `FORCE` flag does NOT change precedence. It only allows setting a policy when one already exists at that level. User-level policies always win.
+
+---
+
+## Error Reference
+
+| Cause | Fix |
+|-------|-----|
+| Security integration doesn't exist or inactive | Create/enable the integration first |
+| Integration type doesn't match AUTHENTICATION_METHODS | Match integration type to auth methods |
+| Invalid PAT_POLICY values | Check DEFAULT_EXPIRY <= MAX_EXPIRY, both 1-365 |
+| CLIENT_POLICY driver set without DRIVERS in CLIENT_TYPES | Add DRIVERS to CLIENT_TYPES |
+| Invalid or misspelled field name | Check for typos in property names |
+| Policy already attached at that level | UNSET existing policy first, or use FORCE |
+| Cannot drop policy (still in use) | UNSET from all accounts/users before dropping |
+
+---
+
+## Stopping Points
+
+- ✋ Step 1: always wait for user selection before routing
+- ✋ Step 2: privilege check — wait for user confirmation before loading workflow
+- ✋ Step 3: must load the workflow file — do not skip
+- ✋ `workflows/recommend.md`: existing-policy inventory branch (R2), lookback window (R3), per-group review of generated SQL (R6), routing decision (R7)
+- ✋ `workflows/create.md`: location (A1), property selection (A2a — including the exclusive "Recommend for me" option), multi-step property values (A2b), compatibility conflicts (A2c), policy name (A3), then A4 SQL approval
+- ✋ `workflows/modify.md`: AskUserQuestion at policy selection, ready-to-proceed confirmation, property selection, **B4c break-glass gate when modifying an account-attached policy**, then B5 SQL approval
+- ✋ `workflows/attach-detach.md` D1: attach or detach, D2a: policy selection, D2b: scope, D2c: break-glass gate (now stricter), D3: conflict check, D4: approval
+- ✋ `workflows/attach-detach.md` D5: detach scope, D6: approval before execution
+- ✋ `workflows/drop.md`: AskUserQuestion at policy selection, then E3 SQL approval
+- ✋ Any time an incompatible combination is detected: stop and explain before proceeding
+
+**Resume rule:** Upon user approval, proceed directly to the next step without re-asking.
+
+---
+
+## Output
+
+- Created or modified authentication policy with verified configuration
+- `DESC AUTHENTICATION POLICY` output confirming properties
+- Revert instructions (saved DDL) for any changes made
+- Attachment confirmation with precedence explanation

--- a/skills/manage-authentication-policy/references/property-reference.md
+++ b/skills/manage-authentication-policy/references/property-reference.md
@@ -1,0 +1,272 @@
+# Authentication Policy Property Reference
+
+Detailed syntax and valid values for the 8 policy properties, plus the canonical SQL queries the agent is allowed to use for any discovery / metadata operation in this skill.
+
+### Strict rules (read first)
+
+- **⚠️ Strict VALUE rule** — for *property values* (e.g. `AUTHENTICATION_METHODS`, `CLIENT_TYPES`, `MFA_ENROLLMENT`). Only use values listed below in **Compatibility Rules** OR confirmed in the official Snowflake documentation linked below. Never infer, guess, or add other values: if a value does not appear in this reference or the official docs, it will be rejected at execution time.
+- **⚠️ Strict SOURCE rule** — for *discovery queries* (looking up users, integrations, current attachments, login activity). Only use the queries listed in the **Canonical Sources of Truth** section below. Do NOT invent system functions, view names, or columns. If a query you'd like to run is not on this list, run `cortex search docs "<topic>"` first to verify before executing.
+
+---
+
+## Official Documentation
+
+Use `snowflake_product_docs` to verify and cross-reference any property behavior covered below, especially if the context below is stale or when encountering unexpected errors.
+
+- [CREATE AUTHENTICATION POLICY](https://docs.snowflake.com/en/sql-reference/sql/create-authentication-policy)
+- [ALTER AUTHENTICATION POLICY](https://docs.snowflake.com/en/sql-reference/sql/alter-authentication-policy)
+- [Authentication Policies Guide](https://docs.snowflake.com/en/user-guide/authentication-policies)
+
+---
+
+## Canonical Sources of Truth (Anti-Hallucination)
+
+Every discovery / metadata query in any workflow must come from this list. Workflows reference this section by name; do not improvise.
+
+### Discovery / metadata
+- `SHOW AUTHENTICATION POLICIES IN ACCOUNT` — list all policies
+- `SHOW AUTHENTICATION POLICIES ON ACCOUNT` — list policies attached at account level (incl. `FOR ALL PERSON USERS`, `FOR ALL SERVICE USERS`)
+- `SHOW AUTHENTICATION POLICIES ON USER <username>` — list policy attached to a specific user
+- `DESC AUTHENTICATION POLICY <name>` — full configuration of a policy
+- `SELECT GET_DDL('POLICY', '<db>.<schema>.<name>')` — DDL for revert
+- `SELECT * FROM TABLE(<policy_db>.INFORMATION_SCHEMA.POLICY_REFERENCES(POLICY_NAME => '<policy_db>.<schema>.<name>'))` — what objects a policy is attached to (qualify with the policy's DB; the unqualified form fails when no current database is set)
+- `SHOW USERS` — canonical list of users with `TYPE` (PERSON / SERVICE / LEGACY_SERVICE / NULL), `DISABLED`, `DEFAULT_ROLE`, etc.
+- `SHOW INTEGRATIONS` — canonical list of security integrations with type (SAML2, OAUTH, etc.)
+
+### Login / usage analysis (used by `workflows/recommend.md`)
+- `SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY` — actual auth method usage. Useful columns: `EVENT_TIMESTAMP`, `USER_NAME`, `CLIENT_IP`, `REPORTED_CLIENT_TYPE`, `REPORTED_CLIENT_VERSION`, `FIRST_AUTHENTICATION_FACTOR`, `SECOND_AUTHENTICATION_FACTOR`, `IS_SUCCESS`, `ERROR_CODE`, `ERROR_MESSAGE`, `RELATED_EVENT_ID`. Latency: up to 2 hours.
+- `SNOWFLAKE.ACCOUNT_USAGE.USERS` — user inventory. Useful columns: `NAME`, `TYPE` (PERSON/SERVICE/LEGACY_SERVICE/NULL — **not** `USER_TYPE`), `DISABLED` (**VARIANT** — cast with `::STRING` or `::BOOLEAN` before comparing), `DELETED_ON`, `LAST_SUCCESS_LOGIN`, `HAS_PASSWORD`, `HAS_RSA_PUBLIC_KEY`, `HAS_MFA`, `HAS_PAT`, `HAS_WORKLOAD_IDENTITY`. Filter `WHERE DELETED_ON IS NULL` for active users.
+- `SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS` / `GRANTS_TO_ROLES` — role assignments (relevant for service-user scoping).
+
+### Forbidden — DO NOT use these (commonly hallucinated)
+- ❌ `SYSTEM$GET_ACCOUNT_AUTHENTICATION_POLICY_DETAILS()` — does not exist. Use `SHOW AUTHENTICATION POLICIES ON ACCOUNT` instead.
+- ❌ Any `SYSTEM$...AUTH_POLICY...` function not documented at [docs.snowflake.com/sql-reference/functions](https://docs.snowflake.com/en/sql-reference-functions).
+- ❌ `SNOWFLAKE.ACCOUNT_USAGE.AUTHENTICATION_POLICIES` — does not exist. Use `SHOW AUTHENTICATION POLICIES IN ACCOUNT`.
+- ❌ `INFORMATION_SCHEMA.LOGIN_HISTORY` for usage analysis — retention is too short (~7 days) and is per-database. Use `SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY`.
+- ❌ Inventing an `ACCOUNT_USAGE.USERS.USER_TYPE` column — the real column is `TYPE`.
+
+### Terminology note: user TYPE vs policy scope keyword
+
+These two concepts look similar but are NOT the same — do not conflate them:
+
+| Concept | Where it lives | Values |
+|---------|---------------|--------|
+| **`USERS.TYPE` column** | `SHOW USERS` and `ACCOUNT_USAGE.USERS` (per-user metadata) | `PERSON`, `SERVICE`, `LEGACY_SERVICE`, `NULL` (treat NULL as "unknown / likely person") |
+| **Account-level scope keyword** | `ALTER ACCOUNT SET AUTHENTICATION POLICY <p> FOR ALL { PERSON \| SERVICE } USERS` | `PERSON USERS`, `SERVICE USERS` (no `LEGACY_SERVICE` form) |
+
+When you generate `ALTER ACCOUNT SET ... FOR ALL PERSON USERS`, Snowflake applies the policy to users where `TYPE = 'PERSON'`. Users with `TYPE = 'LEGACY_SERVICE'` or `TYPE IS NULL` are NOT covered by either `FOR ALL PERSON USERS` or `FOR ALL SERVICE USERS` — they need user-level policies.
+
+If you need data not covered by the list above, **stop and ask the user** rather than guessing a function or view.
+
+---
+
+## Compatibility Rules
+
+Check these after gathering property selections. Violations will cause the CREATE/ALTER to fail.
+
+| Rule | Detail                                                                                                                                                                                                                                                                                                                             |
+|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **SNOWFLAKE_UI requires PASSWORD or SAML** | Only `PASSWORD` and `SAML` can authenticate through `SNOWFLAKE_UI`. This rule only applies when `SNOWFLAKE_UI` is **explicitly** listed in `CLIENT_TYPES` — `CLIENT_TYPES = ALL` does **not** trigger this requirement. When `SNOWFLAKE_UI` is explicit, at least one of `PASSWORD` or `SAML` must be in `AUTHENTICATION_METHODS`. |
+| **MFA_ENROLLMENT requires SNOWFLAKE_UI** | `MFA_ENROLLMENT = REQUIRED` or `REQUIRED_PASSWORD_ONLY` requires `SNOWFLAKE_UI` in `CLIENT_TYPES` (enrollment happens in Snowsight).                                                                                                                                                                                               |
+| **CLIENT_POLICY requires DRIVERS** | Can only specify drivers in `CLIENT_POLICY` if `CLIENT_TYPES` includes `DRIVERS` or `ALL`.                                                                                                                                                                                                                                          |
+| **PAT_POLICY expiry bounds** | `DEFAULT_EXPIRY_IN_DAYS` <= `MAX_EXPIRY_IN_DAYS` <= 365.                                                                                                                                                                                                                                                                           |
+| **SECURITY_INTEGRATIONS must match auth methods** | Integration types must be compatible with `AUTHENTICATION_METHODS` (e.g., a SAML integration requires SAML in the methods list; errno 3621).                                                                                                                                                                                       |
+
+---
+
+## 1. AUTHENTICATION_METHODS
+
+Controls which authentication methods are allowed.
+
+**Valid values:** `ALL` (default), `PASSWORD`, `SAML`, `OAUTH`, `KEYPAIR`, `PROGRAMMATIC_ACCESS_TOKEN`, `WORKLOAD_IDENTITY`
+
+**Compatibility:** Only `PASSWORD` and `SAML` can authenticate through `SNOWFLAKE_UI`. This constraint only applies when `SNOWFLAKE_UI` is **explicitly** listed in `CLIENT_TYPES` — it does not apply when `CLIENT_TYPES = ALL`.
+
+```sql
+CREATE AUTHENTICATION POLICY saml_oauth_policy
+  AUTHENTICATION_METHODS = ('SAML', 'OAUTH')
+  COMMENT = 'SSO and OAuth only';
+```
+
+---
+
+## 2. CLIENT_TYPES
+
+Restricts which client applications can authenticate. **Best-effort control** — does NOT restrict Snowflake REST API access.
+
+**Valid values:** `ALL` (default), `SNOWFLAKE_UI`, `DRIVERS`, `SNOWFLAKE_CLI`, `SNOWSQL`
+
+**Compatibility:** Only `PASSWORD` and `SAML` auth methods work through `SNOWFLAKE_UI`. This constraint only applies when `SNOWFLAKE_UI` is **explicitly** listed — `CLIENT_TYPES = ALL` does not trigger it. When `SNOWFLAKE_UI` is explicit, ensure at least one of `PASSWORD` or `SAML` is in `AUTHENTICATION_METHODS`. If `MFA_ENROLLMENT = REQUIRED`, you **must** include `SNOWFLAKE_UI` (enrollment happens in Snowsight). If `DRIVERS` is excluded, automated ingestion may stop working.
+
+```sql
+CREATE AUTHENTICATION POLICY programmatic_only_policy
+  CLIENT_TYPES = ('DRIVERS', 'SNOWFLAKE_CLI', 'SNOWSQL')
+  COMMENT = 'No web UI access';
+```
+
+---
+
+## 3. CLIENT_POLICY
+
+Specifies minimum version requirements for specific driver clients. **Best-effort control.**
+
+**Syntax:**
+```sql
+CLIENT_POLICY = (
+  <client_type> = ( MINIMUM_VERSION = '<version>' )
+  [, ...]
+)
+```
+
+**Valid client_type values** (unquoted): `JDBC_DRIVER`, `ODBC_DRIVER`, `PYTHON_DRIVER`, `JAVASCRIPT_DRIVER`, `C_DRIVER`, `GO_DRIVER`, `PHP_DRIVER`, `DOTNET_DRIVER`, `SQL_API`, `SNOWPIPE_STREAMING_CLIENT_SDK`, `PY_CORE`, `SPROC_PYTHON`, `PYTHON_SNOWPARK`, `SQL_ALCHEMY`, `SNOWPARK`, `SNOWFLAKE_CLIENT`
+
+**Version format:** Three digits delimited by periods in single quotes (e.g., `'3.25.0'`)
+
+**Compatibility:** Requires `DRIVERS` (or `ALL`) in `CLIENT_TYPES`. Fails if `DRIVERS` is not present.
+
+```sql
+CREATE AUTHENTICATION POLICY driver_version_policy
+  CLIENT_TYPES = ('DRIVERS')
+  CLIENT_POLICY = (
+    JDBC_DRIVER = (MINIMUM_VERSION = '3.25.0'),
+    PYTHON_DRIVER = (MINIMUM_VERSION = '3.0.0')
+  );
+```
+
+---
+
+## 4. SECURITY_INTEGRATIONS
+
+A list of security integrations the authentication policy is associated with. This parameter has no effect when SAML or OAUTH are not in the AUTHENTICATION_METHODS list.
+**Valid values:** List of existing integration names, or `ALL` (default)
+
+**Errors:** Fails if integration does not exist or is inactive (errno=3620). Fails if integration type doesn't match AUTHENTICATION_METHODS (errno=3621).
+
+**Compatibility:** All integrations must match the `AUTHENTICATION_METHODS` list — e.g., a SAML integration requires SAML in the methods. Mismatches fail with errno 3621.
+
+```sql
+CREATE AUTHENTICATION POLICY sso_restricted_policy
+  AUTHENTICATION_METHODS = ('SAML')
+  SECURITY_INTEGRATIONS = ('okta_integration')
+  COMMENT = 'Only Okta SSO allowed';
+```
+
+---
+
+## 5. MFA_ENROLLMENT
+
+Determines whether users must enroll in multi-factor authentication.
+
+**Valid settable values (for CREATE/ALTER):**
+- `REQUIRED` — Human users using password or SSO must enroll in MFA
+- `REQUIRED_PASSWORD_ONLY` — Human users using password must enroll; SSO users exempt
+- `OPTIONAL` — Backwards compatibility only (default).
+
+**⚠️ DESC display value differs from settable value:** `DESC AUTHENTICATION POLICY` returns `REQUIRED_SNOWFLAKE_UI_PASSWORD_ONLY` when the policy uses password-only MFA, but this is a **display-only** value. The correct settable value for CREATE/ALTER is `REQUIRED_PASSWORD_ONLY`. Never use `REQUIRED_SNOWFLAKE_UI_PASSWORD_ONLY` in SQL statements.
+
+**Compatibility:** `REQUIRED` and `REQUIRED_PASSWORD_ONLY` require `SNOWFLAKE_UI` in `CLIENT_TYPES` (Snowsight is the only MFA enrollment interface).
+
+```sql
+CREATE AUTHENTICATION POLICY mfa_required_policy
+  MFA_ENROLLMENT = 'REQUIRED'
+  CLIENT_TYPES = ('SNOWFLAKE_UI', 'DRIVERS');
+```
+
+---
+
+## 6. MFA_POLICY
+
+Specifies the policies that affect how multi-factor authentication (MFA) is enforced.
+
+### ALLOWED_METHODS
+MFA methods users can use as a second factor. Can specify multiple in a comma delimited list.
+
+**Valid values:** `ALL` (default), `PASSKEY`, `TOTP`, `OTP`, `DUO`
+
+### ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION
+Whether MFA is required when authenticating via SSO.
+
+**Valid values:** `ALL` (require MFA for SSO), `NONE` (default)
+
+**Note:** If your IdP already enforces MFA, setting `ALL` may cause double MFA prompts.
+
+```sql
+CREATE AUTHENTICATION POLICY mfa_strict_policy
+  MFA_ENROLLMENT = 'REQUIRED'
+  MFA_POLICY = (
+    ALLOWED_METHODS = ('PASSKEY', 'TOTP')
+    ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION = 'ALL'
+  );
+```
+
+---
+
+## 7. PAT_POLICY (Programmatic Access Token Policy)
+
+Controls programmatic access token behavior.
+
+### Properties
+
+| Property | Description | Default | Range |
+|----------|-------------|---------|-------|
+| `DEFAULT_EXPIRY_IN_DAYS` | Default token expiration | 15 | 1 to MAX_EXPIRY |
+| `MAX_EXPIRY_IN_DAYS` | Maximum allowed expiration | 365 | DEFAULT_EXPIRY to 365 |
+| `NETWORK_POLICY_EVALUATION` | Network policy enforcement for PATs | `ENFORCED_REQUIRED` | See below |
+| `REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS` | Require role-scoped PATs for service users | TRUE | TRUE/FALSE |
+
+**NETWORK_POLICY_EVALUATION:**
+Specifies how network policy requirements are handled for programmatic access tokens.
+
+By default, a user must be subject to a network policy with one or more network rules to generate or use programmatic access tokens
+
+Values:
+- `ENFORCED_REQUIRED` — Must have network policy to generate/use PATs (default)
+- `ENFORCED_NOT_REQUIRED` — Network policy not required, but enforced if present
+- `NOT_ENFORCED` — Network policy not required and not enforced
+
+**Validation:** `DEFAULT_EXPIRY_IN_DAYS` <= `MAX_EXPIRY_IN_DAYS` <= 365 (errno=3618). Changing `REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS` from FALSE to TRUE invalidates existing unrestricted PATs.
+
+```sql
+CREATE AUTHENTICATION POLICY restricted_pat_policy
+  PAT_POLICY = (
+    DEFAULT_EXPIRY_IN_DAYS = 7
+    MAX_EXPIRY_IN_DAYS = 30
+    NETWORK_POLICY_EVALUATION = ENFORCED_REQUIRED
+    REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS = TRUE
+  );
+```
+
+---
+
+## 8. WORKLOAD_IDENTITY_POLICY
+
+Controls workload identity federation (cloud provider service accounts).
+
+### Properties
+
+| Property | Description | Default |
+|----------|-------------|---------|
+| `ALLOWED_PROVIDERS` | Allowed identity providers | `ALL` |
+| `ALLOWED_AWS_ACCOUNTS` | AWS account IDs allowed | `ALL` |
+| `ALLOWED_AZURE_ISSUERS` | Azure Entra ID tenant issuers | `ALL` |
+| `ALLOWED_OIDC_ISSUERS` | OIDC provider issuers | `ALL` |
+
+**ALLOWED_PROVIDERS values:** `ALL`, `AWS`, `AZURE`, `GCP`, `OIDC` (comma-delimited list)
+
+**Format requirements:**
+- AWS accounts: 12-digit string (e.g., `'123456789012'`)
+- Azure issuers: `https://login.microsoftonline.com/<tenantId>/v2.0`
+- OIDC issuers: Valid HTTPS URL, no query/fragment, max 2048 chars
+
+```sql
+CREATE AUTHENTICATION POLICY cloud_workload_policy
+  AUTHENTICATION_METHODS = ('WORKLOAD_IDENTITY')
+  CLIENT_TYPES = ('DRIVERS')
+  WORKLOAD_IDENTITY_POLICY = (
+    ALLOWED_PROVIDERS = (AWS, AZURE)
+    ALLOWED_AWS_ACCOUNTS = ('123456789012')
+    ALLOWED_AZURE_ISSUERS = (
+      'https://login.microsoftonline.com/8c7832f5-de56-4d9f-ba94-3b2c361abe6b/v2.0'
+    )
+  );
+```

--- a/skills/manage-authentication-policy/workflows/attach-detach.md
+++ b/skills/manage-authentication-policy/workflows/attach-detach.md
@@ -1,0 +1,292 @@
+---
+name: attach-detach-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow D: Attach/Detach Policy
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **Attach/detach policy**, or from `workflows/create.md` after a new policy is created.
+
+## Prerequisites
+
+- Step 1 (intent selection) and Step 2 (privilege check) completed
+- If arriving from `workflows/create.md`: policy name is already known — skip D2a (policy selection), go straight to D2b (scope)
+- For user-level operations: requires `APPLY AUTHENTICATION POLICY` on Account (global) or on the specific user (scoped)
+
+---
+
+## D1: Attach or Detach?
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Do you want to attach or detach an authentication policy?",
+        "header": "Operation",
+        "multiSelect": false,
+        "options": [
+            {"label": "Attach a policy", "description": "Apply an authentication policy to account or users"},
+            {"label": "Detach a policy", "description": "Remove an authentication policy from account or users"}
+        ]
+    }]
+)
+```
+
+| Selection | Action |
+|-----------|--------|
+| **Attach a policy** | Proceed to D2a |
+| **Detach a policy** | Proceed to D5 |
+
+---
+
+## Attach Flow
+
+### D2a: Select Policy
+
+Run `SHOW AUTHENTICATION POLICIES IN ACCOUNT;` and present the results as a selectable list.
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Which policy do you want to attach?",
+        "header": "Select Policy",
+        "multiSelect": false,
+        "options": [
+            # One {"label": "<db>.<schema>.<policy_name>"} per row from SHOW AUTHENTICATION POLICIES
+        ]
+    }]
+)
+```
+
+**If arriving from `workflows/create.md`:** The policy name is already known — skip this step entirely.
+
+### D2b: Select Scope
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Where should this policy be applied?",
+        "header": "Attach Scope",
+        "multiSelect": false,
+        "options": [
+            {"label": "Account — all users", "description": "Apply to all users in the account"},
+            {"label": "Account — person users only", "description": "Apply to all person users"},
+            {"label": "Account — service users only", "description": "Apply to all service users"},
+            {"label": "Specific user(s)", "description": "Apply to one or more named users"}
+        ]
+    }]
+)
+```
+
+**If "Specific user(s)":** Ask the user for the username(s).
+
+### D2c: Break-Glass Gate (Account-Level Only)
+
+**Skip this step for user-level attach.**
+
+Account-wide attaches are the highest-risk operation in this skill — a misconfigured policy can lock out **every** admin. Don't proceed without an explicit break-glass user with a permissive policy.
+
+#### D2c-1: Identify the break-glass user (mandatory)
+
+Ask the user to name a single trusted admin user that should always be able to log in (preferably one with `ACCOUNTADMIN` and a working password they have tested in the last 24 hours):
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Account-wide attaches can lock out every user. Name the admin user that should keep unrestricted access (your 'break-glass' user). If you don't have one, pick 'Set one up'.",
+        "header": "Break-Glass User",
+        "multiSelect": false,
+        "options": [
+            # If recommend.md was run earlier and a candidate is known, list it here
+            {"label": "Set one up now", "description": "I don't have a dedicated break-glass user — guide me through creating the policy and assignment"},
+            {"label": "Cancel attach", "description": "I'm not ready — go back to Step 4"}
+        ]
+    }]
+)
+```
+
+If the user types a username (free text mapped to "Something else"), treat that as `<break_glass_user>` and continue.
+
+If the user picks **Cancel attach**: return to Step 4 in `SKILL.md`.
+
+#### D2c-2: Check whether the break-glass user already has a permissive policy
+
+Run:
+```sql
+SHOW AUTHENTICATION POLICIES ON USER <break_glass_user>;
+```
+
+Then for any policy returned, run:
+```sql
+DESC AUTHENTICATION POLICY <db>.<schema>.<policy_name>;
+```
+
+A policy counts as **permissive enough** when:
+- `AUTHENTICATION_METHODS` is `ALL` **OR** includes both `PASSWORD` and `SAML`
+- `CLIENT_TYPES` is `ALL` **OR** includes `SNOWFLAKE_UI`
+- `SECURITY_INTEGRATIONS` is `ALL` (or covers the integration the admin uses)
+
+**Branch:**
+
+| Condition | Action |
+|-----------|--------|
+| Permissive policy already attached to `<break_glass_user>` | Confirm with the user ("`<user>` already has policy `<policy>` covering all auth methods + Snowsight — no break-glass setup needed"), proceed to D3 |
+| No policy attached, OR attached policy is restrictive | Proceed to D2c-3 (mandatory escape-hatch setup) |
+| User chose **Set one up now** | Proceed to D2c-3 |
+
+#### D2c-3: Mandatory Escape-Hatch Setup
+
+⚠️ MANDATORY GATE — present the SQL and require approval before proceeding to D3.
+
+```sql
+-- Submit as a single multi-statement sql_execute call (per Role Persistence Rule)
+USE ROLE <chosen_role>;
+
+-- Step 1: Create a permissive admin policy
+CREATE AUTHENTICATION POLICY admin_escape_hatch
+  AUTHENTICATION_METHODS = ('ALL')
+  CLIENT_TYPES = ('ALL')
+  SECURITY_INTEGRATIONS = ('ALL')
+  COMMENT = 'Permissive fallback for admin - prevents lockout';
+
+-- Step 2: Assign to admin FIRST
+ALTER USER <break_glass_user> SET AUTHENTICATION POLICY admin_escape_hatch;
+```
+
+Present:
+```
+WARNING: I will assign a permissive policy to <break_glass_user> BEFORE applying the
+restrictive account-wide policy. After this completes, you must verify you can still
+log in as <break_glass_user> in a separate session before proceeding to D3.
+
+Do you approve? (Yes / No / Cancel attach)
+```
+
+| Selection | Action |
+|-----------|--------|
+| **Yes** | Execute the multi-statement block, verify with `SHOW AUTHENTICATION POLICIES ON USER <break_glass_user>`, then ask: *"Have you tested logging in as `<break_glass_user>` in a separate session and confirmed it works? (Yes / No)"* If **Yes**, proceed to D3. If **No**, stop and ask the user to test before continuing — do NOT proceed to D3. |
+| **No / Cancel attach** | Return to Step 4 in `SKILL.md`. Do NOT proceed to D3. |
+
+> **Acknowledgement override:** If the user explicitly states they understand the risk, have an out-of-band recovery plan, and want to skip D2c-3, require them to type the exact phrase **"I accept the lockout risk"** in chat. Only on receiving that exact phrase may you proceed to D3 without an escape-hatch in place. Anything weaker (e.g. "yeah it's fine") does not satisfy this gate — re-prompt for the phrase.
+
+### D3: Check for Existing Policy
+
+Check if a policy is already set at the target level:
+- **Account-level:** `SHOW AUTHENTICATION POLICIES ON ACCOUNT;`
+- **User-level:** `SHOW AUTHENTICATION POLICIES ON USER <username>;`
+
+**If a policy is already set at the same level**, present:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "A policy is already set at this level: <existing_policy_name>. How do you want to proceed?",
+        "header": "Policy Conflict",
+        "multiSelect": false,
+        "options": [
+            {"label": "UNSET existing, then attach new", "description": "Remove the current policy first, then set the new one"},
+            {"label": "Use FORCE to replace", "description": "Overwrite the existing policy in one command"},
+            {"label": "Cancel", "description": "Do not attach — go back to Step 4"}
+        ]
+    }]
+)
+```
+
+| Selection | Action |
+|-----------|--------|
+| **UNSET existing, then attach new** | Generate both UNSET + SET commands in sequence |
+| **Use FORCE to replace** | Add `FORCE` to the SET command |
+| **Cancel** | Proceed to Step 4 in SKILL.md |
+
+**If no policy is set**, skip this step and proceed to D4.
+
+### D4: Approve and Execute (Attach)
+
+**⚠️ Role / context persistence (re-read `SKILL.md` Step 2 → Role Persistence Rule):**
+The SQL block below MUST start with `USE ROLE <chosen_role>;` and (when applicable) `USE DATABASE` / `USE SCHEMA`. Submit it as a **single multi-statement `sql_execute` call** — `USE ROLE` is not guaranteed to persist between `sql_execute` invocations.
+
+Example shape (account-level attach):
+```sql
+USE ROLE <chosen_role>;
+ALTER ACCOUNT SET AUTHENTICATION POLICY <db>.<schema>.<policy>
+  [ FOR ALL PERSON USERS | FOR ALL SERVICE USERS ];
+```
+
+**⚠️ MANDATORY CHECKPOINT**: Present the SQL and ask for approval.
+
+For **account-level attachment**, include the impact warning:
+```
+WARNING: This will change authentication requirements IMMEDIATELY for all affected users.
+Users who don't meet the new requirements will be blocked from logging in.
+
+Scope: [ALL USERS | ALL PERSON USERS | ALL SERVICE USERS]
+Policy: <policy_name>
+```
+
+For **all attach operations**, present:
+```
+SQL to execute:
+[SQL command(s)]
+
+Impact: [What this changes and who is affected]
+Revert command (save this):
+[Command to undo this]
+
+Do you approve? (Yes/No)
+```
+
+Wait for explicit approval. NEVER proceed without user confirmation.
+
+1. Execute
+2. Verify with `SHOW AUTHENTICATION POLICIES ON ACCOUNT` or `SHOW AUTHENTICATION POLICIES ON USER <username>`
+3. Provide revert instructions.
+4. **⚠️ You MUST immediately proceed to Step 4 in SKILL.md.** Do not offer follow-up suggestions, do not ad-lib. Step 4 handles what comes next.
+
+---
+
+## Detach Flow
+
+### D5: Select Detach Scope
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Where should the policy be detached from?",
+        "header": "Detach Scope",
+        "multiSelect": false,
+        "options": [
+            {"label": "Account — all users", "description": "Remove the account-wide authentication policy"},
+            {"label": "Account — person users", "description": "Remove the policy for all person users"},
+            {"label": "Account — service users", "description": "Remove the policy for all service users"},
+            {"label": "Specific user", "description": "Remove policy from a named user"}
+        ]
+    }]
+)
+```
+
+**If "Specific user":** Ask for the username.
+
+### D6: Execute (Detach)
+
+**⚠️ Role / context persistence (re-read `SKILL.md` Step 2 → Role Persistence Rule):**
+The detach statement below MUST be submitted alongside `USE ROLE <chosen_role>;` as a **single multi-statement `sql_execute` call**.
+
+⚠️ MANDATORY CHECKPOINT: Present the SQL to the user. Ask for approval once as selectable menu (Yes/No). When the user approves, execute immediately.
+
+**Detach from account:**
+```sql
+USE ROLE <chosen_role>;
+ALTER ACCOUNT UNSET AUTHENTICATION POLICY
+  [ FOR ALL PERSON USERS | FOR ALL SERVICE USERS ];
+```
+
+**Detach from user:**
+```sql
+USE ROLE <chosen_role>;
+ALTER USER <username> UNSET AUTHENTICATION POLICY;
+```
+
+Execute the command. **If it fails** with "no policy set" or similar, inform the user that no policy was attached at that level — no action needed.
+
+**⚠️ AFTER EXECUTION (success or failure): You MUST immediately proceed to Step 4 in SKILL.md.** Do not offer follow-up suggestions, do not ask about other scopes, do not ad-lib. Step 4 handles what comes next.

--- a/skills/manage-authentication-policy/workflows/create.md
+++ b/skills/manage-authentication-policy/workflows/create.md
@@ -1,0 +1,184 @@
+---
+name: create-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow A: Create New Policy
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **Create new policy**.
+
+## Prerequisites
+
+- Step 1 (intent selection) and Step 2 (privilege check) completed
+
+---
+
+## A1: Location
+
+Check if a database and schema are already active:
+
+```sql
+SELECT CURRENT_DATABASE() AS database, CURRENT_SCHEMA() AS schema;
+```
+
+**If both are set:** Confirm with the user (e.g. "Policy will be created in `db.schema`. Good to continue?"). Proceed to A2 on confirmation.
+
+**If database is NULL:** Run `SHOW DATABASES;` and present results as a selectable list. Always include a "Create new database" option at the end:
+
+```python
+AskUserQuestion(
+  questions=[{
+    "question": "Which database should the policy be created in?",
+    "header": "Database",
+    "multiSelect": false,
+    "options": [
+      # One {"label": "<db_name>"} per row from SHOW DATABASES
+      {"label": "Create new database", "description": "I need to create a new database first"}
+    ]
+  }]
+)
+```
+
+After database is selected, run `USE DATABASE <selected_db>;`.
+
+**If schema is NULL (or after selecting database):** Run `SHOW SCHEMAS IN DATABASE <db>;` and present results. Always include a "Create new schema" option at the end:
+
+```python
+AskUserQuestion(
+  questions=[{
+    "question": "Which schema in <db> should the policy be created in?",
+    "header": "Schema",
+    "multiSelect": false,
+    "options": [
+      # One {"label": "<schema_name>"} per row from SHOW SCHEMAS IN DATABASE
+      {"label": "Create new schema", "description": "I need to create a new schema first"}
+    ]
+  }]
+)
+```
+
+After schema is selected, run `USE SCHEMA <selected_db>.<selected_schema>;`. Confirm the final `database.schema` before proceeding.
+
+---
+
+## A2: Gather Requirements
+
+**⚠️ MANDATORY FIRST ACTION — before presenting any options to the user:**
+Read [references/property-reference.md](../references/property-reference.md). You need its valid values, defaults, and compatibility notes for every step that follows.
+
+### A2a: Select Properties to Configure
+
+Present a single multi-select menu of all configurable properties. Unselected properties keep their defaults.
+
+```python
+AskUserQuestion(
+  questions=[{
+    "question": "Which properties do you want to configure? Unselected properties use defaults (ALL/OPTIONAL). Pick 'Recommend for me' if you're not sure.",
+    "header": "Policy Properties",
+    "multiSelect": true,
+    "options": [
+      {"label": "AUTHENTICATION_METHODS", "description": "Which auth methods are allowed (default: ALL)"},
+      {"label": "CLIENT_TYPES", "description": "Which clients can connect (default: ALL)"},
+      {"label": "MFA_ENROLLMENT", "description": "MFA requirement level (default: OPTIONAL)"},
+      {"label": "SECURITY_INTEGRATIONS", "description": "Restrict allowed SAML/OAuth integrations (default: ALL)"},
+      {"label": "PAT_POLICY", "description": "PAT expiry limits, network policy, role restrictions"},
+      {"label": "WORKLOAD_IDENTITY_POLICY", "description": "Restrict cloud providers and accounts for WIF"},
+      {"label": "MFA_POLICY", "description": "MFA method restrictions and SSO enforcement"},
+      {"label": "CLIENT_POLICY", "description": "Minimum driver/connector version requirements"},
+      {"label": "Recommend for me", "description": "I'm not sure — analyze SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY and suggest values for all properties"}
+    ]
+  }]
+)
+```
+
+**Exclusive option — "Recommend for me":**
+If the user selects `Recommend for me`, treat it as exclusive — ignore any other property selections in the same response and route into [workflows/recommend.md](recommend.md). Run R1 → R6; when the user picks an option in R6's gate that involves creating *this* policy, return here with `<authentication_methods>`, `<client_types>`, and any sub-policy values pre-decided. Skip A2b's interactive value collection and surface the recommended values for confirmation directly. The user can still override any value before A4.
+
+> **Anti-loop:** If `recommend.md` was already run earlier in the session and the routing brought us into create.md with pre-decided values, do NOT re-show A2a — go straight to confirming the pre-decided values, then to A3.
+
+### A2b: Configure Selected Properties
+
+Build a **single multi-step AskUserQuestion** with one step per selected property. Only include steps for properties the user selected in A2a.
+
+⚠️ Only present values that appear in [references/property-reference.md](../references/property-reference.md) including 'All' if present, or the official Snowflake documentation. Never infer or guess values.
+```python
+AskUserQuestion(
+  questions=[
+    # Include only steps for properties selected in A2a. Example for AUTHENTICATION_METHODS + CLIENT_TYPES + MFA_ENROLLMENT:
+    {
+      "question": "Which authentication methods should this policy allow?",
+      "header": "Authentication Methods",
+      "multiSelect": true,
+      "options": [
+        # Valid values from property-reference.md section 1: ALL, PASSWORD, SAML, OAUTH, KEYPAIR, PROGRAMMATIC_ACCESS_TOKEN, WORKLOAD_IDENTITY
+      ]
+    },
+    {
+      "question": "Which client types should be allowed to connect?",
+      "header": "Client Types",
+      "multiSelect": true,
+      "options": [
+        # Valid values from property-reference.md section 2: ALL, SNOWFLAKE_UI, DRIVERS, SNOWFLAKE_CLI, SNOWSQL
+      ]
+    },
+    {
+      "question": "What MFA enrollment level is required?",
+      "header": "MFA Enrollment",
+      "multiSelect": false,
+      "options": [
+        # Valid settable values from property-reference.md section 5: OPTIONAL, REQUIRED, REQUIRED_PASSWORD_ONLY
+      ]
+    }
+    # ... one step per selected property, using valid values from the respective property-reference.md sections
+  ]
+)
+```
+
+**Property-specific notes:**
+- **SECURITY_INTEGRATIONS** — before including this step, run `SHOW INTEGRATIONS;` and filter to SAML/OAUTH types. Use the results as options.
+- **Sub-policies** (PAT_POLICY, WORKLOAD_IDENTITY_POLICY, MFA_POLICY, CLIENT_POLICY) — each sub-policy needs its own step(s) for its sub-properties. Use valid values and defaults from [references/property-reference.md](../references/property-reference.md).
+
+### A2c: Validate Compatibility
+
+**Immediately after A2b returns**, check selected values against the **Compatibility Rules** table in [references/property-reference.md](../references/property-reference.md) (already loaded in A2).
+
+If an incompatible combination is found, present each conflict and its resolution options via AskUserQuestion. Resolve one conflict at a time, re-validate after each. If the user chooses to go back, return to A2a.
+
+---
+
+## A3: Policy Name and Comment
+
+Ask the user for plain text input:
+
+1. *"What would you like to name the policy?"*
+2. *"Optional: add a comment/description? (or say 'skip')"*
+
+---
+
+## A4: Generate, Approve, Execute
+
+1. Generate the `CREATE AUTHENTICATION POLICY` SQL based on requirements (include `COMMENT` if provided in A3)
+
+**⚠️ Role / context persistence (re-read `SKILL.md` Step 2 → Role Persistence Rule):**
+The SQL block presented below MUST start with `USE ROLE <chosen_role>;` and the `USE DATABASE` / `USE SCHEMA` from A1. Submit the role-set + context-set + `CREATE` statements as a **single multi-statement `sql_execute` call**. Do NOT split them across calls — `USE ROLE` is not guaranteed to persist between `sql_execute` invocations.
+
+Example shape:
+```sql
+USE ROLE <chosen_role>;
+USE DATABASE <db>;
+USE SCHEMA <schema>;
+CREATE AUTHENTICATION POLICY <name>
+  AUTHENTICATION_METHODS = (...)
+  ...;
+```
+
+**⚠️ MANDATORY CHECKPOINT**: Present the complete SQL and a summary of what each property does. Ask for approval once as selectable menu (Yes/No). When the user approves, execute immediately.
+
+2. Execute the SQL. If it fails, check the Error Reference in SKILL.md and address the issue before retrying.
+3. Verify with `DESC AUTHENTICATION POLICY <name>`
+4. Ask if user wants to attach the policy. If yes, **you MUST read** [workflows/attach-detach.md](attach-detach.md) and begin at **D2b** (Select Scope) — the policy name from A3 is already known, so skip D1 (attach vs detach choice) and D2a (policy selection). Follow D2b → D2c → D3 → D4 as written. Do not summarize or improvise the attach flow.
+5. Present the policy name and location, then proceed to **Step 4** in `SKILL.md`.
+
+> **Routed entry from `recommend.md`:** When this workflow is invoked from `workflows/recommend.md` R7, the A1 (location), A2 (properties), and A3 (policy name) values are already determined by the recommendation. Confirm them with the user, then jump straight to A4. Do not re-collect from scratch.

--- a/skills/manage-authentication-policy/workflows/drop.md
+++ b/skills/manage-authentication-policy/workflows/drop.md
@@ -1,0 +1,99 @@
+---
+name: drop-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow E: Drop Policy
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **Drop policy**.
+
+## Prerequisites
+
+- Step 1 (intent selection) and Step 2 (privilege check) completed
+
+---
+
+## E1: List All Policies
+
+```sql
+SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+```
+
+Present the results as a selectable list:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Which policy would you like to drop?",
+        "header": "Select Policy",
+        "multiSelect": false,
+        "options": [
+            # One {"label": "<db>.<schema>.<policy_name>"} per row from SHOW AUTHENTICATION POLICIES
+        ]
+    }]
+)
+```
+
+---
+
+## E2: Check If Policy Is Attached
+
+Use the fully qualified name as a single-quoted string literal, matching exactly as shown in SHOW AUTHENTICATION POLICIES. **Qualify the table function with the policy's database** — `INFORMATION_SCHEMA.POLICY_REFERENCES` is per-database and the unqualified form fails when no current database is set.
+
+```sql
+-- Example: POLICY_NAME must be a single-quoted, fully qualified string
+SELECT * FROM TABLE(mydb.INFORMATION_SCHEMA.POLICY_REFERENCES(
+  POLICY_NAME => 'mydb.myschema.my_policy'
+));
+```
+
+If any rows are returned, the policy is **in use** and cannot be dropped. Detach first — **Load** `workflows/attach-detach.md`.
+
+---
+
+## E3: Capture DDL Before Dropping
+
+```sql
+SELECT GET_DDL('POLICY', '<db>.<schema>.<name>');
+```
+
+Save the output so the policy can be recreated if needed.
+
+---
+
+## E4: Drop
+
+**⚠️ Role / context persistence (re-read `SKILL.md` Step 2 → Role Persistence Rule):**
+The DROP statement below MUST be submitted alongside `USE ROLE <chosen_role>;` (and `USE DATABASE` / `USE SCHEMA` if applicable) as a **single multi-statement `sql_execute` call** — `USE ROLE` is not guaranteed to persist between `sql_execute` invocations.
+
+Example shape:
+```sql
+USE ROLE <chosen_role>;
+DROP AUTHENTICATION POLICY [ IF EXISTS ] <db>.<schema>.<name>;
+```
+
+**⚠️ MANDATORY CHECKPOINT**: Before dropping:
+
+Present to user:
+```
+I will drop the following policy:
+
+[DROP statement]
+
+Saved DDL for recreation if needed:
+[GET_DDL output from E3]
+
+This policy is [not attached / attached to X — must detach first].
+
+Do you approve? (Yes/No/Modify)
+```
+
+Wait for explicit approval. NEVER proceed without user confirmation.
+
+```sql
+DROP AUTHENTICATION POLICY [ IF EXISTS ] <name>;
+```
+
+Execute, confirm the policy no longer appears in `SHOW AUTHENTICATION POLICIES IN ACCOUNT`, and present confirmation to user. Then proceed to **Step 4** in `SKILL.md`.

--- a/skills/manage-authentication-policy/workflows/modify.md
+++ b/skills/manage-authentication-policy/workflows/modify.md
@@ -1,0 +1,170 @@
+---
+name: modify-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow B: Modify Existing Policy
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **Modify existing policy**.
+
+## Prerequisites
+
+- Step 1 (intent selection) and Step 2 (privilege check) completed
+
+---
+
+## B1: Identify Policy
+
+Help user find the policy:
+
+```sql
+SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+```
+
+Present the results as a selectable list:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Which policy would you like to modify?",
+        "header": "Select Policy",
+        "multiSelect": false,
+        "options": [
+            # One {"label": "<db>.<schema>.<policy_name>"} per row from SHOW AUTHENTICATION POLICIES
+        ]
+    }]
+)
+```
+
+---
+
+## B2: Capture Current State
+
+**Before any changes:**
+
+```sql
+DESC AUTHENTICATION POLICY <name>;
+SELECT GET_DDL('POLICY', '<db>.<schema>.<name>');
+```
+
+Show current configuration to user. Save the DDL for revert capability. Then pause:
+
+```python
+AskUserQuestion(
+  questions=[{
+    "question": "Current state is displayed above. Ready to specify your changes?",
+    "header": "Confirm Ready",
+    "multiSelect": false,
+    "options": [
+      {"label": "Yes, specify changes", "description": "Proceed to select properties to modify"},
+      {"label": "No, review more details first", "description": "I need to review more before changing"}
+    ]
+  }]
+)
+```
+
+---
+
+## B3: Determine Changes
+
+Ask which properties to modify:
+
+```python
+AskUserQuestion(
+  questions=[{
+    "question": "Which properties do you want to modify? Select all that apply.",
+    "header": "Properties to Modify",
+    "multiSelect": true,
+    "options": [
+      {"label": "AUTHENTICATION_METHODS", "description": "Which auth methods are allowed"},
+      {"label": "CLIENT_TYPES", "description": "Which client types can connect"},
+      {"label": "MFA_ENROLLMENT", "description": "MFA requirement level (OPTIONAL / REQUIRED / REQUIRED_PASSWORD_ONLY)"},
+      {"label": "SECURITY_INTEGRATIONS", "description": "Allowed SAML/OAuth integrations"},
+      {"label": "PAT_POLICY", "description": "PAT expiry and network policy settings"},
+      {"label": "WORKLOAD_IDENTITY_POLICY", "description": "Cloud provider restrictions"},
+      {"label": "MFA_POLICY", "description": "MFA method restrictions and SSO enforcement"},
+      {"label": "CLIENT_POLICY", "description": "Minimum driver version requirements"}
+    ]
+  }]
+)
+```
+
+For each selected property, ask for the new value via a follow-up AskUserQuestion. Only use values that appear in [references/property-reference.md](../references/property-reference.md) or official Snowflake documentation, never infer or guess values.
+
+**Sub-policy follow-ups** — when a modification enables or adds a sub-policy, ask about its properties in a separate AskUserQuestion:
+
+- **PAT_POLICY:** Ask for `DEFAULT_EXPIRY_IN_DAYS`, `MAX_EXPIRY_IN_DAYS`, `NETWORK_POLICY_EVALUATION`, `REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS`
+- **WORKLOAD_IDENTITY_POLICY:** Ask for `ALLOWED_PROVIDERS` and account/issuer restrictions
+- **MFA_POLICY:** Ask for `ALLOWED_METHODS`, `ENFORCE_MFA_ON_EXTERNAL_AUTHENTICATION`
+- **SECURITY_INTEGRATIONS:** Ask which named integrations to allow (run `SHOW INTEGRATIONS` to present options)
+- **CLIENT_POLICY:** Ask for driver names and minimum versions
+
+For full syntax and valid values, **Load** [references/property-reference.md](../references/property-reference.md).
+
+---
+
+## B4: Check If Policy Is Active
+
+```sql
+SHOW AUTHENTICATION POLICIES ON ACCOUNT;
+```
+
+Cross-reference against the policy being modified. Three branches:
+
+**B4a — Not attached anywhere:** No special gating — proceed to B5.
+
+**B4b — Attached only to specific users (not account-level):** Warn that modifications take effect immediately for those users. Show the revert DDL from B2. Proceed to B5.
+
+**B4c — Attached at account level (highest risk):**
+
+⚠️ MANDATORY GATE — modifying an account-attached policy can lock out every admin just like attaching a new one. Run the **same break-glass check** as `attach-detach.md` D2c (D2c-1 → D2c-2 → D2c-3) before proceeding.
+
+The check is identical:
+1. Ask the user to name a break-glass user.
+2. Run `SHOW AUTHENTICATION POLICIES ON USER <break_glass_user>`; for each result, `DESC AUTHENTICATION POLICY <db>.<schema>.<policy>`.
+3. A policy counts as "permissive enough" when `AUTHENTICATION_METHODS = ALL` (or includes both `PASSWORD` and `SAML`) AND `CLIENT_TYPES = ALL` (or includes `SNOWFLAKE_UI`) AND `SECURITY_INTEGRATIONS = ALL` (or covers the integration the admin uses).
+4. If no permissive policy is attached, set up the escape-hatch (D2c-3 SQL block in `attach-detach.md`) BEFORE running the `ALTER AUTHENTICATION POLICY` in B5.
+5. The "I accept the lockout risk" phrase override applies here too.
+
+Show the revert DDL from B2 alongside the gate. Proceed to B5 only after the gate passes (or the user types the override phrase).
+
+---
+
+## B5: Generate, Approve, Execute
+
+1. Generate the `ALTER AUTHENTICATION POLICY <name> SET ...` statement. **Combine all property changes into a single ALTER ... SET statement when possible.** Only use separate ALTER statements when changes affect different objects or have sequential dependencies.
+
+**⚠️ Role / context persistence (re-read `SKILL.md` Step 2 → Role Persistence Rule):**
+The SQL block presented below MUST start with `USE ROLE <chosen_role>;` (and `USE DATABASE` / `USE SCHEMA` if you needed to switch context to find the policy). Submit the role-set + `ALTER` as a **single multi-statement `sql_execute` call** — `USE ROLE` is not guaranteed to persist between `sql_execute` invocations.
+
+Example shape:
+```sql
+USE ROLE <chosen_role>;
+ALTER AUTHENTICATION POLICY <db>.<schema>.<name> SET
+  AUTHENTICATION_METHODS = (...)
+  ...;
+```
+
+**⚠️ MANDATORY CHECKPOINT**: Before applying changes:
+
+Present to user:
+```
+I will make the following changes to [policy_name]:
+
+[ALTER SQL statement]
+
+Impact:
+- [What changes]
+- [Revert DDL if policy is active]
+
+Do you approve? (Yes/No/Modify)
+```
+
+Wait for explicit approval (e.g., "approved", "looks good", "proceed").
+NEVER proceed without user confirmation.
+
+2. Execute
+3. Verify with `DESC AUTHENTICATION POLICY <name>`
+4. Provide revert instructions (the saved DDL from B2), then proceed to **Step 4** in `SKILL.md`.

--- a/skills/manage-authentication-policy/workflows/recommend.md
+++ b/skills/manage-authentication-policy/workflows/recommend.md
@@ -1,0 +1,387 @@
+---
+name: recommend-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow R: Recommend Policies (LOGIN_HISTORY-driven)
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **Recommend policies for me**. Also the recommended starting point when the user's prompt is generic ("help me set up auth policies", "what should I do for authentication", "audit my auth setup") and Step 1 routes here.
+
+## Why this workflow exists
+
+Most customers don't know exactly which policies they want — they want guidance. Picking values blind is risky: "block password login" sounds simple but can lock out the human admin who relies on Snowsight + password, or break service accounts that still use PAT. This workflow grounds recommendations in **actual login activity** so the agent can produce concrete, per-user-aware suggestions.
+
+## Prerequisites
+
+- Step 1 + Step 2 (intent + privilege check) completed. Entry can be either via the top-level "Recommend policies for me" menu option, **or** routed in from `workflows/create.md` A2a's exclusive "Recommend for me" property option.
+- Read access to `SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY` and `SNOWFLAKE.ACCOUNT_USAGE.USERS` (typically `ACCOUNTADMIN` or a role with `IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE`)
+
+**Strict rule:** Use only the queries listed in [`references/property-reference.md` → "Canonical Sources of Truth"](../references/property-reference.md#canonical-sources-of-truth-anti-hallucination). Do NOT invent system functions or view names.
+
+**Role persistence:** Re-read the Role Persistence Rule in `SKILL.md` Step 2. Any later DDL routed from this workflow into `create.md` / `attach-detach.md` MUST prepend `USE ROLE <chosen_role>;` and run as a single multi-statement `sql_execute` call.
+
+---
+
+## R1: Verify Access to ACCOUNT_USAGE
+
+Run a probe query first; do not yet pull the full data set:
+
+```sql
+SELECT COUNT(*) AS row_count
+FROM SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY
+WHERE EVENT_TIMESTAMP >= DATEADD(day, -1, CURRENT_TIMESTAMP());
+```
+
+**If it succeeds** (any row count, including 0): proceed to R2.
+
+**If it fails** with an access error: tell the user the exact role/grant problem, suggest:
+```sql
+GRANT IMPORTED PRIVILEGES ON DATABASE SNOWFLAKE TO ROLE <their_role>;
+```
+…and stop until they confirm they fixed it (or ask them to switch to `ACCOUNTADMIN`).
+
+Do NOT silently fall back to `INFORMATION_SCHEMA.LOGIN_HISTORY` — its retention is much shorter (~7 days) and is per-database.
+
+---
+
+## R2: Existing Policy Inventory
+
+Before pulling login activity, check what policies and attachments already exist. If a policy is already attached account-wide, recommending from scratch is the wrong default — the user is likely better served by `view.md` or `modify.md`.
+
+```sql
+-- Catalog of policies in the account
+SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+```
+
+```sql
+-- Account-level attachments (covers ALL USERS, ALL PERSON USERS, ALL SERVICE USERS)
+SHOW AUTHENTICATION POLICIES ON ACCOUNT;
+```
+
+For any policy returned by the first query, optionally enumerate its attachment scope (qualify with the policy's database — `INFORMATION_SCHEMA.POLICY_REFERENCES` is per-database):
+
+```sql
+SELECT POLICY_NAME, REF_ENTITY_NAME, REF_ENTITY_DOMAIN
+FROM TABLE(<policy_db>.INFORMATION_SCHEMA.POLICY_REFERENCES(
+  POLICY_NAME => '<policy_db>.<schema>.<policy_name>'
+));
+```
+
+Branch on what you find:
+
+**State A — No policies in account, nothing attached.** Tell the user: *"Your account has no authentication policies yet. We'll recommend a starting set."* Proceed to R3.
+
+**State B — Policies exist but none attached at account level.** Some may be attached to specific users (per `POLICY_REFERENCES`). Surface the catalog and ask:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Found <N> policy/policies in your account; none attached at account level. How would you like to proceed?",
+        "header": "Existing Policies",
+        "multiSelect": false,
+        "options": [
+            {"label": "Continue with fresh recommendations", "description": "Generate recommendations based purely on LOGIN_HISTORY"},
+            {"label": "Inspect existing policies first", "description": "Skip recommendations — load workflows/view.md to inspect what's already defined"},
+            {"label": "Attach an existing policy instead", "description": "Skip recommendations — load workflows/attach-detach.md and apply one of the existing policies"},
+            {"label": "Cancel", "description": "Return to Step 4 in SKILL.md"}
+        ]
+    }]
+)
+```
+
+**State C — A policy is already attached at account level.** Modifying or replacing an account-attached policy is high-risk. Surface the policy name and scope, and ask:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Account-level policy <policy_name> is already attached for <scope>. How would you like to proceed?",
+        "header": "Account Policy In Place",
+        "multiSelect": false,
+        "options": [
+            {"label": "Recommend changes to <policy_name>", "description": "Generate recommendations and present them as proposed modifications; the modify.md break-glass gate will apply"},
+            {"label": "Recommend fresh and compare", "description": "Generate recommendations from LOGIN_HISTORY without touching <policy_name>; compare side-by-side before deciding"},
+            {"label": "Inspect existing only", "description": "Skip recommendations — load workflows/view.md"},
+            {"label": "Cancel", "description": "Return to Step 4 in SKILL.md"}
+        ]
+    }]
+)
+```
+
+| Selection (any state) | Action |
+|-----------------------|--------|
+| **Continue / Recommend fresh / Recommend changes** | Carry the inventory forward (so R6 generated SQL respects existing attachments via `FORCE`/`UNSET` only on explicit user approval) and proceed to R3. |
+| **Inspect existing** | **You MUST read** `workflows/view.md` and follow it. Do not return to recommend.md. |
+| **Attach an existing policy** | **You MUST read** `workflows/attach-detach.md` and start at D2a. Do not return to recommend.md. |
+| **Cancel** | Return to Step 4 in `SKILL.md`. |
+
+---
+
+## R3: Lookback Window
+
+Wait for the user's selection before continuing.
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "How far back should I analyze login activity?",
+        "header": "Lookback Window",
+        "multiSelect": false,
+        "options": [
+            {"label": "30 days", "description": "Recent activity only — fastest, but may miss monthly batch jobs"},
+            {"label": "60 days", "description": "Balanced view"},
+            {"label": "90 days", "description": "Recommended for service accounts — captures quarterly jobs"},
+            {"label": "180 days", "description": "Slower; good if you have rare-but-real workflows"}
+        ]
+    }]
+)
+```
+
+Record the choice as `<lookback_days>`.
+
+---
+
+## R4: Run Analysis Queries
+
+Run these read-only queries. Present a brief summary of each result before moving on, so the user can spot anomalies. (Existing-policy state was already captured in R2; do not re-query here.)
+
+### R4a: User inventory
+
+```sql
+SELECT
+  TYPE AS user_type,
+  COUNT_IF(DELETED_ON IS NULL AND DISABLED::STRING = 'false') AS active_users,
+  COUNT_IF(DELETED_ON IS NULL AND DISABLED::STRING = 'true')  AS disabled_users,
+  COUNT_IF(DELETED_ON IS NOT NULL)                            AS deleted_users
+FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+GROUP BY TYPE
+ORDER BY user_type;
+```
+
+> **Note on `TYPE` values:** PERSON, SERVICE, LEGACY_SERVICE, NULL. Treat NULL as "unknown — likely person" and surface it for the user to disambiguate.
+>
+> **Note on `DISABLED`:** the column is `VARIANT` (not BOOLEAN). Cast with `::STRING` (or `::BOOLEAN`) before comparing. Direct `DISABLED = 'false'` may not match.
+
+### R4b: Auth method usage by user, last `<lookback_days>` days
+
+```sql
+WITH recent_logins AS (
+  SELECT
+    USER_NAME,
+    UPPER(FIRST_AUTHENTICATION_FACTOR) AS auth_method,
+    UPPER(REPORTED_CLIENT_TYPE)        AS client_type,
+    IS_SUCCESS,
+    EVENT_TIMESTAMP
+  FROM SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY
+  WHERE EVENT_TIMESTAMP >= DATEADD(day, -<lookback_days>, CURRENT_TIMESTAMP())
+)
+SELECT
+  l.USER_NAME,
+  u.TYPE AS user_type,
+  l.auth_method,
+  l.client_type,
+  COUNT(*)                            AS attempts,
+  COUNT_IF(l.IS_SUCCESS = 'YES')      AS successes,
+  MAX(l.EVENT_TIMESTAMP)              AS last_seen
+FROM recent_logins l
+LEFT JOIN SNOWFLAKE.ACCOUNT_USAGE.USERS u
+  ON u.NAME = l.USER_NAME AND u.DELETED_ON IS NULL
+GROUP BY 1, 2, 3, 4
+ORDER BY l.USER_NAME, attempts DESC;
+```
+
+---
+
+## R5: Build Recommendations
+
+Aggregate the R4b results into per-user-type buckets. Use these heuristics:
+
+### R5a: Person users
+
+For PERSON users (and NULL-type users the user confirms are humans):
+
+1. Compute the dominant auth method per user (the method with the most successes in the window).
+2. The set of methods to keep is the **union** of all methods used by ≥5% of person users (or used at least once by anyone if the population is small — under 20 people).
+3. Default scaffold:
+   - `CLIENT_TYPES`: include `SNOWFLAKE_UI` (Snowsight) and `DRIVERS` if drivers were observed
+   - `AUTHENTICATION_METHODS`: include `SAML` if any SSO observed; add `OAUTH` if OAUTH observed in any client; add `PASSWORD` only if a non-trivial percentage still uses password (≥10% of users) AND tighten via MFA
+   - `MFA_ENROLLMENT`: `REQUIRED_PASSWORD_ONLY` if `PASSWORD` is in the methods, else `OPTIONAL`
+4. Per-user impact preview format:
+   - `JDOE — last PASSWORD login 2026-01-15; 92 of last 100 logins were SAML → policy will not block JDOE`
+   - `KSMITH — only PASSWORD usage in window; will be blocked unless PASSWORD stays allowed`
+
+### R5b: Service users
+
+Service users get **one account-level `FOR ALL SERVICE USERS` policy** with the union of authentication methods observed in `LOGIN_HISTORY` for `TYPE = 'SERVICE'` users. This single policy covers every service user automatically — no per-user `ALTER USER` statements.
+
+Valid methods for service users (`PASSWORD` is **not** supported and must not be proposed):
+
+| Method | When to include | Companion config |
+|---|---|---|
+| `OAUTH` | Any OAUTH login observed | `SECURITY_INTEGRATIONS = (<observed integration names>)` |
+| `KEYPAIR` | Any KEYPAIR login observed | None |
+| `PROGRAMMATIC_ACCESS_TOKEN` | Any PAT login observed | Tight `PAT_POLICY` (`MAX_EXPIRY_IN_DAYS = 30`, `REQUIRE_ROLE_RESTRICTION_FOR_SERVICE_USERS = TRUE`, `NETWORK_POLICY_EVALUATION = ENFORCED_REQUIRED`); flag as "older software only" |
+| `WORKLOAD_IDENTITY` | Any WIF login observed | `WORKLOAD_IDENTITY_POLICY` listing cloud providers + account/issuer constraints actually observed (see below) |
+
+#### Generated SQL
+
+```sql
+CREATE AUTHENTICATION POLICY service_account_policy
+  AUTHENTICATION_METHODS = (<union of observed methods>)
+  CLIENT_TYPES = (<observed client types, typically 'DRIVERS'>)
+  -- Add SECURITY_INTEGRATIONS if OAUTH is in the union
+  -- Add PAT_POLICY block if PROGRAMMATIC_ACCESS_TOKEN is in the union
+  -- Add WORKLOAD_IDENTITY_POLICY block if WORKLOAD_IDENTITY is in the union
+  COMMENT = 'Service-account policy — union of observed login methods';
+
+ALTER ACCOUNT SET AUTHENTICATION POLICY service_account_policy FOR ALL SERVICE USERS;
+```
+
+#### `WORKLOAD_IDENTITY_POLICY` shape (when WIF is in the union)
+
+Inspect `LOGIN_HISTORY.LOGIN_DETAILS` to identify which cloud providers showed up, then emit:
+
+```sql
+WORKLOAD_IDENTITY_POLICY = (
+  ALLOWED_PROVIDERS = (<observed: AWS, AZURE, GCP, OIDC>)
+  ALLOWED_AWS_ACCOUNTS = (<observed AWS account IDs>)        -- if AWS observed
+  ALLOWED_AZURE_ISSUERS = ('https://login.microsoftonline.com/<tenant>/v2.0')  -- if AZURE observed
+  ALLOWED_OIDC_ISSUERS = ('https://<issuer>')                                  -- if OIDC observed
+)
+```
+
+If exact AWS account / Azure tenant / OIDC issuer values cannot be determined from `LOGIN_HISTORY`, set only `ALLOWED_PROVIDERS` to the observed providers and surface a note asking the user to tighten the issuer lists once they confirm the values.
+
+#### Anomalies to surface (do not silently lump into the default policy)
+
+- **`TYPE = 'SERVICE'` user with PASSWORD logins** — anomalous; surface for investigation; do NOT include `PASSWORD` in `AUTHENTICATION_METHODS` for the service policy.
+- **`TYPE = 'LEGACY_SERVICE'` users** — `FOR ALL SERVICE USERS` may not cover them. Surface separately with a migration recommendation (convert to `TYPE = 'SERVICE'` with KEYPAIR or OAUTH).
+- **`TYPE IS NULL` users that look service-like** — ask the user to disambiguate; do not auto-assign.
+
+
+
+### R5c: Inactive / unknown users
+
+Surface separately — no policy recommendation, but suggest the user either disable them or assign a deny-all break-glass-style policy. Do not generate `ALTER` statements automatically; let the user decide.
+
+### R5d: Break-glass
+
+Always include a recommendation block at the top of the output:
+```sql
+-- Break-glass: a permissive policy attached to a single trusted admin user.
+-- Confirm this user can log in BEFORE applying any account-level restriction.
+CREATE AUTHENTICATION POLICY admin_escape_hatch
+  AUTHENTICATION_METHODS = ('ALL')
+  CLIENT_TYPES = ('ALL')
+  SECURITY_INTEGRATIONS = ('ALL')
+  COMMENT = 'Permissive fallback for admin - prevents lockout';
+
+ALTER USER <admin_user> SET AUTHENTICATION POLICY admin_escape_hatch;
+```
+
+If `SHOW AUTHENTICATION POLICIES ON USER <admin_user>` (e.g. checked from `attach-detach.md` D2c) shows the user already has a permissive policy, mark this block as "already in place — skip" instead of removing it from the output.
+
+### R5e: Reconciliation with existing policies (from R2)
+
+If R2 found existing policies or account-level attachments, the recommendation block must address them explicitly:
+
+- **State C (existing account-level policy):** present recommendations as a **diff** against the attached policy when the user picked "Recommend changes". Generated SQL is `ALTER AUTHENTICATION POLICY <name> SET ...` (route to `modify.md` in R7), not a fresh `CREATE`. The B4c break-glass gate from `modify.md` applies.
+- **State C (recommend fresh + compare):** generate a fresh `CREATE` with a new policy name (do NOT collide with the attached one), and surface the side-by-side diff so the user can decide whether to swap.
+- **State B (policies exist, none attached):** if any existing policy already matches the recommended shape, propose attaching it (route to `attach-detach.md`) instead of creating a duplicate.
+
+---
+
+## R6: Present as Copy-Paste Blocks (MANDATORY GATE)
+
+⚠️ MANDATORY GATE — present everything for review BEFORE any execution.
+
+Output structure (single message to the user):
+
+```
+## Recommendation summary
+
+- <N> active person users analyzed; dominant methods: <list>
+- <M> active service users (TYPE='SERVICE') analyzed; observed methods: <OAUTH:x, KEYPAIR:y, PAT:z, WIF:w>
+- <L> LEGACY_SERVICE users — separate migration recommendations below
+- <K> users had no logins in the last <lookback_days> days
+- Existing account-level policy: <name or "none">
+
+## Recommended SQL (copy into a worksheet to review, then approve below)
+
+-- 1. Break-glass (do this FIRST)
+<R5d block>
+
+-- 2. Person-user policy
+<CREATE + ALTER ACCOUNT FOR ALL PERSON USERS>
+
+-- 3. Service-user policy (default: single FOR ALL SERVICE USERS, union of observed methods)
+<CREATE service_account_policy with AUTHENTICATION_METHODS = (<union>) [+ PAT_POLICY] [+ WORKLOAD_IDENTITY_POLICY] [+ SECURITY_INTEGRATIONS]>
+<ALTER ACCOUNT SET AUTHENTICATION POLICY service_account_policy FOR ALL SERVICE USERS>
+
+-- 4. LEGACY_SERVICE users (if any) — migration recommendation
+<list of LEGACY_SERVICE users, no auto-generated SQL — manual decision required>
+
+## Anomalies / manual decisions
+
+<list:>
+- TYPE='SERVICE' users with PASSWORD logins (anomalous — investigate)
+- TYPE IS NULL users that look service-like (need disambiguation)
+
+## Per-user impact preview
+
+<bulleted list of "<user> — last <method> login <date>; <N>/<M> recent logins were <method> → will / will not be blocked">
+
+## Inactive / unknown users (no automated recommendation)
+
+<list>
+```
+
+Then ask:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Review the SQL and impact preview above. How would you like to proceed?",
+        "header": "Next Step",
+        "multiSelect": false,
+        "options": [
+            {"label": "Apply the break-glass first, then person-user policy", "description": "Route into create.md + attach-detach.md for blocks 1 and 2 only — defer service users"},
+            {"label": "Apply everything (with my approval at each step)", "description": "Walk through every block (break-glass → person → service) one at a time, with explicit approval per block"},
+            {"label": "Just give me the SQL to paste myself", "description": "Take the output to a worksheet — no further automated execution"},
+            {"label": "Adjust the recommendations", "description": "Re-run with different lookback or different heuristics"}
+        ]
+    }]
+)
+```
+
+Do NOT execute any DDL/DML in this workflow itself. All execution flows through `create.md` and `attach-detach.md` (or `modify.md` if R2 routed us into "recommend changes" against an attached policy) for their existing approval gates.
+
+---
+
+## R7: Route to Execution
+
+| Selection | Action |
+|-----------|--------|
+| **Apply break-glass first, then person-user policy** | For each of the 2 blocks in turn: read `workflows/create.md` and execute starting at A2 using the pre-decided values from R5. After A4 succeeds, read `workflows/attach-detach.md` starting at D2b (scope already known). Re-prepend `USE ROLE <chosen_role>;` per the Role Persistence Rule. **If R2 returned State C with "Recommend changes",** route into `workflows/modify.md` at B3 instead of `create.md` for the affected policy. |
+| **Apply everything** | Same as above, but walk through all generated blocks (break-glass → person → service-user policy via `FOR ALL SERVICE USERS`), confirming with the user before each `create.md` / `modify.md` invocation. |
+| **Just give me the SQL** | Display the final SQL bundle, then proceed to **Step 4** in `SKILL.md`. |
+| **Adjust the recommendations** | Return to R3 (lookback) or R5 heuristics — ask which dimension to change, then re-run R4–R6. R2 inventory is still valid; do NOT re-run it. |
+
+After all blocks are applied (or the user is done), proceed to **Step 4** in `SKILL.md`.
+
+---
+
+## Stopping Points
+
+- ✋ R2: existing-policy inventory branch — wait for the user's selection (continue / inspect / attach existing / modify / cancel)
+- ✋ R3: lookback window — wait for selection
+- ✋ R6: present everything before any execution; wait for the user's "what next?" choice
+- ✋ R7: each routed block goes through `create.md` / `modify.md` / `attach-detach.md`'s own approval gates — do not bypass them
+- ✋ Any time existing policies conflict with recommendations: stop and surface the conflict; let the user decide UNSET vs FORCE vs cancel
+
+## Output
+
+- A copy-paste-ready SQL bundle (break-glass → person → service-user groups)
+- Per-user impact preview tied to actual `LOGIN_HISTORY` activity
+- Optional follow-through into `create.md` / `modify.md` / `attach-detach.md` for guided execution

--- a/skills/manage-authentication-policy/workflows/view.md
+++ b/skills/manage-authentication-policy/workflows/view.md
@@ -1,0 +1,110 @@
+---
+name: view-authentication-policy-workflow
+parent_skill: manage-authentication-policy
+---
+
+# Workflow C: View/Describe Policy
+
+## When to Load
+
+Loaded from `manage-authentication-policy/SKILL.md` when user selects **View/describe policy**.
+
+**Prerequisites:** Step 1 (intent selection) and Step 2 (privilege check) completed.
+
+---
+
+## C2: Select View Type
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "What would you like to view?",
+        "header": "View",
+        "multiSelect": false,
+        "options": [
+            {"label": "List all policies", "description": "Show all authentication policies in the account"},
+            {"label": "Account-level attachments", "description": "Show which policies are attached at the account level"},
+            {"label": "User-level attachment", "description": "Show which policy is attached to a specific user"},
+            {"label": "Inspect a policy", "description": "Show full configuration for a specific policy"}
+        ]
+    }]
+)
+```
+
+| Selection | Go to |
+|-----------|-------|
+| List all policies | C2a |
+| Account-level attachments | C2b |
+| User-level attachment | C2c |
+| Inspect a policy | C2d |
+
+---
+
+## C2a: List All Policies
+
+```sql
+SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+```
+
+Display all rows returned. Then go to **Next Step**.
+
+---
+
+## C2b: Account-Level Attachments
+
+```sql
+SHOW AUTHENTICATION POLICIES ON ACCOUNT;
+```
+
+Display all rows returned. Then go to **Next Step**.
+
+---
+
+## C2c: User-Level Attachment
+
+Ask the user which Snowflake username to check (a username, not a role name — e.g. `JSMITH`, not `SYSADMIN`).
+
+```sql
+SHOW AUTHENTICATION POLICIES ON USER <username>;
+```
+
+Display all rows returned. Then go to **Next Step**.
+
+---
+
+## C2d: Inspect a Policy
+
+First, list available policies:
+
+```sql
+SHOW AUTHENTICATION POLICIES IN ACCOUNT;
+```
+
+Present the results as a selectable list:
+
+```python
+AskUserQuestion(
+    questions=[{
+        "question": "Which policy would you like to inspect?",
+        "header": "Select Policy",
+        "multiSelect": false,
+        "options": [
+            # One {"label": "<db>.<schema>.<policy_name>"} per row from SHOW AUTHENTICATION POLICIES
+        ]
+    }]
+)
+```
+
+Then run:
+
+```sql
+DESC AUTHENTICATION POLICY <db>.<schema>.<policy_name>;
+```
+
+Display all rows returned. Then go to **Next Step**.
+
+---
+
+## C3: Next Step
+
+Proceed to **Step 4** in `SKILL.md`. Additionally offer a "View something else" option that returns to C2.


### PR DESCRIPTION
## Summary

Adds the `manage-authentication-policy` skill — covers create, modify, view, attach, detach, drop, and recommend operations for Snowflake authentication policies. Spans `AUTHENTICATION_METHODS` (PASSWORD, SAML, OAUTH, KEYPAIR), MFA enforcement, `PAT_POLICY`, workload identity federation, `CLIENT_TYPES`, and minimum driver versions.

Promoted from `snowflake-eng/cortex-code-skills/database-security/iam/authentication/manage-authentication-policy` after audit review (top-7 strong-promote candidate from the 28-skill promotion candidate set). Fills a real security gap not currently covered by any bundled or Labs skill.

## Files

- `skills/manage-authentication-policy/SKILL.md` — Labs frontmatter + main router
- `skills/manage-authentication-policy/LICENSE` — Snowflake Skills License (employee author)
- `skills/manage-authentication-policy/references/property-reference.md` — full property syntax / canonical sources
- `skills/manage-authentication-policy/workflows/{create,modify,view,attach-detach,drop,recommend}.md` — 6 sub-workflows

The internal `skill_metadata/` directory (auditor seed file with owner email) was intentionally not promoted.

## Audit pipeline status

`audit run-tier labs --client mock`:
- Blocking checks: **0 failures** (frontmatter, license, no internal refs all pass)
- Advisory: 4 (word budget; no Overview/Common-Mistakes section; multi-language code blocks for Python+SQL)

## Test plan

- [ ] Reviewer verifies frontmatter renders in skill catalog
- [ ] `/skill add` from this branch loads cleanly with all 6 workflow files and reference
- [ ] `$manage-authentication-policy recommend authentication policies for my account based on recent login activity` produces a useful recommendation
- [ ] Each workflow file is reachable from the main router
