### PR TITLE
chore: trigger prod publish for all skills

### DIFF
--- a/.github/workflows/publish-skills-on-merge.yml
+++ b/.github/workflows/publish-skills-on-merge.yml
@@ -24,7 +24,7 @@ jobs:
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${{ github.repository }}/commits/${commit_sha}" \
-            | jq -r '.files[]? | select(.status != "removed") | .filename | select(startswith("skills/")) | select(endswith("/SKILL.md"))')
+            | jq -r '.files[]? | select(.status != "removed") | .filename | select(test("^skills/[^/]+/SKILL\\.md$"))')
 
           if [ -z "$changed_files" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -37,7 +37,7 @@ jobs:
           objs='[]'
           while IFS= read -r file; do
             [ -z "$file" ] && continue
-            skill_name=$(echo "$file" | sed -E 's|skills/([^/]+)/SKILL.md|\1|')
+            skill_name=$(echo "$file" | sed -E 's|^skills/([^/]+)/SKILL\.md$|\1|')
             objs=$(echo "$objs" | jq -c --arg name "$skill_name" '. + [{name:$name}]')
           done <<< "$changed_files"
           echo "skills_json=$objs" >> $GITHUB_OUTPUT

--- a/.github/workflows/stage-skills-on-pr.yml
+++ b/.github/workflows/stage-skills-on-pr.yml
@@ -31,7 +31,7 @@ jobs:
             -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             "https://api.github.com/repos/${repo}/pulls/${pr_number}/files?per_page=100" \
-            | jq -r '.[] | select(.status != "removed") | .filename | select(startswith("skills/")) | select(endswith("/SKILL.md"))')
+            | jq -r '.[] | select(.status != "removed") | .filename | select(test("^skills/[^/]+/SKILL\\.md$"))')
 
           if [ -z "$changed_files" ]; then
             echo "has_changes=false" >> $GITHUB_OUTPUT
@@ -44,7 +44,7 @@ jobs:
           objs='[]'
           while IFS= read -r file; do
             [ -z "$file" ] && continue
-            skill_name=$(echo "$file" | sed -E 's|skills/([^/]+)/SKILL.md|\1|')
+            skill_name=$(echo "$file" | sed -E 's|^skills/([^/]+)/SKILL\.md$|\1|')
             objs=$(echo "$objs" | jq -c --arg name "$skill_name" '. + [{name:$name}]')
           done <<< "$changed_files"
           echo "skills_json=$objs" >> $GITHUB_OUTPUT

--- a/skills/dcr-v1-to-v2/SKILL.md
+++ b/skills/dcr-v1-to-v2/SKILL.md
@@ -103,3 +103,4 @@ Print generated file list and next steps (run provider setup, run consumer setup
 - `discover/INSTRUCTIONS.md` — V1 introspection queries
 - `generate/INSTRUCTIONS.md` — V2 Collaboration API script generation
 - `v1_v2_mapping.md` — reference mapping table
+

--- a/skills/manage-zerocopy-sapbdc/SKILL.md
+++ b/skills/manage-zerocopy-sapbdc/SKILL.md
@@ -135,3 +135,4 @@ Assistant: Runs DESC ZEROCOPY CONNECTOR, checks privileges, validates invitation
 ## Output
 
 Depends on selected use case — see sub-skill outputs.
+

--- a/skills/mlops/SKILL.md
+++ b/skills/mlops/SKILL.md
@@ -102,3 +102,4 @@ Refuse these rationalizations:
 - Assessment route: maturity scorecard + prioritized roadmap.
 - Patterns route: implementation playbook for the selected capability.
 - Full setup: complete architecture with sequenced implementation plan.
+

--- a/skills/ontology-stack-builder/SKILL.md
+++ b/skills/ontology-stack-builder/SKILL.md
@@ -1202,3 +1202,4 @@ Deployed directly to Snowflake (via native skills):
 ├── Ontology semantic views     (created by `semantic-view` skill in Phase 5)
 └── Cortex Agent                (created by `cortex-agent` skill in Phase 6)
 ```
+

--- a/skills/ontology-stack-builder/SKILL.md
+++ b/skills/ontology-stack-builder/SKILL.md
@@ -26,7 +26,7 @@ prompt: "$ontology-stack-builder Build an ontology stack on MY_DB.MY_SCHEMA usin
 language: en
 status: Published
 author: Tianxia Jia
-type: Snowflake Staff
+type: snowflake
 demo-url: https://medium.com/snowflake/ontology-on-snowflake-from-architecture-to-deployment-with-a-cortex-code-skill-197866ce9c9f
 ---
 

--- a/skills/openflow-spcs-privatelink/SKILL.md
+++ b/skills/openflow-spcs-privatelink/SKILL.md
@@ -122,3 +122,4 @@ Order matters — Snowflake first, then AWS:
 ## Cost note
 
 NLB (hourly + LCU), VPC Endpoint Service (hourly), PrivateLink endpoint (hourly + per-GB), and cross-zone data transfer all incur AWS charges. Check current AWS pricing.
+

--- a/skills/quickstart-guide/SKILL.md
+++ b/skills/quickstart-guide/SKILL.md
@@ -284,3 +284,4 @@ Assistant: Fetches the Cortex Agents Quickstart, checks environment, asks mode, 
 ### Example 2: Legacy URL
 User: $quickstart-guide https://quickstarts.snowflake.com/guide/getting_started_with_dataengineering_ml_using_snowpark_python
 Assistant: Detects legacy URL pattern, converts underscores to hyphens, fetches content, and delivers the Data Engineering with Snowpark experience.
+

--- a/skills/rbac/SKILL.md
+++ b/skills/rbac/SKILL.md
@@ -101,3 +101,4 @@ This skill tells you which roles to reference. Those skills handle policy implem
 This router skill issues no SQL on its own. Each sub-flow that creates roles, applies grants, or alters schemas defines its own stopping points. The general rule across all sub-flows:
 
 ⚠️ STOPPING POINT: Before running any `CREATE ROLE`, `GRANT`, `REVOKE`, `ALTER SCHEMA … ENABLE MANAGED ACCESS`, or `DROP ROLE` statement, show the planned SQL to the user and wait for explicit confirmation. RBAC changes are easy to apply but painful to reverse once users start depending on them.
+

--- a/skills/review-skill-sflabs/SKILL.md
+++ b/skills/review-skill-sflabs/SKILL.md
@@ -117,3 +117,4 @@ A single rendered report per `references/report-template.md`. Includes verdict, 
 - When the data-policy principles update, only `references/data-policy-principles.md` changes — the workflows reason against whatever the current file says.
 
 
+

--- a/skills/semantic-view-patterns/SKILL.md
+++ b/skills/semantic-view-patterns/SKILL.md
@@ -82,3 +82,4 @@ DDL-only features (no YAML equivalent): `AI_QUESTION_CATEGORIZATION`, `WITH TAG`
 - **Cardinality wrong on a relationship** — silently inflates metrics; verify with `SHOW METRICS` and a row-count sanity query.
 - **Fan trap from two facts joined through a shared dim without `USING`** — disambiguate with the `USING (relationship)` clause on each metric.
 - **Forgetting to switch roles** in access-control snippets before running query blocks.
+

--- a/skills/snowflake-docs/SKILL.md
+++ b/skills/snowflake-docs/SKILL.md
@@ -89,3 +89,4 @@ Use the returned content to answer the user's question.
 ## Output
 
 A concise answer to the user's Snowflake question, grounded in official documentation. **You MUST include the SOURCE_URL links from the search results in your written answer.** List them as references at the end so the user can read the full pages. Never omit the URLs.
+

--- a/skills/snowpipe-bcdr/SKILL.md
+++ b/skills/snowpipe-bcdr/SKILL.md
@@ -133,3 +133,4 @@ Catchup choices: `ALTER PIPE … REFRESH` (≤7 days), `COPY INTO … FROM @stag
 
 - [Stage, Pipe, and Load History Replication](https://docs.snowflake.com/en/user-guide/account-replication-stages-pipes-load-history)
 - [Automating Snowpipe for Azure Blob Storage](https://docs.snowflake.com/en/user-guide/data-load-snowpipe-auto-azure)
+

--- a/skills/snowpro-study/SKILL.md
+++ b/skills/snowpro-study/SKILL.md
@@ -11,7 +11,7 @@ description: >
 language: en
 status: beta
 authors: Andy Brown
-type: Community
+type: community
 prompt: "$snowpro-study Core Deep Dive Domain 2"
 tools:
   - web_fetch

--- a/skills/snowpro-study/SKILL.md
+++ b/skills/snowpro-study/SKILL.md
@@ -409,3 +409,4 @@ Before generating ANY files (applies to all sub-skills):
 | User specifies a cert that doesn't exist | Show available certs from cache/discovery and ask them to choose |
 | User specifies a domain number that doesn't exist | Show available domains for that cert and ask them to choose |
 | Cache file is corrupted | Delete and re-fetch |
+

--- a/skills/solutions-installer/SKILL.md
+++ b/skills/solutions-installer/SKILL.md
@@ -250,3 +250,4 @@ Assistant:
 ## Example 2: List available solutions
 User: $solutions-installer
 Assistant: Scans repo for manifest.json files, shows table of available solutions, asks user to pick one
+

--- a/skills/spec-driven/SKILL.md
+++ b/skills/spec-driven/SKILL.md
@@ -265,3 +265,4 @@ For post-completion changes (code modified after spec is complete), use the **Ev
 ---
 
 **Next Step**: Based on detected intent, load appropriate sub-skill and begin PHASE 1: CLARIFY.
+

--- a/skills/spec-driven/bugfix/SKILL.md
+++ b/skills/spec-driven/bugfix/SKILL.md
@@ -292,3 +292,4 @@ CLARIFY → SPECIFY (3-part) → IMPLEMENT → VALIDATE
 3. Unchanged Behavior - Regression prevention
 
 **Key Principle**: The Unchanged Behavior section is NOT optional. Every bugfix MUST document what should NOT change.
+

--- a/skills/spec-driven/evolve/SKILL.md
+++ b/skills/spec-driven/evolve/SKILL.md
@@ -325,3 +325,4 @@ DETECT → AMEND SPEC → IMPLEMENT (delta only) → VALIDATE (full)
 - The change is a bug fix → use `bugfix/SKILL.md`
 - The change is purely structural (no behavior change) → use `refactor/SKILL.md`
 - The change is so large it's effectively a new feature → use `feature/SKILL.md` with a new spec folder
+

--- a/skills/spec-driven/feature/SKILL.md
+++ b/skills/spec-driven/feature/SKILL.md
@@ -320,3 +320,4 @@ CLARIFY → SPECIFY → [DESIGN] → IMPLEMENT → VALIDATE
 - `specs/features/{name}/requirements.md`
 - `specs/features/{name}/design.md` (if complex)
 - `specs/features/{name}/tasks.md`
+

--- a/skills/spec-driven/implement/SKILL.md
+++ b/skills/spec-driven/implement/SKILL.md
@@ -241,3 +241,4 @@ LOCATE → VALIDATE → PLAN → EXECUTE → VALIDATE → FINALIZE
 - Features: `specs/features/{name}/requirements.md`
 - Bugfixes: `specs/bugfixes/{id}/bugfix-spec.md`
 - Refactors: `specs/refactors/{name}/spec.md`
+

--- a/skills/spec-driven/refactor/SKILL.md
+++ b/skills/spec-driven/refactor/SKILL.md
@@ -246,3 +246,4 @@ CLARIFY → SPECIFY → IMPLEMENT (iterative) → VALIDATE
 - Event emissions
 - Error messages and codes
 - Performance characteristics
+

--- a/skills/well-architected-framework-assessment/SKILL.md
+++ b/skills/well-architected-framework-assessment/SKILL.md
@@ -417,3 +417,4 @@ Confirm:
 
 - **Primary:** Inline report in CoCo (metric cards, bar charts, markdown tables)
 - **Optional:** Single self-contained HTML report file (no sibling files)
+


### PR DESCRIPTION
## Skill submission checklist

Before submitting, please confirm the following:

### Folder structure
- [ ] My skill lives at `skills/<my-skill-id>/`
- [ ] The folder name matches the `id` field in `SKILL.md` (lowercase, hyphens only)
- [ ] `SKILL.md` is present in the skill folder
- [ ] `LICENSE` is present in the skill folder

### Frontmatter
- [ ] `name` field is filled in
- [ ] `description` field clearly explains what the skill does, when to use it, and what triggers it
- [ ] `id` field matches the folder name
- [ ] `authors` field includes the contributor's name
- [ ] `type` is set to `community` or `snowflake`
- [ ] `status` is set to `stable`, `beta`, or `draft`
- [ ] `categories` includes at least one relevant tag

### License
- [ ] Community contributors: LICENSE is Apache 2.0
- [ ] Snowflake employees: LICENSE is the Snowflake Skills License

### Testing
- [ ] I tested this skill in a Cortex Code session against my example prompt
- [ ] The skill behavior matches what is described in the `description` field

### Optional
- [ ] Supporting files (templates, examples) are organized into `templates/` or `references/` subdirectories
- [ ] I checked that my skill name does not conflict with a bundled Cortex Code skill (run `/skill` in a session to verify)

---

**Describe your skill:**

<!-- What does it do? What problem does it solve? Who is it for? -->

**Example prompt that triggers it:**

<!-- e.g. "good morning" or "run my daily pipeline check" -->
