### PR TITLE
feat: switch AEM credentials from GitHub secrets to AWS Secrets Manag…

### DIFF
--- a/.github/workflows/publish-skill-to-aem.yml
+++ b/.github/workflows/publish-skill-to-aem.yml
@@ -15,15 +15,10 @@ on:
         description: 'PR number for commenting (optional, omit for merge runs)'
         required: false
         type: number
-    secrets:
-      AEM_USERNAME:
+      aws_secret_name:
+        description: 'AWS Secrets Manager secret name containing AEM credentials'
         required: true
-      AEM_PASSWORD:
-        required: true
-      AEM_AUTHOR_URL:
-        required: true
-      AEM_PUBLISH_URL:
-        required: true
+        type: string
 
 env:
   CF_BASE_PATH: /content/dam/snowflake-site/en/content-fragments/skills-library/cortex-code-skills-base-cf
@@ -32,12 +27,36 @@ env:
 jobs:
   publish_skill:
     runs-on: ubuntu-latest
-    env:
-      AEM_URL: ${{ secrets.AEM_AUTHOR_URL }}
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::886692307588:role/github-snowflake-labs-aem-iam-role
+          aws-region: us-west-1
+
+      - name: Fetch AEM secrets
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id "${{ inputs.aws_secret_name }}" \
+            --query SecretString --output text)
+
+          aem_username=$(echo "$secret" | jq -r '.AEM_USERNAME')
+          aem_password=$(echo "$secret" | jq -r '.AEM_PASSWORD')
+          aem_author_url=$(echo "$secret" | jq -r '.AEM_AUTHOR_URL')
+          aem_publish_url=$(echo "$secret" | jq -r '.AEM_PUBLISH_URL')
+
+          echo "::add-mask::$aem_username"
+          echo "::add-mask::$aem_password"
+
+          echo "AEM_USERNAME=$aem_username" >> $GITHUB_ENV
+          echo "AEM_PASSWORD=$aem_password" >> $GITHUB_ENV
+          echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
+          echo "AEM_PUBLISH_URL=$aem_publish_url" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -170,7 +189,7 @@ jobs:
         if: inputs.pr_number != 0
         uses: actions/github-script@v7
         env:
-          AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL }}
+          AEM_PUBLISH_URL: ${{ env.AEM_PUBLISH_URL }}
         with:
           script: |
             const skillName = '${{ inputs.skill_name }}';

--- a/.github/workflows/publish-skills-on-merge.yml
+++ b/.github/workflows/publish-skills-on-merge.yml
@@ -46,6 +46,9 @@ jobs:
   publish_skills:
     needs: detect_changes
     if: needs.detect_changes.outputs.has_changes == 'true'
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         skill: ${{ fromJson(needs.detect_changes.outputs.skills_json) }}
@@ -55,8 +58,4 @@ jobs:
     with:
       skill_name: ${{ matrix.skill.name }}
       commit_sha: ${{ github.sha }}
-    secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_STAGING }}
+      aws_secret_name: github-snowflake-labs-aem-staging-secrets

--- a/.github/workflows/stage-skills-on-pr.yml
+++ b/.github/workflows/stage-skills-on-pr.yml
@@ -53,6 +53,10 @@ jobs:
   stage_skills:
     needs: detect_changes
     if: needs.detect_changes.outputs.has_changes == 'true'
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
     strategy:
       matrix:
         skill: ${{ fromJson(needs.detect_changes.outputs.skills_json) }}
@@ -63,8 +67,4 @@ jobs:
       skill_name: ${{ matrix.skill.name }}
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.pull_request.number }}
-    secrets:
-      AEM_USERNAME: ${{ secrets.AEM_USERNAME_STAGING }}
-      AEM_PASSWORD: ${{ secrets.AEM_PASSWORD_STAGING }}
-      AEM_AUTHOR_URL: ${{ secrets.AEM_AUTHOR_URL_STAGING }}
-      AEM_PUBLISH_URL: ${{ secrets.AEM_PUBLISH_URL_STAGING }}
+      aws_secret_name: github-snowflake-labs-aem-staging-secrets


### PR DESCRIPTION
…er via OIDC

Replace GitHub Actions secrets (AEM_USERNAME_STAGING etc.) with AWS Secrets Manager fetched via GitHub OIDC. Credentials are fetched inside the reusable workflow (publish-skill-to-aem.yml) via aws_secret_name input. All workflows use staging secrets for now.

IAM role github-snowflake-labs-aem-iam-role (account 886692307588) already trusts Snowflake-Labs/coco-skills.

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Skill submission checklist

Before submitting, please confirm the following:

### Folder structure
- [ ] My skill lives at `skills/<my-skill-id>/`
- [ ] The folder name matches the `id` field in `SKILL.md` (lowercase, hyphens only)
- [ ] `SKILL.md` is present in the skill folder
- [ ] `LICENSE` is present in the skill folder

### Frontmatter
- [ ] `name` field is filled in
- [ ] `description` field clearly explains what the skill does, when to use it, and what triggers it
- [ ] `id` field matches the folder name
- [ ] `authors` field includes the contributor's name
- [ ] `type` is set to `community` or `snowflake`
- [ ] `status` is set to `stable`, `beta`, or `draft`
- [ ] `categories` includes at least one relevant tag

### License
- [ ] Community contributors: LICENSE is Apache 2.0
- [ ] Snowflake employees: LICENSE is the Snowflake Skills License

### Testing
- [ ] I tested this skill in a Cortex Code session against my example prompt
- [ ] The skill behavior matches what is described in the `description` field

### Optional
- [ ] Supporting files (templates, examples) are organized into `templates/` or `references/` subdirectories
- [ ] I checked that my skill name does not conflict with a bundled Cortex Code skill (run `/skill` in a session to verify)

---

**Describe your skill:**

<!-- What does it do? What problem does it solve? Who is it for? -->

**Example prompt that triggers it:**

<!-- e.g. "good morning" or "run my daily pipeline check" -->
