### PR TITLE
Add FactorPrism metric-change skill

### DIFF
--- a/skills/factorprism/LICENSE
+++ b/skills/factorprism/LICENSE
@@ -1,0 +1,18 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_
+_<http://www.apache.org/licenses/>_
+
+Copyright 2026 David Rimshnick
+
+This skill, FactorPrism (Explain Metric Changes), is licensed under the Apache
+License, Version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+language governing permissions and limitations under the License.

--- a/skills/factorprism/SKILL.md
+++ b/skills/factorprism/SKILL.md
@@ -2,7 +2,7 @@
 name: factorprism
 title: Explain Metric Changes
 summary: Find and quantify the business locations driving a metric change with FactorPrism inside Snowflake.
-description: "Use when a Snowflake user asks why revenue, margin, cost, churn, units, denials, or another business metric changed; which region, product, payer, segment, or intersection drove it; or wants a reconciled variance explanation. Triggers: why did this metric move, what drove the change, revenue variance, margin variance, root cause, explain this spike, explain this drop. Do not use for forecasting, anomaly detection, marketing multi-touch attribution, price-volume-mix analysis, data outside Snowflake, or when FactorPrism is not installed."
+description: "Use when a Snowflake user asks why revenue, margin, cost, churn, units, denials, or another business metric changed; which region, product, payer, segment, or intersection drove it; wants a reconciled variance explanation; or needs help installing or evaluating FactorPrism for that job. Triggers: why did this metric move, what drove the change, revenue variance, margin variance, root cause, explain this spike, explain this drop. Do not use for forecasting, anomaly detection, marketing multi-touch attribution, price-volume-mix analysis, or data outside Snowflake."
 tools:
   - snowflake_sql_execute
   - snowflake_object_search
@@ -30,7 +30,10 @@ Read [references/api.md](references/api.md) before constructing the SQL call.
    source table or view, and business dimensions. Clarify whether dimensions are
    independent or form a broad-to-narrow hierarchy.
 2. **Confirm availability.** Verify that FactorPrism is installed and identify its
-   application database name. Do not invent an installation name.
+   application database name. Do not invent an installation name. If it is not
+   installed, stop before inspecting or binding customer data and offer the two
+   paths in [Getting FactorPrism](#getting-factorprism). Continue only after the
+   user chooses a path and any required installation is complete.
 3. **Inspect the source.** Use object search or `DESCRIBE` to verify column names and
    types. Never request row-level sensitive data in chat.
 4. **Bind only when necessary.** If the requested table or view is not already bound,
@@ -45,6 +48,24 @@ Read [references/api.md](references/api.md) before constructing the SQL call.
    can offset, so individual shares may exceed 100%.
 7. **Offer the next useful step.** Suggest another period, metric, scope, or saved run;
    do not automatically create schedules or modify additional objects.
+
+## Getting FactorPrism
+
+If the application is unavailable, explain that this skill needs the FactorPrism
+Snowflake Native App to run the analysis. Offer these choices without implying that
+an install has already happened:
+
+1. **Install and try the built-in demo.** Open the tracked
+   [Cortex Code setup page](https://www.factorprism.com/cortex-code.html?utm_source=snowflake_skills&utm_medium=ecosystem&utm_campaign=cortex_code_skill&utm_content=install),
+   which links to the Snowflake Marketplace and provides the installation prompt.
+   After installation, verify the application again and offer the built-in demo
+   before requesting access to customer data.
+2. **Request a guided evaluation.** Open the tracked
+   [evaluation intake](https://www.factorprism.com/evaluation.html?use_case=cortex-code-skill&utm_source=snowflake_skills&utm_medium=ecosystem&utm_campaign=cortex_code_skill&utm_content=evaluation).
+   No installation or sensitive data is required before that conversation.
+
+Do not install the app, bind a source, or submit an evaluation request without the
+user's explicit choice.
 
 ## Example
 
@@ -61,5 +82,7 @@ locations and how much of the change each explains.
 - Putting a baseline date inside the analysis window.
 - Describing the output as experimental causal inference.
 - Claiming one named cause when the result says movement is broadly distributed.
+- Ending at a missing installation without offering the install/demo and guided
+  evaluation paths above.
 - Installing FactorPrism, binding a new source, or creating a schedule without the
   user's approval.

--- a/skills/factorprism/SKILL.md
+++ b/skills/factorprism/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: factorprism
+title: Explain Metric Changes
+summary: Find and quantify the business locations driving a metric change with FactorPrism inside Snowflake.
+description: "Use when a Snowflake user asks why revenue, margin, cost, churn, units, denials, or another business metric changed; which region, product, payer, segment, or intersection drove it; or wants a reconciled variance explanation. Triggers: why did this metric move, what drove the change, revenue variance, margin variance, root cause, explain this spike, explain this drop. Do not use for forecasting, anomaly detection, marketing multi-touch attribution, price-volume-mix analysis, data outside Snowflake, or when FactorPrism is not installed."
+tools:
+  - snowflake_sql_execute
+  - snowflake_object_search
+  - Read
+prompt: why did weekly revenue drop across region and product?
+language: en
+status: Published
+author: David Rimshnick
+type: community
+---
+
+# FactorPrism
+
+## Overview
+
+Use FactorPrism to answer: **Why did this business metric move, and where did the
+change originate?** FactorPrism runs inside the customer's Snowflake account and
+returns a ranked explanation whose contributions reconcile to the observed change.
+
+Read [references/api.md](references/api.md) before constructing the SQL call.
+
+## Workflow
+
+1. **Confirm the job.** Ask for the metric, date field, analysis window, time grain,
+   source table or view, and business dimensions. Clarify whether dimensions are
+   independent or form a broad-to-narrow hierarchy.
+2. **Confirm availability.** Verify that FactorPrism is installed and identify its
+   application database name. Do not invent an installation name.
+3. **Inspect the source.** Use object search or `DESCRIBE` to verify column names and
+   types. Never request row-level sensitive data in chat.
+4. **Bind only when necessary.** If the requested table or view is not already bound,
+   explain that the binding grants the app persistent, read-only access to that one
+   object, then run the appropriate `SET_SOURCE` call after the user agrees.
+5. **Run the analysis.** Call `API.RUN_DECOMPOSITION` with explicit named parameters.
+   Use `persist => FALSE` for an ad-hoc agent answer unless the user wants the run
+   saved.
+6. **Explain the result.** Lead with the top one or two drivers, their business
+   locations, direction, contribution, and timing. State whether the movement is
+   concentrated or broadly distributed. Mention that positive and negative drivers
+   can offset, so individual shares may exceed 100%.
+7. **Offer the next useful step.** Suggest another period, metric, scope, or saved run;
+   do not automatically create schedules or modify additional objects.
+
+## Example
+
+User: "Why did weekly revenue drop in Q2 across region and product?"
+
+Expected behavior: verify the source and columns, represent region and product as
+independent dimension groups, run one FactorPrism call, then summarize the leading
+locations and how much of the change each explains.
+
+## Common mistakes
+
+- Treating independent dimensions as nested levels.
+- Omitting `metric_field`; pass `NULL` when using row count.
+- Putting a baseline date inside the analysis window.
+- Describing the output as experimental causal inference.
+- Claiming one named cause when the result says movement is broadly distributed.
+- Installing FactorPrism, binding a new source, or creating a schedule without the
+  user's approval.

--- a/skills/factorprism/references/api.md
+++ b/skills/factorprism/references/api.md
@@ -1,0 +1,77 @@
+# FactorPrism SQL reference
+
+## Bind a source
+
+Substitute the actual installed application database name for `FACTORPRISM`.
+
+```sql
+CALL FACTORPRISM.API.SET_SOURCE(
+  'SOURCE_VIEW',
+  SYSTEM$REFERENCE('VIEW', 'MY_DB.MY_SCHEMA.MY_VIEW', 'PERSISTENT', 'SELECT')
+);
+```
+
+Use `SOURCE_TABLE` and `TABLE` for a table. A persistent binding survives upgrades.
+To remove it:
+
+```sql
+CALL FACTORPRISM.API.CLEAR_SOURCE('SOURCE_VIEW');
+```
+
+## Run an analysis
+
+```sql
+CALL FACTORPRISM.API.RUN_DECOMPOSITION(
+  source_ref    => 'SOURCE_VIEW',
+  date_field    => 'ORDER_DATE',
+  metric_field  => 'REVENUE',
+  use_row_count => FALSE,
+  rollup        => 'WEEK',
+  hierarchies   => PARSE_JSON('[["REGION"],["PRODUCT"]]'),
+  period_start  => '2026-04-01',
+  period_end    => '2026-06-30',
+  persist       => FALSE
+);
+```
+
+### Parameters
+
+- `source_ref`: `SOURCE_TABLE` or `SOURCE_VIEW`.
+- `date_field`: date or timestamp column.
+- `metric_field`: numeric column to sum. Pass `NULL` with `use_row_count => TRUE`.
+- `rollup`: `DAY`, `WEEK`, `MONTH`, or `YEAR`.
+- `hierarchies`: JSON array of arrays. Columns inside one array are broad-to-narrow
+  levels. Separate arrays are independent dimensions.
+- `period_start`, `period_end`: inclusive analysis window.
+- `baseline_period`: optional date, comma-separated dates, or JSON array. Every
+  baseline date must be before `period_start`.
+- `persist`: optional; defaults to `TRUE`.
+
+Examples:
+
+- Nested geography: `[["REGION","DIVISION","STATE"]]`
+- Independent dimensions: `[["REGION"],["PRODUCT"],["CHANNEL"]]`
+- Mixed: `[["REGION","STATE"],["CATEGORY","PRODUCT"],["CHANNEL"]]`
+
+## Read the result
+
+Important fields include:
+
+- `RANK`: importance order.
+- `FACTOR`: business location of the driver.
+- `ORIGIN`: broad-based or localized.
+- `PATTERN`: timing and shape.
+- `AVG_MOVEMENT_PER_PERIOD`: average absolute movement.
+- `NET_CONTRIBUTION_PER_PERIOD`: signed units explained per period.
+- `SHARE_OF_NET_CHANGE_PCT`: share of net change; may be `NULL` when offsetting
+  movement makes the net change too small for a useful percentage.
+
+If `SHARE_OF_NET_CHANGE_PCT` is `NULL`, explain that the metric was roughly flat
+while its composition shifted and rank by `AVG_MOVEMENT_PER_PERIOD` instead.
+
+## Safety and interpretation
+
+- The app reads only the bound object.
+- Keep `persist => FALSE` for an ad-hoc agent answer.
+- Results locate and quantify where movement originated; they are not experimental
+  proof that an intervention caused the change.


### PR DESCRIPTION
## What changed

Adds the `factorprism` community skill for Snowflake Cortex Code. The skill teaches
Cortex Code when a changed business metric is a good fit for FactorPrism, how to
verify and bind a Snowflake source, how to call the app's SQL API, and how to explain
the ranked result responsibly.

The package includes:

- A focused 361-word workflow with explicit triggers and non-goals
- A sample prompt for a weekly revenue change
- An on-demand SQL reference covering source binding, parameters, hierarchies, and
  result interpretation
- Apache 2.0 licensing

## Why

Snowflake users commonly ask why revenue, margin, cost, churn, or another KPI moved.
FactorPrism is a Snowflake Native App built for that workflow, but an agent still
needs precise instructions for source permissions, hierarchy structure, API
parameters, and honest interpretation. This skill packages those instructions so the
workflow can be invoked consistently from Cortex Code.

## User impact

Users with FactorPrism installed can invoke `$factorprism` with a natural-language
metric-change question. The skill verifies prerequisites, avoids unsupported use
cases, defaults ad-hoc calls to non-persistent execution, and does not create
schedules or bind new sources without approval.

## Validation

- Snowflake Labs repository validator: passed with zero errors
- Required frontmatter, title length, summary length, tools, prompt, and license:
  validated
- Linked SQL reference and packaged files: verified
- Customer-facing protected-copy scan: passed
