### PR TITLE
Align manage-zerocopy-sapbdc CSN type mapping to Snowflake -> Iceberg -> CSN

### DIFF
--- a/skills/manage-zerocopy-sapbdc/README.md
+++ b/skills/manage-zerocopy-sapbdc/README.md
@@ -208,7 +208,7 @@ The **csn-generator** sub-skill generates minimal [SAP CSN Interop v1.0](https:/
 **Key capabilities:**
 - Generates CSN Interop v1.0 (SDK-compatible) — no options, reviews, or validation loops
 - Core structure only: `definitions`, `kind`, `elements`, primary keys (`key: true`)
-- SDK-matching type mappings (e.g. `INTEGER → cds.Integer`, `TIMESTAMP → cds.DateTime`, unbounded strings → `length: 5000`)
+- Type mappings follow the Snowflake → Iceberg → CSN chain (e.g. `INTEGER → cds.Integer`, `BIGINT → cds.Integer64`, `NUMBER(p,s) → cds.Decimal(p,s)`, `FLOAT → cds.Double`, `TIMESTAMP_*(6) → cds.Timestamp`, strings → `cds.String` with no length); `TIME`, nanosecond timestamps, `BINARY`, `VARIANT`, and complex types are unsupported
 - Foreign-key associations only when PK/FK constraints are available (`@ObjectModel.foreignKey.association`); no heuristic inference
 - `kind: context` namespacing (SAP BDC standard), lowercase entity/namespace names, empty `i18n: {}`
 - Intentionally omits display labels, i18n translations, semantic/PII/analytical annotations, and entity classification

--- a/skills/manage-zerocopy-sapbdc/csn-generator/INSTRUCTIONS.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/INSTRUCTIONS.md
@@ -22,24 +22,26 @@ Use this skill when:
 Snowflake Iceberg (parquet) → SAP Materialization Job (≤10 min) → HDL Files (Delta Table) → CSN Validation
 ```
 
-**Key insight:** SAP validates CSN against the **materialized Delta table**, NOT directly against Iceberg. This is why:
-1. Type mappings must match what the Delta table reports (not Snowflake's nominal types)
+**Key insight:** SAP validates CSN against the **materialized Delta table**, which is created from the Snowflake **Iceberg** column types. This is why:
+1. Type mappings must follow the Snowflake → Iceberg → CSN chain (not Snowflake's nominal types)
 2. Empty tables fail ("Remote object not found") because no Delta table gets created
 3. You must wait ~10 minutes after publishing before deploying on SAP
 
-### Why INTEGER → cds.Decimal (Not cds.Integer)
+### Why INTEGER → cds.Integer
 
-Snowflake stores INTEGER/BIGINT as `decimal(38,0)` in Iceberg metadata. When SAP materializes:
-- Iceberg `decimal(38,0)` → Delta table `DECIMAL(38,0)`
-- CSN `cds.Integer` fails: "inputDataType=INTEGER, actualDataType=DECIMAL"
-- CSN `cds.Decimal(38,0)` matches → ✅ Success
+When a column is declared as an Iceberg `int` (32-bit) it maps to `cds.Integer`; an Iceberg `long` (64-bit) maps to `cds.Integer64`. Snowflake `INTEGER` produces Iceberg `int` and `BIGINT` produces Iceberg `long`. Only fixed-point `NUMBER(p,s)`/`DECIMAL(p,s)` (Iceberg `decimal(p,s)`) maps to `cds.Decimal(p,s)`.
 
-### Why TIME → cds.Timestamp (Not cds.Time)
+### Why FLOAT → cds.Double
 
-Snowflake TIME in Iceberg metadata is `time`. When SAP materializes:
-- Iceberg `time` → Delta table `TIMESTAMP`
-- CSN `cds.Time` fails: "inputDataType=TIME, actualDataType=TIMESTAMP"
-- CSN `cds.Timestamp` matches → ✅ Success
+Snowflake `FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`. Declare them as `cds.Double` in CSN — MSA applies `floatToDoubleWidening` automatically. `REAL`/`DOUBLE PRECISION` are Iceberg `double` (64-bit) and also map to `cds.Double`.
+
+### Why strings have no length
+
+`VARCHAR`/`STRING`/`TEXT` map to Iceberg `string` → `cds.String` with **no length**. Do NOT emit `cds.String(255)` or `length: 5000` — the length must be omitted entirely.
+
+### Unsupported types
+
+`TIME`, high-precision timestamps (`TIMESTAMP_*(9)` → Iceberg `timestamp_ns`), `BINARY`/`BINARY(n)`, `VARIANT`, `OBJECT`, `ARRAY`, `MAP`, `GEOMETRY`, and `GEOGRAPHY` are **not supported**. Exclude or convert these columns before publishing.
 
 ## What This Generates
 
@@ -47,7 +49,7 @@ Snowflake TIME in Iceberg metadata is `time`. When SAP materializes:
 - ✅ Core structure (`definitions`, `kind`, `elements`, `types`)
 - ✅ Primary key designation (`key: true`)
 - ✅ Foreign key associations (if FK constraints available)
-- ✅ Correct type mapping (Snowflake → Iceberg → Delta → CDS types)
+- ✅ Correct type mapping (Snowflake → Iceberg → CDS types)
 - ✅ `@ObjectModel.foreignKey.association` on FK columns (if FKs exist)
 - ✅ `@PersonalData.*` annotations (when PII columns detected)
 - ❌ NO display labels or i18n translations
@@ -55,36 +57,51 @@ Snowflake TIME in Iceberg metadata is `time`. When SAP materializes:
 
 ## SAP BDC Valid CDS Types (Complete List)
 
-From SAP BDC REST API validation:
+Types produced by this mapping:
 ```
-cds.Boolean, cds.Decimal, cds.Double, cds.String, cds.LargeString,
-cds.Date, cds.Timestamp, cds.UUID, cds.Association, cds.Composition
+cds.Boolean, cds.Integer, cds.Integer64, cds.Decimal, cds.Double,
+cds.String (no length), cds.Date, cds.Timestamp, cds.Association
 ```
 
-**⚠️ DO NOT USE (pass publish but fail deployment):**
-- `cds.Integer` / `cds.Integer64` → use `cds.Decimal(p,0)` instead
-- `cds.Time` → use `cds.Timestamp` instead
-- `cds.DateTime` → use `cds.Timestamp` instead
+**⚠️ DO NOT USE:**
+- `cds.String(n)` / `length` on strings → emit `cds.String` with no length
+- `cds.Time` → TIME is not supported (exclude the column)
+- `cds.DateTime` → use `cds.Timestamp` for supported timestamps
+- `cds.Binary` → BINARY is not supported (exclude the column)
 
-## Type Mapping (Final - July 2026)
+## Type Mapping (Snowflake → Iceberg → CSN)
 
-| Snowflake Type | Iceberg Metadata | Delta Table | CDS Type | Status |
-|----------------|------------------|-------------|----------|--------|
-| BOOLEAN | boolean | BOOLEAN | `cds.Boolean` | ✅ Validated |
-| INTEGER | decimal(38,0) | DECIMAL(38,0) | `cds.Decimal(38,0)` | ✅ Validated |
-| BIGINT | decimal(38,0) | DECIMAL(38,0) | `cds.Decimal(38,0)` | ✅ Validated |
-| NUMBER(p,s) | decimal(p,s) | DECIMAL(p,s) | `cds.Decimal(p,s)` | ✅ Validated |
-| DECIMAL(p,s) | decimal(p,s) | DECIMAL(p,s) | `cds.Decimal(p,s)` | ✅ Validated |
-| FLOAT/FLOAT4/FLOAT8 | float | DOUBLE | `cds.Double` | ✅ Validated |
-| REAL/DOUBLE | double | DOUBLE | `cds.Double` | ✅ Validated |
-| VARCHAR/STRING/TEXT | string | NVARCHAR | `cds.String(5000)` | ✅ Validated |
-| DATE | date | DATE | `cds.Date` | ✅ Validated |
-| TIME | time | TIMESTAMP | `cds.Timestamp` | ✅ Validated |
-| TIMESTAMP_NTZ | timestamp | TIMESTAMP | `cds.Timestamp` | ✅ Validated |
-| TIMESTAMP_LTZ | timestamptz | TIMESTAMP | `cds.Timestamp` | ✅ Validated |
-| VARIANT | string | NVARCHAR | `cds.String(5000)` | ✅ Validated |
-| BINARY | binary | ❌ FAILS | N/A | ⛔ Unsupported |
-| VARBINARY | N/A | N/A | N/A | ⛔ Blocked (Snowflake Iceberg doesn't support) |
+| Snowflake Type | Iceberg Type | CSN Type | Notes |
+|----------------|--------------|----------|-------|
+| BOOLEAN | boolean | `cds.Boolean` | |
+| int | int | `cds.Integer` | Only when declared as Iceberg DDL `int` — produces Iceberg `int` (32-bit) |
+| long | long | `cds.Integer64` | Only when declared as Iceberg DDL `long` — produces Iceberg `long` (64-bit) |
+| INTEGER | int | `cds.Integer` | |
+| BIGINT | long | `cds.Integer64` | |
+| NUMBER(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Use matching precision and scale |
+| DECIMAL(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Snowflake alias for `NUMBER(p,s)` |
+| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` — MSA applies `floatToDoubleWidening` automatically |
+| FLOAT4 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
+| FLOAT8 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
+| REAL | double | `cds.Double` | Iceberg type is `double` (64-bit) |
+| DOUBLE PRECISION | double | `cds.Double` | Iceberg type is `double` (64-bit) |
+| VARCHAR | string | `cds.String` | Do **not** include a length (use `cds.String`, not `cds.String(255)`) |
+| STRING | string | `cds.String` | Snowflake synonym for `VARCHAR(134217728)`. Do **not** include a length |
+| TEXT | string | `cds.String` | Snowflake synonym for `VARCHAR(134217728)`. Do **not** include a length |
+| DATE | date | `cds.Date` | |
+| TIMESTAMP_NTZ(6) | timestamp | `cds.Timestamp` | |
+| TIMESTAMP_LTZ(6) | timestamptz | `cds.Timestamp` | |
+| TIMESTAMP_NTZ(9) | timestamp_ns | — | Not supported |
+| TIMESTAMP_LTZ(9) | timestamptz_ns | — | Not supported |
+| TIME(6) | time | — | Not supported |
+| BINARY | binary | — | Not supported |
+| BINARY(n) | fixed(n) | — | Not supported |
+| VARIANT | variant | — | Not supported |
+| OBJECT(...) | struct | — | Not supported in Datasphere |
+| ARRAY(...) | list | — | Not supported in Datasphere |
+| MAP(...) | map | — | Not supported in Datasphere |
+| GEOMETRY | geometry | — | Not supported |
+| GEOGRAPHY | geography | — | Not supported |
 
 ## CSN Structural Requirements
 
@@ -111,7 +128,7 @@ cds.Date, cds.Timestamp, cds.UUID, cds.Association, cds.Composition
 1. Context = SCHEMA name (e.g., `PUBLIC`), NOT database name
 2. Entity names must EXACTLY match table names in the share
 3. At least one `key: true` element per entity
-4. All String columns → `length: 5000`
+4. All String columns → `cds.String` with **no length**
 5. UPPERCASE identifiers matching Snowflake
 
 ## PII Detection (New - July 2026)
@@ -133,26 +150,27 @@ Detect and annotate PII columns:
 ## Type Mapping Function (Python)
 
 ```python
-def map_to_cds_type(source_type: str, precision: int, scale: int) -> dict:
-    """Map database type to CDS type following SAP materialization rules.
-    
-    CRITICAL: Types must match what SAP's Delta table reports, NOT Snowflake's nominal types.
+def map_to_cds_type(source_type: str, precision: int = None, scale: int = None) -> dict:
+    """Map a Snowflake type to a CDS type following the Snowflake -> Iceberg -> CSN chain.
+
+    Raises ValueError for types SAP BDC / Datasphere cannot materialize.
     """
     upper_type = source_type.upper()
-    
-    # String types - ALWAYS use 5000 for remote mode compatibility
+
+    # String types -> cds.String with NO length
     if any(t in upper_type for t in ['VARCHAR', 'STRING', 'TEXT', 'CHAR']):
-        return {"type": "cds.String", "length": 5000}
-    
-    # Integer types - MUST use cds.Decimal (SAP Delta reports DECIMAL)
-    # DO NOT use cds.Integer - it fails at deployment
-    if upper_type in ['INTEGER', 'INT', 'SMALLINT', 'TINYINT']:
-        return {"type": "cds.Decimal", "precision": 38, "scale": 0}
+        return {"type": "cds.String"}  # no length
+
+    # 32-bit integer (Iceberg int)
+    if upper_type in ['INTEGER', 'INT', 'SMALLINT', 'TINYINT', 'BYTEINT']:
+        return {"type": "cds.Integer"}
+
+    # 64-bit integer (Iceberg long)
     if upper_type == 'BIGINT':
-        return {"type": "cds.Decimal", "precision": 38, "scale": 0}
-    
-    # Decimal/Number types - use exact precision from INFORMATION_SCHEMA
-    if upper_type in ['DECIMAL', 'NUMERIC', 'NUMBER']:
+        return {"type": "cds.Integer64"}
+
+    # Fixed-point NUMBER/DECIMAL -> cds.Decimal(p,s) with exact precision/scale
+    if upper_type in ['NUMBER', 'DECIMAL', 'NUMERIC']:
         effective_precision = precision if precision is not None else 38
         effective_scale = scale if scale is not None else 0
         return {
@@ -160,38 +178,47 @@ def map_to_cds_type(source_type: str, precision: int, scale: int) -> dict:
             "precision": effective_precision,
             "scale": effective_scale
         }
-    
-    # Float types
-    if upper_type in ['FLOAT', 'FLOAT4', 'FLOAT8', 'REAL', 'DOUBLE']:
+
+    # Floating point -> cds.Double (MSA widens float -> double automatically)
+    if upper_type in ['FLOAT', 'FLOAT4', 'FLOAT8', 'REAL', 'DOUBLE', 'DOUBLE PRECISION']:
         return {"type": "cds.Double"}
-    
+
     # Boolean
     if upper_type in ['BOOLEAN', 'BOOL']:
         return {"type": "cds.Boolean"}
-    
+
     # Date
     if upper_type == 'DATE':
         return {"type": "cds.Date"}
-    
-    # Time and Timestamp - ALL map to cds.Timestamp
-    # DO NOT use cds.Time or cds.DateTime - they fail at deployment
-    if upper_type == 'TIME':
-        return {"type": "cds.Timestamp"}  # NOT cds.Time
+
+    # Timestamp at microsecond precision -> cds.Timestamp.
+    # Nanosecond precision (TIMESTAMP_*(9) -> Iceberg timestamp_ns) is NOT supported.
     if upper_type in ['TIMESTAMP', 'TIMESTAMP_NTZ', 'TIMESTAMP_LTZ', 'DATETIME']:
-        return {"type": "cds.Timestamp"}  # NOT cds.DateTime
-    
-    # VARIANT (JSON) - map to String, NOT LargeString
-    # LargeString causes NCLOB vs NVARCHAR mismatch
-    if upper_type == 'VARIANT':
-        return {"type": "cds.String", "length": 5000}
-    
-    # Binary - UNSUPPORTED by SAP materialization
-    # VARBINARY is blocked at Snowflake Iceberg level entirely
-    if upper_type in ['BINARY', 'VARBINARY', 'BYTES']:
-        raise ValueError(f"BINARY type not supported - VARBINARY blocked by Snowflake Iceberg, BINARY blocked by SAP materialization")
-    
-    # Default fallback
-    return {"type": "cds.String", "length": 5000}
+        if precision is not None and precision > 6:
+            raise ValueError(
+                f"{source_type}({precision}) not supported - nanosecond timestamps "
+                "map to Iceberg timestamp_ns, which SAP BDC cannot materialize. "
+                "Reduce to microsecond precision, e.g. TIMESTAMP_NTZ(6)."
+            )
+        return {"type": "cds.Timestamp"}
+
+    # Unsupported types -> reject with a clear message
+    unsupported = {
+        'TIMESTAMP_TZ': 'TIMESTAMP_TZ is not supported',
+        'TIME': 'TIME (Iceberg time) is not supported',
+        'BINARY': 'BINARY/VARBINARY (Iceberg binary/fixed) is not supported',
+        'VARIANT': 'VARIANT is not supported',
+        'OBJECT': 'OBJECT (struct) is not supported in Datasphere',
+        'ARRAY': 'ARRAY (list) is not supported in Datasphere',
+        'MAP': 'MAP is not supported in Datasphere',
+        'GEOMETRY': 'GEOMETRY is not supported',
+        'GEOGRAPHY': 'GEOGRAPHY is not supported',
+    }
+    for key, msg in unsupported.items():
+        if key in upper_type:
+            raise ValueError(f"{source_type} not supported: {msg}. Exclude or convert this column.")
+
+    raise ValueError(f"Unknown type '{source_type}' - no CSN mapping available")
 ```
 
 ## Pre-Publish Checklist
@@ -200,12 +227,13 @@ Before calling `SYSTEM$SAP_PUBLISH_DATA_PRODUCT`:
 
 - [ ] **Tables have ≥1 row of data** (parquet files must exist for materialization)
 - [ ] CSN entity names match `DESCRIBE SHARE` table names exactly
-- [ ] All INTEGER/BIGINT columns use `cds.Decimal(38,0)` (NOT cds.Integer)
-- [ ] All TIME/TIMESTAMP columns use `cds.Timestamp` (NOT cds.Time/cds.DateTime)
-- [ ] DECIMAL columns use exact precision from `INFORMATION_SCHEMA.COLUMNS`
-- [ ] **No BINARY columns** (unsupported by SAP materialization)
+- [ ] INTEGER columns use `cds.Integer`; BIGINT columns use `cds.Integer64`
+- [ ] NUMBER/DECIMAL columns use `cds.Decimal` with exact precision/scale from `INFORMATION_SCHEMA.COLUMNS`
+- [ ] FLOAT/FLOAT4/FLOAT8/REAL/DOUBLE columns use `cds.Double`
+- [ ] Supported TIMESTAMP columns (microsecond precision) use `cds.Timestamp`
+- [ ] **No TIME, nanosecond timestamps, BINARY, VARIANT, OBJECT, ARRAY, MAP, GEOMETRY, or GEOGRAPHY columns** (unsupported)
 - [ ] Context is SCHEMA name (e.g., `PUBLIC`), not database name
-- [ ] All String columns have `length: 5000`
+- [ ] All String columns use `cds.String` with **no length**
 
 After publishing:
 
@@ -245,11 +273,13 @@ ORDER BY TABLE_NAME, ORDINAL_POSITION;
 ### Step 3: Generate CSN
 
 Use the type mapping function above. Key points:
-- INTEGER → `cds.Decimal(38,0)`
-- BIGINT → `cds.Decimal(38,0)`
-- TIME → `cds.Timestamp`
-- TIMESTAMP_NTZ/LTZ → `cds.Timestamp`
-- Reject BINARY columns with error
+- INTEGER → `cds.Integer`
+- BIGINT → `cds.Integer64`
+- NUMBER(p,s)/DECIMAL(p,s) → `cds.Decimal(p,s)` (exact precision/scale)
+- FLOAT/FLOAT4/FLOAT8/REAL/DOUBLE → `cds.Double`
+- VARCHAR/STRING/TEXT → `cds.String` (no length)
+- TIMESTAMP_NTZ(6)/LTZ(6) → `cds.Timestamp`
+- Reject TIME, nanosecond timestamps, BINARY, VARIANT, OBJECT, ARRAY, MAP, GEOMETRY, GEOGRAPHY columns with an error
 
 ### Step 4: Verify Entity Names Match Share
 
@@ -285,20 +315,16 @@ Publishing complete.
       "elements": {
         "CUSTOMER_ID": {
           "type": "cds.String",
-          "length": 5000,
           "key": true,
           "notNull": true,
           "@PersonalData.fieldSemantics": {"#": "DataSubjectIDType"}
         },
         "EMAIL": {
           "type": "cds.String",
-          "length": 5000,
           "@PersonalData.isPotentiallyPersonal": true
         },
         "ORDER_COUNT": {
-          "type": "cds.Decimal",
-          "precision": 38,
-          "scale": 0
+          "type": "cds.Integer"
         },
         "TOTAL_AMOUNT": {
           "type": "cds.Decimal",
@@ -324,25 +350,25 @@ Publishing complete.
 3. **Context is DATABASE name** → Use SCHEMA name (e.g., `PUBLIC`)
 4. **Entity name mismatch** → Run `DESCRIBE SHARE` and verify names match
 
-### Error: "inputDataType=INTEGER, actualDataType=DECIMAL"
+### Error: type mismatch on an integer column
 
-**Cause:** Using `cds.Integer` for INTEGER columns  
-**Fix:** Use `cds.Decimal(38,0)` for all INTEGER/BIGINT columns
+**Cause:** Emitting `cds.Decimal` (or a length) where the Iceberg type is `int`/`long`  
+**Fix:** Use `cds.Integer` for INTEGER and `cds.Integer64` for BIGINT; reserve `cds.Decimal(p,s)` for NUMBER/DECIMAL columns only
 
-### Error: "inputDataType=TIME, actualDataType=TIMESTAMP"
+### Error: type mismatch on a string column
 
-**Cause:** Using `cds.Time` for TIME columns  
-**Fix:** Use `cds.Timestamp` for TIME columns
+**Cause:** Emitting a `length` on `cds.String` (e.g. `cds.String(5000)`)  
+**Fix:** Emit `cds.String` with **no length** for VARCHAR/STRING/TEXT columns
 
 ### Error: "MISMATCH IN DATA TYPE PRECISION"
 
 **Cause:** Using assumed precision (38) instead of actual  
-**Fix:** Query `INFORMATION_SCHEMA.COLUMNS` for exact `NUMERIC_PRECISION`
+**Fix:** Query `INFORMATION_SCHEMA.COLUMNS` for exact `NUMERIC_PRECISION`/`NUMERIC_SCALE`
 
-### Error: Materialization fails for BINARY column
+### Error: materialization fails for TIME / BINARY / VARIANT / nanosecond timestamp
 
-**Cause:** SAP cannot materialize Iceberg binary data to Delta format  
-**Fix:** Exclude BINARY/VARBINARY columns from the data product
+**Cause:** These Iceberg types (`time`, `binary`/`fixed`, `variant`, `timestamp_ns`) cannot be materialized by SAP  
+**Fix:** Exclude the column, or convert it (e.g. cast to a supported type, reduce timestamp precision to `(6)`)
 
 ## Annotations Included
 

--- a/skills/manage-zerocopy-sapbdc/csn-generator/README.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/README.md
@@ -29,17 +29,14 @@ This skill generates CSN **exactly matching the SDK format** to maximize accepta
       "elements": {
         "customer_id": {
           "type": "cds.String",
-          "length": 36,
           "key": true,
           "notNull": true
         },
         "customer_name": {
-          "type": "cds.String",
-          "length": 5000
+          "type": "cds.String"
         },
         "email": {
-          "type": "cds.String",
-          "length": 5000
+          "type": "cds.String"
         },
         "created_date": {
           "type": "cds.Date"
@@ -63,7 +60,7 @@ This skill generates CSN **exactly matching the SDK format** to maximize accepta
 ### What's Included
 - ✅ Core CSN structure (definitions, kind, elements)
 - ✅ Primary key designation (`key: true`)
-- ✅ Type mappings (Snowflake/Postgres/BigQuery → CDS)
+- ✅ Type mappings following the Snowflake → Iceberg → CSN chain
 - ✅ Foreign key associations (if constraints available)
 - ✅ One annotation: `@ObjectModel.foreignKey.association` (FK only)
 
@@ -90,9 +87,9 @@ This skill produces CSN **matching the SDK format** but with these awareness poi
 5. Lowercase namespace and entity names
 6. Association names: lowercase without underscore prefix
 7. Cardinality: always `{"min": 0, "max": 1}`
-8. String lengths: hardcoded `5000` for unbounded
-9. Type mapping: `INTEGER → cds.Integer`, `TIMESTAMP → cds.DateTime`
-10. Float rejection: warns to use DOUBLE
+8. Strings: `cds.String` with **no length**
+9. Type mapping follows Snowflake → Iceberg → CSN (`INTEGER → cds.Integer`, `BIGINT → cds.Integer64`, `TIMESTAMP_*(6) → cds.Timestamp`)
+10. Float widening: `FLOAT`/`FLOAT4`/`FLOAT8` → `cds.Double`
 
 ### ⚠️ Differences
 - SDK is specific to Databricks shares
@@ -157,26 +154,28 @@ CALL SYSTEM$SAP_PUBLISH_DATA_PRODUCT(
 
 ## Type Mapping Reference
 
-| Source Type | CDS Type | Notes |
-|-------------|----------|-------|
-| VARCHAR(n) ≤ 5000 | `cds.String`, `length: n` | Exact length |
-| VARCHAR(n) > 5000 | `cds.String`, `length: 5000` | Hardcoded max |
-| STRING (unbounded) | `cds.String`, `length: 5000` | Hardcoded |
-| INTEGER | `cds.Integer` | **NOT** `cds.Decimal` |
-| BIGINT | `cds.Integer64` | |
-| DECIMAL(p,s) | `cds.Decimal`, `precision: p`, `scale: s` | |
-| FLOAT | **REJECTED** | Use DOUBLE |
-| DOUBLE | `cds.Double` | |
-| BOOLEAN | `cds.Boolean` | |
-| DATE | `cds.Date` | |
-| TIMESTAMP | `cds.DateTime` | **NOT** `cds.Timestamp` |
-| TIME | `cds.Time` | |
-| BINARY | `cds.Binary` | |
+| Snowflake Type | Iceberg Type | CDS Type | Notes |
+|----------------|--------------|----------|-------|
+| BOOLEAN | boolean | `cds.Boolean` | |
+| INTEGER | int | `cds.Integer` | 32-bit |
+| BIGINT | long | `cds.Integer64` | 64-bit |
+| NUMBER(p,s) / DECIMAL(p,s) | decimal(p,s) | `cds.Decimal`, `precision: p`, `scale: s` | Exact precision/scale |
+| FLOAT / FLOAT4 / FLOAT8 | float | `cds.Double` | MSA applies `floatToDoubleWidening` |
+| REAL / DOUBLE PRECISION | double | `cds.Double` | |
+| VARCHAR / STRING / TEXT | string | `cds.String` | **No length** |
+| DATE | date | `cds.Date` | |
+| TIMESTAMP_NTZ(6) / TIMESTAMP_LTZ(6) | timestamp / timestamptz | `cds.Timestamp` | Microsecond precision only |
+| TIME | time | — | Not supported |
+| TIMESTAMP_*(9) | timestamp_ns | — | Not supported |
+| BINARY / BINARY(n) | binary / fixed(n) | — | Not supported |
+| VARIANT / OBJECT / ARRAY / MAP | variant / struct / list / map | — | Not supported |
+| GEOMETRY / GEOGRAPHY | geometry / geography | — | Not supported |
 
 **Critical Differences:**
-- ✅ INTEGER → `cds.Integer` (NOT `cds.Decimal(38,0)`)
-- ✅ TIMESTAMP → `cds.DateTime` (NOT `cds.Timestamp`)
-- ✅ Unbounded strings → `length: 5000` (hardcoded)
+- ✅ INTEGER → `cds.Integer`; BIGINT → `cds.Integer64` (only `NUMBER`/`DECIMAL` → `cds.Decimal`)
+- ✅ TIMESTAMP_*(6) → `cds.Timestamp` (no `cds.DateTime`/`cds.Time`)
+- ✅ Strings → `cds.String` with **no length**
+- ✅ `FLOAT`/`FLOAT4`/`FLOAT8` → `cds.Double`; `TIME`, nanosecond timestamps, `BINARY`, `VARIANT`, and complex types are rejected
 
 ## Association Example
 
@@ -186,7 +185,6 @@ CALL SYSTEM$SAP_PUBLISH_DATA_PRODUCT(
   "elements": {
     "customer_id": {
       "type": "cds.String",
-      "length": 36,
       "@ObjectModel.foreignKey.association": "customer"
     },
     "customer": {
@@ -228,13 +226,13 @@ CALL SYSTEM$SAP_PUBLISH_DATA_PRODUCT(
 ## Troubleshooting
 
 ### "INTEGER type not recognized"
-**Solution:** Ensure mapping uses `cds.Integer`, not `cds.Decimal(38,0)`
+**Solution:** Use `cds.Integer` for INTEGER and `cds.Integer64` for BIGINT; reserve `cds.Decimal(p,s)` for NUMBER/DECIMAL
 
 ### "TIMESTAMP type not recognized"
-**Solution:** Use `cds.DateTime`, not `cds.Timestamp`
+**Solution:** Use `cds.Timestamp` for microsecond timestamps; exclude TIME and nanosecond (`(9)`) timestamps
 
-### "String length exceeds maximum"
-**Solution:** Cap all strings > 5000 to exactly 5000
+### "String type mismatch"
+**Solution:** Emit `cds.String` with **no length** (never `cds.String(n)`)
 
 ### "Association target not found"
 **Solution:** Use lowercase target name without underscore prefix
@@ -250,11 +248,12 @@ These are **intentional** to match SDK:
 2. ❌ No semantic annotations → users enrich in SAP UI after import
 3. ❌ No PII detection → no privacy annotations
 4. ❌ No entity classification → SAP can't distinguish FACT/DIMENSION
-5. ❌ Hardcoded string lengths → all unbounded → 5000
+5. ❌ Strings carry no length → SAP infers from the materialized column
 6. ❌ Simple associations → always optional
 7. ❌ CSN 1.0 limitations → missing features from 1.2
 8. ❌ No heuristic inference → if FK unavailable, no associations
 9. ❌ Lowercase naming → SDK convention
+10. ❌ Unsupported types excluded → TIME, nanosecond timestamps, BINARY, VARIANT, and complex types
 
 ## Files in This Skill
 
@@ -276,9 +275,10 @@ skill/
 ### Test 2: Edge Cases
 Test with:
 - Tables without FK constraints (Iceberg tables)
-- VARCHAR(16777216) columns
-- INTEGER columns (verify `cds.Integer` acceptance)
-- TIMESTAMP columns (verify `cds.DateTime` acceptance)
+- VARCHAR(16777216) columns (verify `cds.String` with no length)
+- INTEGER columns (verify `cds.Integer`) and BIGINT columns (verify `cds.Integer64`)
+- TIMESTAMP_NTZ(6) columns (verify `cds.Timestamp` acceptance)
+- Unsupported columns (TIME, TIMESTAMP_*(9), BINARY, VARIANT) are excluded/rejected
 
 ### Test 3: Compare with SDK
 If you have access to Databricks SDK:

--- a/skills/manage-zerocopy-sapbdc/csn-generator/references/type-mapping-sdk.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/references/type-mapping-sdk.md
@@ -1,461 +1,250 @@
-# Type Mapping Reference - SDK Rules
+# Type Mapping Reference — Snowflake → Iceberg → CSN
 
-Complete Snowflake → CDS type mapping following the SAP BDC Connect SDK behavior.
+Complete Snowflake → CSN (CDS) type mapping for the SAP BDC zero-copy publish path.
 
 ## Overview
 
-The SDK's type mapping is **intentionally simplistic** to maximize compatibility with SAP BDC. It prioritizes:
-1. **Predictability** over sophistication
-2. **Compatibility** over precision
-3. **Simplicity** over optimization
+Publishing goes through the chain **Snowflake → Iceberg → CSN**. SAP materializes the Snowflake Iceberg column types into a Delta table and validates the CSN against them, so the CSN type must match the **Iceberg** type, not Snowflake's nominal type.
 
-This document captures those rules exactly.
+Guiding rules:
+1. Integer widths follow the Iceberg type: `int` → `cds.Integer`, `long` → `cds.Integer64`
+2. Fixed-point `NUMBER`/`DECIMAL` → `cds.Decimal(p,s)` with exact precision and scale
+3. All floating point → `cds.Double` (MSA widens `float` → `double` automatically)
+4. Strings → `cds.String` with **no length**
+5. Only microsecond timestamps are supported → `cds.Timestamp`
+6. Everything else in the "Not supported" list must be excluded or converted
 
-## String Types
+## Full Mapping
 
-| Snowflake Type | Max Length | CDS Type | Length | Notes |
-|----------------|------------|----------|--------|-------|
-| VARCHAR(n) | n ≤ 5000 | `cds.String` | n | Exact length preserved |
-| VARCHAR(n) | n > 5000 | `cds.String` | 5000 | **Hardcoded** max |
-| STRING (unbounded) | N/A | `cds.String` | 5000 | **Hardcoded** |
-| TEXT | N/A | `cds.String` | 5000 | **Hardcoded** |
-| CHAR(n) | any | `cds.String` | n | Fixed-width → variable |
-
-**Critical Rule:** All unbounded or oversized strings → **exactly 5000**, not `LargeString`
-
-### Python Implementation
-```python
-def map_string_type(length: Optional[int]) -> dict:
-    """Map string types following SDK rules."""
-    if length is None or length > 5000:
-        return {"type": "cds.String", "length": 5000}  # Hardcoded
-    return {"type": "cds.String", "length": length}
-```
-
-### Examples
-```json
-// VARCHAR(100)
-{"type": "cds.String", "length": 100}
-
-// VARCHAR(16777216) - Snowflake max
-{"type": "cds.String", "length": 5000}  // Capped
-
-// STRING (unbounded)
-{"type": "cds.String", "length": 5000}  // Hardcoded
-```
+| Snowflake Type | Iceberg Type | CSN Type | Notes |
+|----------------|--------------|----------|-------|
+| BOOLEAN | boolean | `cds.Boolean` | |
+| int | int | `cds.Integer` | Only when declared as Iceberg DDL `int` — produces Iceberg `int` (32-bit) |
+| long | long | `cds.Integer64` | Only when declared as Iceberg DDL `long` — produces Iceberg `long` (64-bit) |
+| INTEGER | int | `cds.Integer` | |
+| BIGINT | long | `cds.Integer64` | |
+| NUMBER(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Use matching precision and scale |
+| DECIMAL(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Snowflake alias for `NUMBER(p,s)` |
+| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` — MSA applies `floatToDoubleWidening` automatically |
+| FLOAT4 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
+| FLOAT8 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
+| REAL | double | `cds.Double` | Iceberg type is `double` (64-bit) |
+| DOUBLE PRECISION | double | `cds.Double` | Iceberg type is `double` (64-bit) |
+| VARCHAR | string | `cds.String` | Do **not** include a length (use `cds.String`, not `cds.String(255)`) |
+| STRING | string | `cds.String` | Snowflake synonym for `VARCHAR(134217728)`. Do **not** include a length |
+| TEXT | string | `cds.String` | Snowflake synonym for `VARCHAR(134217728)`. Do **not** include a length |
+| DATE | date | `cds.Date` | |
+| TIMESTAMP_NTZ(6) | timestamp | `cds.Timestamp` | |
+| TIMESTAMP_LTZ(6) | timestamptz | `cds.Timestamp` | |
+| TIMESTAMP_NTZ(9) | timestamp_ns | — | Not supported |
+| TIMESTAMP_LTZ(9) | timestamptz_ns | — | Not supported |
+| TIME(6) | time | — | Not supported |
+| BINARY | binary | — | Not supported |
+| BINARY(n) | fixed(n) | — | Not supported |
+| VARIANT | variant | — | Not supported |
+| OBJECT(...) | struct | — | Not supported in Datasphere |
+| ARRAY(...) | list | — | Not supported in Datasphere |
+| MAP(...) | map | — | Not supported in Datasphere |
+| GEOMETRY | geometry | — | Not supported |
+| GEOGRAPHY | geography | — | Not supported |
 
 ## Integer Types
 
-| Snowflake Type | CDS Type | Notes |
-|----------------|----------|-------|
-| INTEGER | `cds.Integer` | **NOT** `cds.Decimal(38,0)` |
-| SMALLINT | `cds.Integer` | Promoted to 32-bit |
-| TINYINT | `cds.Integer` | Promoted to 32-bit |
-| BIGINT | `cds.Integer64` | 64-bit integer |
-| NUMBER (scale=0) | `cds.Integer64` | Snowflake internal representation |
+`INTEGER`/`INT`/`SMALLINT`/`TINYINT`/`BYTEINT` produce Iceberg `int` → `cds.Integer` (32-bit). `BIGINT` produces Iceberg `long` → `cds.Integer64` (64-bit). Emit no precision/scale on these.
 
-**Critical Rule:** Do **NOT** map INTEGER to `cds.Decimal(38,0)` even though Snowflake stores all integers as NUMBER internally.
-
-### Why This Matters
-
-**Wrong (full CSN approach):**
 ```json
-// Snowflake INTEGER column
-{
-  "order_count": {
-    "type": "cds.Decimal",
-    "precision": 38,
-    "scale": 0
-  }
-}
+// INTEGER
+{"type": "cds.Integer"}
+
+// BIGINT
+{"type": "cds.Integer64"}
 ```
 
-**Right (SDK approach):**
-```json
-{
-  "order_count": {
-    "type": "cds.Integer"
-  }
-}
-```
-
-SAP BDC expects semantic INTEGER type, not "decimal that happens to have scale=0".
-
-### Python Implementation
-```python
-def map_integer_type(data_type: str) -> dict:
-    """Map integer types following SDK rules."""
-    upper = data_type.upper()
-    
-    if upper in ['INTEGER', 'INT', 'SMALLINT', 'TINYINT']:
-        return {"type": "cds.Integer"}  # No precision/scale
-    
-    if upper in ['BIGINT', 'NUMBER']:  # NUMBER without scale
-        return {"type": "cds.Integer64"}
-    
-    raise ValueError(f"Not an integer type: {data_type}")
-```
+Do **not** map integers to `cds.Decimal` — that is only for `NUMBER`/`DECIMAL` columns.
 
 ## Decimal Types
 
-| Snowflake Type | CDS Type | Precision | Scale | Notes |
-|----------------|----------|-----------|-------|-------|
-| DECIMAL(p,s) | `cds.Decimal` | p | s | Exact mapping |
-| NUMERIC(p,s) | `cds.Decimal` | p | s | Synonym |
-| NUMBER(p,s) | `cds.Decimal` | p | s | Snowflake type |
-| NUMBER (no args) | `cds.Decimal` | 38 | 0 | Default precision |
+`NUMBER(p,s)`/`DECIMAL(p,s)`/`NUMERIC(p,s)` → `cds.Decimal` with the exact precision and scale from `INFORMATION_SCHEMA.COLUMNS`.
 
-### Python Implementation
-```python
-def map_decimal_type(precision: Optional[int], scale: Optional[int]) -> dict:
-    """Map decimal types following SDK rules.
-    
-    CRITICAL: Use 'is not None' checks, NOT 'or' operator.
-    The 'or' operator treats 0 as falsy, breaking DECIMAL(38,0) columns.
-    """
-    effective_precision = precision if precision is not None else 38  # Snowflake max
-    effective_scale = scale if scale is not None else 0
-    return {
-        "type": "cds.Decimal",
-        "precision": effective_precision,
-        "scale": effective_scale
-    }
-```
-
-### Examples
 ```json
-// DECIMAL(15,2) - currency
+// DECIMAL(15,2) — currency
 {"type": "cds.Decimal", "precision": 15, "scale": 2}
 
-// DECIMAL(13,3) - quantity
-{"type": "cds.Decimal", "precision": 13, "scale": 3}
-
-// NUMBER - unbounded
+// NUMBER(38,0)
 {"type": "cds.Decimal", "precision": 38, "scale": 0}
+```
+
+```python
+def map_decimal_type(precision, scale) -> dict:
+    """Use 'is not None' checks, NOT 'or' — 0 is a valid scale and is falsy."""
+    return {
+        "type": "cds.Decimal",
+        "precision": precision if precision is not None else 38,
+        "scale": scale if scale is not None else 0,
+    }
 ```
 
 ## Floating Point Types
 
-| Snowflake Type | CDS Type | Notes |
-|----------------|----------|-------|
-| FLOAT | **REJECTED** | Warn user to use DOUBLE |
-| DOUBLE | `cds.Double` | 64-bit floating point |
-| REAL | `cds.Double` | Synonym |
+`FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`; `REAL`/`DOUBLE PRECISION` are 64-bit Iceberg `double`. All map to `cds.Double` — MSA applies `floatToDoubleWidening` automatically.
 
-**Critical Rule:** **Reject FLOAT types** with a warning message.
-
-### Why Reject FLOAT?
-
-The SDK does not support FLOAT (32-bit) types. Reasons:
-1. Precision loss issues in data transfer
-2. SAP systems typically use DOUBLE for floating point
-3. Snowflake FLOAT is non-standard (variable precision)
-
-### Python Implementation
-```python
-def map_float_type(data_type: str) -> dict:
-    """Map float types following SDK rules."""
-    upper = data_type.upper()
-    
-    if upper == 'FLOAT':
-        raise ValueError(
-            "FLOAT type not supported by SAP BDC. "
-            "Use DOUBLE instead: ALTER TABLE ... MODIFY COLUMN ... DOUBLE"
-        )
-    
-    if upper in ['DOUBLE', 'REAL']:
-        return {"type": "cds.Double"}
-    
-    raise ValueError(f"Unknown float type: {data_type}")
+```json
+{"type": "cds.Double"}
 ```
 
-## Boolean Types
+## String Types
 
-| Snowflake Type | CDS Type | Notes |
-|----------------|----------|-------|
-| BOOLEAN | `cds.Boolean` | Direct mapping |
-| BOOL | `cds.Boolean` | Synonym |
+`VARCHAR`/`STRING`/`TEXT`/`CHAR` → `cds.String` with **no length**. `STRING` and `TEXT` are Snowflake synonyms for `VARCHAR(134217728)`.
 
-### Python Implementation
-```python
-def map_boolean_type() -> dict:
-    """Map boolean types."""
-    return {"type": "cds.Boolean"}
+```json
+// VARCHAR, VARCHAR(255), STRING, TEXT — all the same
+{"type": "cds.String"}
 ```
 
-## Date/Time Types
-
-| Snowflake Type | CDS Type | Notes |
-|----------------|----------|-------|
-| DATE | `cds.Date` | Date only (no time) |
-| TIME | `cds.Time` | Time only (no date) |
-| TIMESTAMP | `cds.DateTime` | **NOT** `cds.Timestamp` |
-| TIMESTAMP_NTZ | `cds.DateTime` | No timezone |
-| TIMESTAMP_LTZ | `cds.DateTime` | Local timezone |
-| TIMESTAMP_TZ | `cds.DateTime` | With timezone |
-| DATETIME | `cds.DateTime` | Synonym |
-
-**Critical Rule:** Map TIMESTAMP → `cds.DateTime`, **NOT** `cds.Timestamp`
-
-### Why DateTime, Not Timestamp?
-
-The SDK uses `cds.DateTime` for timestamp columns because:
-1. SAP systems use DATETIME semantics (not UNIX epoch)
-2. `cds.Timestamp` is reserved for audit fields (created_at, updated_at)
-3. `cds.DateTime` better matches Snowflake TIMESTAMP semantics
-
-### Python Implementation
 ```python
-def map_datetime_type(data_type: str) -> dict:
-    """Map date/time types following SDK rules."""
-    upper = data_type.upper()
-    
-    if upper == 'DATE':
-        return {"type": "cds.Date"}
-    
-    if upper == 'TIME':
-        return {"type": "cds.Time"}
-    
-    if 'TIMESTAMP' in upper or upper == 'DATETIME':
-        return {"type": "cds.DateTime"}  # NOT cds.Timestamp
-    
-    raise ValueError(f"Unknown date/time type: {data_type}")
+def map_string_type() -> dict:
+    return {"type": "cds.String"}  # never emit a length
 ```
 
-### Examples
+## Boolean Type
+
+```json
+{"type": "cds.Boolean"}
+```
+
+## Date / Time Types
+
+- `DATE` → `cds.Date`
+- `TIMESTAMP_NTZ(6)` / `TIMESTAMP_LTZ(6)` (Iceberg `timestamp` / `timestamptz`) → `cds.Timestamp`
+- `TIMESTAMP_NTZ(9)` / `TIMESTAMP_LTZ(9)` (Iceberg `timestamp_ns` / `timestamptz_ns`) → **not supported**
+- `TIME` (Iceberg `time`) → **not supported**
+
 ```json
 // DATE
 {"type": "cds.Date"}
 
-// TIMESTAMP_NTZ
-{"type": "cds.DateTime"}  // NOT cds.Timestamp
-
-// TIME
-{"type": "cds.Time"}
+// TIMESTAMP_NTZ(6)
+{"type": "cds.Timestamp"}
 ```
 
-## Binary Types
+Reduce nanosecond timestamps to microsecond precision (`(6)`) before publishing; exclude `TIME` columns.
 
-| Snowflake Type | CDS Type | Length | Notes |
-|----------------|----------|--------|-------|
-| BINARY(n) | `cds.Binary` | n | Fixed-width |
-| VARBINARY(n) | `cds.Binary` | n | Variable-width |
-| BINARY (unbounded) | `cds.Binary` | 5000 | Hardcoded max |
+## Not Supported
 
-### Python Implementation
-```python
-def map_binary_type(length: Optional[int]) -> dict:
-    """Map binary types following SDK rules."""
-    if length is None or length > 5000:
-        return {"type": "cds.Binary", "length": 5000}  # Hardcoded
-    return {"type": "cds.Binary", "length": length}
-```
+These Iceberg types cannot be materialized by SAP BDC / consumed in Datasphere. Exclude or convert the column:
 
-## Complex Types (Not Supported)
-
-| Snowflake Type | CDS Type | Notes |
-|----------------|----------|-------|
-| VARIANT | **NOT SUPPORTED** | Use STRING(5000) |
-| OBJECT | **NOT SUPPORTED** | Flatten to columns |
-| ARRAY | **NOT SUPPORTED** | Use separate table |
-| GEOGRAPHY | **NOT SUPPORTED** | Use STRING |
-| GEOMETRY | **NOT SUPPORTED** | Use STRING |
-
-**Rule:** Warn user that complex types must be flattened or converted.
-
-### Python Implementation
-```python
-def map_complex_type(data_type: str) -> dict:
-    """Handle complex types (unsupported)."""
-    upper = data_type.upper()
-    
-    if upper in ['VARIANT', 'GEOGRAPHY', 'GEOMETRY']:
-        warnings.warn(
-            f"{upper} type not supported by SAP BDC. "
-            f"Mapping to cds.String(5000) - consider flattening."
-        )
-        return {"type": "cds.String", "length": 5000}
-    
-    if upper in ['OBJECT', 'ARRAY']:
-        raise ValueError(
-            f"{upper} type not supported by SAP BDC. "
-            "Flatten nested structures before generating CSN."
-        )
-    
-    raise ValueError(f"Unknown complex type: {data_type}")
-```
+| Snowflake Type | Iceberg Type | Reason |
+|----------------|--------------|--------|
+| TIME(6) | time | Not materializable |
+| TIMESTAMP_*(9) | timestamp_ns / timestamptz_ns | Nanosecond precision not supported |
+| BINARY / BINARY(n) | binary / fixed(n) | Not materializable |
+| VARIANT | variant | Semi-structured not supported |
+| OBJECT(...) | struct | Not supported in Datasphere |
+| ARRAY(...) | list | Not supported in Datasphere |
+| MAP(...) | map | Not supported in Datasphere |
+| GEOMETRY | geometry | Not supported |
+| GEOGRAPHY | geography | Not supported |
 
 ## Complete Type Mapping Function
 
 ```python
 from typing import Optional, Dict, Any
-import warnings
+
 
 def map_snowflake_to_cds(
     data_type: str,
-    length: Optional[int] = None,
+    length: Optional[int] = None,      # accepted but unused: strings carry no length
     precision: Optional[int] = None,
-    scale: Optional[int] = None
+    scale: Optional[int] = None,
 ) -> Dict[str, Any]:
+    """Map a Snowflake type to a CSN (CDS) type following Snowflake -> Iceberg -> CSN.
+
+    Raises ValueError for unsupported types.
     """
-    Map Snowflake type to CDS type following SDK rules.
-    
-    Args:
-        data_type: Snowflake type name (e.g., 'VARCHAR', 'INTEGER')
-        length: For string/binary types
-        precision: For decimal types
-        scale: For decimal types
-    
-    Returns:
-        Dict with 'type' and optional type-specific properties
-    
-    Raises:
-        ValueError: For unsupported types or FLOAT usage
-    """
-    upper_type = data_type.upper()
-    
-    # String types
-    if any(t in upper_type for t in ['VARCHAR', 'STRING', 'TEXT', 'CHAR']):
-        if length is None or length > 5000:
-            return {"type": "cds.String", "length": 5000}
-        return {"type": "cds.String", "length": length}
-    
-    # Integer types - CRITICAL: use cds.Integer
-    if upper_type in ['INTEGER', 'INT', 'SMALLINT', 'TINYINT']:
+    upper = data_type.upper()
+
+    # Strings -> cds.String with NO length
+    if any(t in upper for t in ['VARCHAR', 'STRING', 'TEXT', 'CHAR']):
+        return {"type": "cds.String"}
+
+    # Integers
+    if upper in ['INTEGER', 'INT', 'SMALLINT', 'TINYINT', 'BYTEINT']:
         return {"type": "cds.Integer"}
-    if upper_type in ['BIGINT']:
+    if upper == 'BIGINT':
         return {"type": "cds.Integer64"}
-    
-    # Decimal types - CRITICAL: use 'is not None', NOT 'or' operator
-    if upper_type in ['DECIMAL', 'NUMERIC']:
-        effective_precision = precision if precision is not None else 15
-        effective_scale = scale if scale is not None else 2
+
+    # Fixed-point
+    if upper in ['NUMBER', 'DECIMAL', 'NUMERIC']:
         return {
             "type": "cds.Decimal",
-            "precision": effective_precision,
-            "scale": effective_scale
+            "precision": precision if precision is not None else 38,
+            "scale": scale if scale is not None else 0,
         }
-    if upper_type == 'NUMBER':
-        if scale == 0:
-            return {"type": "cds.Integer64"}  # Integer NUMBER
-        effective_precision = precision if precision is not None else 38
-        effective_scale = scale if scale is not None else 0
-        return {
-            "type": "cds.Decimal",
-            "precision": effective_precision,
-            "scale": effective_scale
-        }
-    
-    # Float types - REJECT FLOAT
-    if upper_type == 'FLOAT':
-        raise ValueError(
-            "FLOAT type not supported. Use DOUBLE: "
-            "ALTER TABLE ... MODIFY COLUMN ... DOUBLE"
-        )
-    if upper_type in ['DOUBLE', 'REAL']:
+
+    # Floating point
+    if upper in ['FLOAT', 'FLOAT4', 'FLOAT8', 'REAL', 'DOUBLE', 'DOUBLE PRECISION']:
         return {"type": "cds.Double"}
-    
+
     # Boolean
-    if upper_type in ['BOOLEAN', 'BOOL']:
+    if upper in ['BOOLEAN', 'BOOL']:
         return {"type": "cds.Boolean"}
-    
-    # Date/Time - CRITICAL: TIMESTAMP → cds.DateTime
-    if upper_type == 'DATE':
+
+    # Date / supported timestamps
+    if upper == 'DATE':
         return {"type": "cds.Date"}
-    if upper_type == 'TIME':
-        return {"type": "cds.Time"}
-    if 'TIMESTAMP' in upper_type or upper_type == 'DATETIME':
-        return {"type": "cds.DateTime"}  # NOT cds.Timestamp
-    
-    # Binary
-    if 'BINARY' in upper_type:
-        if length is None or length > 5000:
-            return {"type": "cds.Binary", "length": 5000}
-        return {"type": "cds.Binary", "length": length}
-    
-    # Complex types (warn/reject)
-    if upper_type in ['VARIANT', 'GEOGRAPHY', 'GEOMETRY']:
-        warnings.warn(
-            f"{upper_type} not supported - mapping to cds.String(5000)"
-        )
-        return {"type": "cds.String", "length": 5000}
-    
-    if upper_type in ['OBJECT', 'ARRAY']:
-        raise ValueError(
-            f"{upper_type} not supported - flatten structure first"
-        )
-    
-    # Fallback
-    warnings.warn(f"Unknown type {data_type} - defaulting to cds.String(5000)")
-    return {"type": "cds.String", "length": 5000}
+    if upper in ['TIMESTAMP', 'TIMESTAMP_NTZ', 'TIMESTAMP_LTZ', 'DATETIME']:
+        if precision is not None and precision > 6:
+            raise ValueError(
+                f"{data_type}({precision}) not supported - nanosecond timestamps "
+                "(Iceberg timestamp_ns) cannot be materialized. Use precision 6."
+            )
+        return {"type": "cds.Timestamp"}
+
+    # Unsupported
+    unsupported = ['TIMESTAMP_TZ', 'TIME', 'BINARY', 'VARBINARY', 'VARIANT',
+                   'OBJECT', 'ARRAY', 'MAP', 'GEOMETRY', 'GEOGRAPHY']
+    for key in unsupported:
+        if key in upper:
+            raise ValueError(
+                f"{data_type} not supported by SAP BDC - exclude or convert this column."
+            )
+
+    raise ValueError(f"Unknown type '{data_type}' - no CSN mapping available")
 ```
 
 ## Validation Checklist
 
 After mapping types, validate:
-- [ ] No `cds.Decimal` for INTEGER columns (should be `cds.Integer`)
-- [ ] No `cds.Timestamp` for TIMESTAMP columns (should be `cds.DateTime`)
-- [ ] All string lengths > 5000 capped at exactly 5000
-- [ ] No FLOAT types (rejected with error)
-- [ ] No OBJECT/ARRAY types (rejected with error)
-- [ ] VARIANT/GEOGRAPHY/GEOMETRY mapped to String(5000) with warning
+- [ ] INTEGER → `cds.Integer`, BIGINT → `cds.Integer64` (never `cds.Decimal`)
+- [ ] NUMBER/DECIMAL → `cds.Decimal` with exact precision/scale (use `is not None`, not `or`)
+- [ ] FLOAT/FLOAT4/FLOAT8/REAL/DOUBLE → `cds.Double`
+- [ ] All strings → `cds.String` with **no length**
+- [ ] Supported timestamps (microsecond) → `cds.Timestamp`; no `cds.Time`/`cds.DateTime`
+- [ ] No TIME, nanosecond timestamps, BINARY, VARIANT, OBJECT, ARRAY, MAP, GEOMETRY, or GEOGRAPHY columns
 
 ## Testing Examples
 
-### Test Case 1: Integer Column
 ```python
-# Snowflake: INTEGER column
-result = map_snowflake_to_cds('INTEGER')
-assert result == {"type": "cds.Integer"}  # NOT cds.Decimal(38,0)
+assert map_snowflake_to_cds('INTEGER') == {"type": "cds.Integer"}
+assert map_snowflake_to_cds('BIGINT') == {"type": "cds.Integer64"}
+assert map_snowflake_to_cds('VARCHAR', length=255) == {"type": "cds.String"}
+assert map_snowflake_to_cds('FLOAT') == {"type": "cds.Double"}
+assert map_snowflake_to_cds('TIMESTAMP_NTZ', precision=6) == {"type": "cds.Timestamp"}
+
+import pytest
+with pytest.raises(ValueError):
+    map_snowflake_to_cds('TIME')
+with pytest.raises(ValueError):
+    map_snowflake_to_cds('TIMESTAMP_NTZ', precision=9)
+with pytest.raises(ValueError):
+    map_snowflake_to_cds('VARIANT')
 ```
-
-### Test Case 2: Timestamp Column
-```python
-# Snowflake: TIMESTAMP_NTZ column
-result = map_snowflake_to_cds('TIMESTAMP_NTZ')
-assert result == {"type": "cds.DateTime"}  # NOT cds.Timestamp
-```
-
-### Test Case 3: Large String
-```python
-# Snowflake: VARCHAR(16777216) column
-result = map_snowflake_to_cds('VARCHAR', length=16777216)
-assert result == {"type": "cds.String", "length": 5000}  # Capped
-```
-
-### Test Case 4: Float Rejection
-```python
-# Snowflake: FLOAT column
-with pytest.raises(ValueError, match="FLOAT type not supported"):
-    map_snowflake_to_cds('FLOAT')
-```
-
-## Cross-Database Notes
-
-### Postgres → CDS
-
-| Postgres Type | CDS Type | Notes |
-|---------------|----------|-------|
-| INTEGER | `cds.Integer` | Same as Snowflake |
-| TEXT | `cds.String`, `length: 5000` | Unbounded → capped |
-| TIMESTAMP | `cds.DateTime` | Same as Snowflake |
-| BYTEA | `cds.Binary`, `length: 5000` | Binary data |
-
-### BigQuery → CDS
-
-| BigQuery Type | CDS Type | Notes |
-|---------------|----------|-------|
-| INT64 | `cds.Integer64` | 64-bit integer |
-| STRING | `cds.String`, `length: 5000` | Unbounded → capped |
-| TIMESTAMP | `cds.DateTime` | Same as Snowflake |
-| BYTES | `cds.Binary`, `length: 5000` | Binary data |
 
 ## References
 
-- **SDK Source:** Reverse-engineered from `sap-bdc-connect-sdk`
 - **CSN Interop Spec:** https://sap.github.io/csn-interop-specification/
-- **Analysis:** See `/SkillCSN/sdk-csn-generator-source-analysis.md`
+- **Zero-Copy Integration:** https://docs.snowflake.com/en/user-guide/data-integration/zero-copy/about-sap-snowflake
 
 ---
 
-**Key Principle:** When in doubt, favor **simplicity** and **SDK compatibility** over sophistication.
+**Key Principle:** Match the **Iceberg** type, keep strings length-free, and exclude anything SAP cannot materialize.


### PR DESCRIPTION
## Summary
Aligns the `manage-zerocopy-sapbdc` **csn-generator** type mapping to the authoritative Snowflake → Iceberg → CSN chain across `INSTRUCTIONS.md`, `README.md`, and `references/type-mapping-sdk.md`.

Key mapping changes:
- `INTEGER`/`INT`/`SMALLINT`/`TINYINT` → `cds.Integer`; `BIGINT` → `cds.Integer64`
- `NUMBER(p,s)`/`DECIMAL(p,s)` → `cds.Decimal(p,s)` (exact precision/scale)
- `FLOAT`/`FLOAT4`/`FLOAT8`/`REAL`/`DOUBLE` → `cds.Double` (MSA applies `floatToDoubleWidening`)
- `VARCHAR`/`STRING`/`TEXT` → `cds.String` with **no length** (previously hardcoded `length: 5000`)
- `TIMESTAMP_NTZ(6)`/`TIMESTAMP_LTZ(6)` → `cds.Timestamp`
- `TIME`, nanosecond timestamps (`TIMESTAMP_*(9)`), `BINARY`/`BINARY(n)`, `VARIANT`, `OBJECT`, `ARRAY`, `MAP`, `GEOMETRY`, `GEOGRAPHY` → **not supported** (rejected)

This corrects the prior contradiction where `INSTRUCTIONS.md` mapped INTEGER → `cds.Decimal(38,0)` / TIME → `cds.Timestamp` while `references/type-mapping-sdk.md` mapped INTEGER → `cds.Integer` / TIMESTAMP → `cds.DateTime`.

## Notes for reviewers
- The Python mapping helper now **raises** on unsupported types rather than silently mapping them.
- Draft: pending review of the unsupported-type handling and any downstream sample CSN.

## Test plan
- [ ] Generated CSN uses `cds.Integer`/`cds.Integer64` for integer columns and `cds.Decimal(p,s)` only for NUMBER/DECIMAL
- [ ] String elements emit `cds.String` with no `length`
- [ ] Supported timestamps emit `cds.Timestamp`; unsupported columns are excluded/rejected
- [ ] Publish + materialization succeeds in SAP BDC

Made with [Cursor](https://cursor.com)