### PR TITLE
Remove floatToDoubleWidening note; add publish-back guardrail

### DIFF
--- a/skills/manage-zerocopy-sapbdc/csn-generator/INSTRUCTIONS.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/INSTRUCTIONS.md
@@ -39,7 +39,7 @@ When a column is declared as an Iceberg `int` (32-bit) it maps to `cds.Integer`;
 
 ### Why FLOAT → cds.Double
 
-Snowflake `FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`. Declare them as `cds.Double` in CSN — MSA applies `floatToDoubleWidening` automatically. `REAL`/`DOUBLE PRECISION` are Iceberg `double` (64-bit) and also map to `cds.Double`.
+Snowflake `FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`. Declare them as `cds.Double` in CSN. `REAL`/`DOUBLE PRECISION` are Iceberg `double` (64-bit) and also map to `cds.Double`.
 
 ### Why strings have no length
 
@@ -86,7 +86,7 @@ cds.String (no length), cds.Date, cds.Timestamp, cds.Association
 | BIGINT | long | `cds.Integer64` | |
 | NUMBER(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Use matching precision and scale |
 | DECIMAL(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Snowflake alias for `NUMBER(p,s)` |
-| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` — MSA applies `floatToDoubleWidening` automatically |
+| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` |
 | FLOAT4 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
 | FLOAT8 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
 | REAL | double | `cds.Double` | Iceberg type is `double` (64-bit) |

--- a/skills/manage-zerocopy-sapbdc/csn-generator/README.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/README.md
@@ -114,7 +114,7 @@ Publish through the Publish workflow (`publish/INSTRUCTIONS.md`), which calls `S
 | INTEGER | int | `cds.Integer` | 32-bit |
 | BIGINT | long | `cds.Integer64` | 64-bit |
 | NUMBER(p,s) / DECIMAL(p,s) | decimal(p,s) | `cds.Decimal`, `precision: p`, `scale: s` | Exact precision/scale |
-| FLOAT / FLOAT4 / FLOAT8 | float | `cds.Double` | MSA applies `floatToDoubleWidening` |
+| FLOAT / FLOAT4 / FLOAT8 | float | `cds.Double` | 32-bit float |
 | REAL / DOUBLE PRECISION | double | `cds.Double` | |
 | VARCHAR / STRING / TEXT | string | `cds.String` | **No length** |
 | DATE | date | `cds.Date` | |

--- a/skills/manage-zerocopy-sapbdc/csn-generator/references/type-mapping-sdk.md
+++ b/skills/manage-zerocopy-sapbdc/csn-generator/references/type-mapping-sdk.md
@@ -25,7 +25,7 @@ Guiding rules:
 | BIGINT | long | `cds.Integer64` | |
 | NUMBER(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Use matching precision and scale |
 | DECIMAL(p,s) | decimal(p,s) | `cds.Decimal(p,s)` | Snowflake alias for `NUMBER(p,s)` |
-| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` — MSA applies `floatToDoubleWidening` automatically |
+| FLOAT | float | `cds.Double` | Iceberg type is `float` (32-bit). Declare as `cds.Double` |
 | FLOAT4 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
 | FLOAT8 | float | `cds.Double` | Iceberg type is `float` (32-bit). Same widening as FLOAT |
 | REAL | double | `cds.Double` | Iceberg type is `double` (64-bit) |
@@ -86,7 +86,7 @@ def map_decimal_type(precision, scale) -> dict:
 
 ## Floating Point Types
 
-`FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`; `REAL`/`DOUBLE PRECISION` are 64-bit Iceberg `double`. All map to `cds.Double` — MSA applies `floatToDoubleWidening` automatically.
+`FLOAT`/`FLOAT4`/`FLOAT8` are 32-bit Iceberg `float`; `REAL`/`DOUBLE PRECISION` are 64-bit Iceberg `double`. All map to `cds.Double`.
 
 ```json
 {"type": "cds.Double"}

--- a/skills/manage-zerocopy-sapbdc/publish/INSTRUCTIONS.md
+++ b/skills/manage-zerocopy-sapbdc/publish/INSTRUCTIONS.md
@@ -464,6 +464,11 @@ Primary key check: The following tables are missing primary key constraints.
 
    And `csn_document_json` is the CSN content obtained in Step 3.
 
+   **IMPORTANT — publish back only through this system function:**
+   - Pass the ORD metadata JSON and the CSN JSON **only** as arguments to `SYSTEM$SAP_PUBLISH_DATA_PRODUCT`. This is the only function used to publish back.
+   - Do **not** use any other system function to publish the data product.
+   - Do **not** run any separate "set CSN" (or equivalent) SQL statements to attach the CSN. The CSN is delivered exclusively via the `csn_document_json` argument of this call.
+
 3. **Confirm** success and present result to user.
 
 ### Step 6: Verify Publication


### PR DESCRIPTION
## Summary
- Remove the "MSA applies \`floatToDoubleWidening\` automatically" note from the FLOAT type mappings in the csn-generator docs (`INSTRUCTIONS.md`, `README.md`, `references/type-mapping-sdk.md`). FLOAT still maps to `cds.Double`.
- `publish/INSTRUCTIONS.md`: add an explicit instruction that publish-back goes **only** through `SYSTEM$SAP_PUBLISH_DATA_PRODUCT`, passing the ORD metadata JSON and CSN JSON as its arguments — no other system function, and no separate "set CSN" SQL statements.

## Test plan
- [ ] No remaining references to `floatToDoubleWidening` in the skill
- [ ] Publish workflow instructs delivering CSN/ORD only via the publish system function

Made with [Cursor](https://cursor.com)