### PR TITLE
security: use pull_request_target and split trusted script checkout

### DIFF
--- a/.github/workflows/publish-skill-to-aem.yml
+++ b/.github/workflows/publish-skill-to-aem.yml
@@ -19,6 +19,11 @@ on:
         description: 'AWS Secrets Manager secret name containing AEM credentials'
         required: true
         type: string
+      base_sha:
+        description: 'Base branch SHA for trusted script checkout (prevents fork PR script injection)'
+        required: false
+        type: string
+        default: ''
 
 env:
   CF_BASE_PATH: /content/dam/snowflake-site/en/content-fragments/skills-library/cortex-code-skills-base-cf
@@ -57,14 +62,22 @@ jobs:
           echo "AEM_URL=$aem_author_url" >> $GITHUB_ENV
           echo "AEM_PUBLISH_URL=$aem_publish_url" >> $GITHUB_ENV
 
-      - name: Checkout repository
+      - name: Checkout skill content (from PR branch)
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit_sha }}
           sparse-checkout: |
             skills/${{ inputs.skill_name }}
+          sparse-checkout-cone-mode: true
+
+      - name: Checkout trusted scripts (from base branch)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base_sha || inputs.commit_sha }}
+          sparse-checkout: |
             scripts/aem-skills
           sparse-checkout-cone-mode: true
+          path: trusted-scripts
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -87,7 +100,7 @@ jobs:
 
       - name: Parse SKILL.md
         run: |
-          python3 scripts/aem-skills/parse_skill.py \
+          python3 trusted-scripts/scripts/aem-skills/parse_skill.py \
             "${{ steps.find_md.outputs.md_file }}" \
             --output-json parsed_skill.json
           echo "📄 Parsed skill:"
@@ -95,7 +108,7 @@ jobs:
 
       - name: Prepare AEM payload
         run: |
-          python3 scripts/aem-skills/prepare_skill_payload.py \
+          python3 trusted-scripts/scripts/aem-skills/prepare_skill_payload.py \
             parsed_skill.json \
             --output-json skill_payload.json
           echo "📦 Payload prepared"

--- a/.github/workflows/stage-skills-on-pr.yml
+++ b/.github/workflows/stage-skills-on-pr.yml
@@ -1,7 +1,7 @@
 name: Stage Skills to AEM on PR
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
     paths:
       - 'skills/**/SKILL.md'
@@ -66,5 +66,6 @@ jobs:
     with:
       skill_name: ${{ matrix.skill.name }}
       commit_sha: ${{ github.event.pull_request.head.sha }}
+      base_sha: ${{ github.event.pull_request.base.sha }}
       pr_number: ${{ github.event.pull_request.number }}
       aws_secret_name: github-snowflake-labs-aem-staging-secrets


### PR DESCRIPTION
- stage-skills-on-pr.yml: switch trigger from pull_request to pull_request_target so the workflow runs from the base branch and has access to OIDC credentials from fork PRs

- publish-skill-to-aem.yml: add base_sha input; split single checkout into two separate sparse checkouts:
    1. skill content (skills/<name>/) from PR head SHA (untrusted)
    2. scripts (scripts/aem-skills/) from base branch SHA (trusted) Script invocations updated to use trusted-scripts/ prefix

Prevents fork PR script injection (same fix as CASEC-10663 / H1-3820088 applied to sfquickstarts)

## Skill submission checklist

Before submitting, please confirm the following:

### Folder structure
- [ ] My skill lives at `skills/<my-skill-id>/`
- [ ] The folder name matches the `id` field in `SKILL.md` (lowercase, hyphens only)
- [ ] `SKILL.md` is present in the skill folder
- [ ] `LICENSE` is present in the skill folder

### Frontmatter
- [ ] `name` field is filled in
- [ ] `description` field clearly explains what the skill does, when to use it, and what triggers it
- [ ] `id` field matches the folder name
- [ ] `authors` field includes the contributor's name
- [ ] `type` is set to `community` or `snowflake`
- [ ] `status` is set to `stable`, `beta`, or `draft`
- [ ] `categories` includes at least one relevant tag

### License
- [ ] Community contributors: LICENSE is Apache 2.0
- [ ] Snowflake employees: LICENSE is the Snowflake Skills License

### Testing
- [ ] I tested this skill in a Cortex Code session against my example prompt
- [ ] The skill behavior matches what is described in the `description` field

### Optional
- [ ] Supporting files (templates, examples) are organized into `templates/` or `references/` subdirectories
- [ ] I checked that my skill name does not conflict with a bundled Cortex Code skill (run `/skill` in a session to verify)

---

**Describe your skill:**

<!-- What does it do? What problem does it solve? Who is it for? -->

**Example prompt that triggers it:**

<!-- e.g. "good morning" or "run my daily pipeline check" -->
