### PR TITLE
Add the XO plugin under a new plugins/ folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Once installed, invoke a skill by typing `$<skill-name>` followed by your prompt
 
 Some contributions are **plugins** rather than single skills. A plugin bundles one or more skills together with hooks, subagents, and other components under `plugins/<name>/`, and installs through CoCo's plugin mechanism (not the single-skill install above). See [`plugins/README.md`](plugins/README.md) for the layout and how to add one.
 
+Plugins in this repo:
+
+| Plugin | What it does |
+| --- | --- |
+| [`xo`](plugins/xo) | General purpose Data Engineering Harness — automatic cross-session memory and recall, composable workflow stages, and specialised subagents, amongst many other best-practice token-efficient strategies. |
+
 ---
 
 ## Authoring a skill

--- a/plugins/xo/.cortex-plugin/plugin.json
+++ b/plugins/xo/.cortex-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "xo",
+  "description": "XO operator workflow system for Cortex Code: composable workflow stages with quality gates, specialised subagents (proposer/critic/verifier), behavioural-enforcement hooks (automatic session recording, context checkpointing, and process guidance), and persistent cross-session memory. Prereqs: node, git, gh, jq. After install, run the bundled plugin/setup.sh to set XOCORTEX_HOME, put node on the hooks' PATH, and optionally create a git-backed vault.",
+  "version": "3.3.1"
+}

--- a/plugins/xo/LICENSE
+++ b/plugins/xo/LICENSE
@@ -1,0 +1,20 @@
+Apache License
+==============
+
+_Version 2.0, January 2004_
+_<http://www.apache.org/licenses/>_
+
+Copyright 2026 Snowflake Inc.
+
+This plugin, xo (XO operator workflow system),
+is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/xo/README.md
+++ b/plugins/xo/README.md
@@ -1,0 +1,74 @@
+# XO
+
+*/ˈɛksoʊ/ — from exocortex. Smarter rocks.*
+
+XO is an operator workflow system (an "AI harness") for [Cortex Code](https://www.snowflake.com/en/product/features/cortex-code/) — Desktop and CLI. It helps an AI agent operate as a reliable partner across multi-session, multi-step knowledge work — documentation, problem-solving, analysis, coding, testing, and research — with structure and human supervision.
+
+It is delivered as a **plugin** containing hooks, a skill, and specialised subagents:
+
+- **Automatic, durable memory** — session-recording hooks keep a local markdown trail (diary, notes, tasks, checkpoints) so context survives summarisation and compaction, and work resumes cleanly across sessions. Every significant session gets a local "Work Item" number.
+- **Composable stages** — a builder's tool belt mapped to an OODA loop (**Observe → Orient → Decide → Act**), so the agent reaches for the right step at the right moment: never forcing heavyweight process onto a small job, never skipping discipline on a large one.
+- **Specialised subagents** — proposer / critic / verifier roles for scoped, reviewable work.
+
+The stages are artifact-type-neutral — the same discipline applies whether the output is code, a document, a Snowflake object, a configuration, an app, or a demo. Most work uses only a slice (a typo fix goes straight to build-and-verify; documentation runs analyse → distil → document → prove → ship).
+
+## What XO encodes
+
+XO's value is what it makes an agent do reliably. Two parts: the **phases** it composes per task, and the **correction practices** that sit around the whole piece of work. None are code-specific — they apply to whatever gets shipped (a PR, a document, a config, an email), and all are plain files you can read, tune, or override.
+
+### Phases
+
+| Phase | Role |
+|---|---|
+| Triage | Classify the request and route it to the right phases before acting |
+| Survey | Breadth-first discovery: locate where the subject lives |
+| Analyse | Depth-first investigation: establish verified facts |
+| Recall | Search the memory vault of past notes, tasks, and decisions |
+| Distil | Compile raw evidence into a findings brief |
+| Workshop | Explore several angles in parallel; bring back candidates for you to choose |
+| Spec | Write the bounding contract: goal, requirements, out-of-scope, done |
+| Plan | Turn the spec into an implementation plan |
+| Provision | Set up the workspace: branch, scratch, local/cloud infra |
+| Build | Produce the work, with parallel critics and a verifier, holding scope |
+| Document | Write the guide when the artifact is prose rather than code |
+| Prove | Verify: tests, interactive checks, state validation, or citation audit |
+| Ship | Deliver: a PR, a publish, a deploy, or a hand-off |
+| Capture | Keep the durable learnings from the work |
+| Cleanup | Prune and consolidate so the memory stays a help, not a hoard |
+
+A task uses only the phases it needs, in sequences XO composes and reuses.
+
+### Correction practices
+
+Each addresses a specific failure mode of an unsupervised agent:
+
+- **Notes as you go** — records decisions into plain files as it works, so a long job survives the context limit and resumes later instead of starting over.
+- **Named phases** — tracks the next action and where it is in the sequence, so when a task grows mid-flight it can split off the blocker and still resume in place.
+- **One place for the work** — capture anything, however rough, where the work happens; nothing leaves your hands until you Ship it, and then the checks apply at the boundary.
+- **Organisation across task-switching** — structured notes, a daily diary, and a low-overhead task queue hold what was decided, what was touched, and what's still owed, so you move between demands without carrying the organisation in your head.
+- **Curated memory, not a hoard** — captured findings and rules are periodically promoted into the vault, and pruned (stale ones dropped), with a nudge when curation is overdue, so memory compounds instead of rotting or being re-learned.
+- **Durable, portable memory** — everything is plain text in a git-backed vault you own; the harness nudges you to commit and push once it has gone unsaved for a while.
+- **Delegate closed questions** — sends a subagent to fetch just the relevant past work, so the main session stays on your goal instead of reloading everything.
+- **Isolation before parallelism** — each concurrent session gets its own workspace and makes session-local, never global, changes, so parallel runs don't collide.
+- **Chain of evidence** — every claim traces to a file read or command run; what couldn't be verified is listed as a gap, not smoothed over.
+- **Cold finder, warm writer** — one agent gathers facts and invents nothing; a separate one writes using only those facts, so the writing can't quietly fill a gap.
+- **Null-result reasoning** — an empty search prompts a second hypothesis before concluding a thing isn't there.
+- **Triage first** — reads what you actually asked, and how large it is, before acting.
+- **Survey before create** — checks whether a thing already exists (locally first) before building, and records what it didn't find.
+- **Spec and operator gates** — you approve a short scoped contract before anything is built; it stops to report at decision points rather than running ahead.
+- **Workshop the options** — for real trade-offs, explores several angles in parallel and brings them back for you to choose.
+- **Cold critic** — the agent that produced the work never signs it off; a fresh one checks it against the goal, and can't pass on "it ran without errors" alone.
+- **Review the whole chain** — checks the reasoning, not just the result, so a wrong upstream assumption doesn't slip through tidy output.
+- **Complexity gate** — matches effort to the change: mechanical fixes apply fast; judgment calls re-enter the full critique before shipping.
+
+## Prerequisites
+
+`node`, `git`, `gh`, and `jq` on your PATH.
+
+## Install & set up
+
+Install the plugin through Cortex Code, then run the bundled setup once. See **[SETUP.md](SETUP.md)** for the happy-path install (zero-config or git-backed) — it sets `XOCORTEX_HOME`, puts `node` on the hooks' PATH, and optionally creates a git-backed memory vault.
+
+## License
+
+Apache License 2.0 — see [LICENSE](LICENSE).

--- a/plugins/xo/SETUP.md
+++ b/plugins/xo/SETUP.md
@@ -1,0 +1,104 @@
+# XO Setup
+
+Post-install runbook for the XO plugin. Catalog installs copy the `plugin/` tree and register the manifest, but they do not run the bundled installer for you. Clone-based installs use the same installer. Run it as below to finish setup.
+
+---
+
+## After install: run the bundled setup script
+
+Running the plugin's `setup.sh` is what gives you the full install:
+
+- a git-backed `xocortex` vault if you choose `init`
+- `XOCORTEX_HOME` exported from the shell profile the hooks actually read
+- `node` added to the hook shell PATH when needed, which is what makes the JS hooks reliably fire
+
+XO still works without this step in zero-config mode. In that mode it falls back to `~/.snowflake/cortex/memory/xocortex/`, but hooks may not fire until `node` is resolvable in the hook shell.
+
+### If you installed XO from a git clone
+
+```bash
+git clone https://github.com/Snowflake-Labs/coco-skills.git
+coco-skills/plugins/xo/setup.sh install
+```
+
+### If you installed XO from the catalog
+
+Run the bundled installer from the installed plugin directory. If you are using the default Cortex plugin location, that is typically:
+
+```bash
+~/.snowflake/cortex/plugins/xo/setup.sh install
+```
+
+If your plugin was installed somewhere else, run the `setup.sh` at the root of that install directory.
+
+### Git-backed vault (recommended)
+
+```bash
+git clone https://github.com/Snowflake-Labs/coco-skills.git
+coco-skills/plugins/xo/setup.sh init
+```
+
+From a cloned repo, `init` creates a private `xocortex` repo under your authenticated GitHub account by default (or under an org you choose), clones it alongside the `coco-skills/` checkout, registers the plugin, writes the `XOCORTEX_HOME` export, and ensures `node` is reachable for hooks. If the repo already exists it offers to clone it.
+
+If you run `init` from a catalog-installed plugin instead of a git clone, it avoids writing a vault into the plugin cache: it honors `--xocortex <path>` if you provide one, otherwise defaults to `$HOME/xocortex` and tells you where it is going.
+
+> Requires `node`, `git`, `gh`, `jq`, a completed `gh auth login`, and, only if you choose an org as the repo owner, access to that org.
+
+---
+
+## `XOCORTEX_HOME` and hook execution
+
+The hooks read `XOCORTEX_HOME` from their process environment. CoCo runs hooks as `$SHELL -c` — a non-interactive, non-login shell — so the variable must be set in whichever file that context sources:
+
+| Shell | File |
+|-------|------|
+| zsh | `~/.zshenv` |
+| fish | `~/.config/fish/config.fish` |
+| bash | a system mechanism — `launchctl setenv` (macOS), `/etc/environment` (Linux) |
+
+The plugin's `setup.sh` writes this for you. To set it manually (zsh): `echo 'export XOCORTEX_HOME="/path/to/xocortex"' >> ~/.zshenv`, then open a new terminal.
+
+---
+
+## tgrep search index (optional)
+
+XO uses `tgrep` — Cortex Code's built-in local search index — to speed up vault and code search when it is available, and falls back to plain `grep` when it is not. Nothing breaks without it; it is an accelerator, not a dependency.
+
+To get the benefit, confirm it is enabled:
+
+- **Setting:** `tgrep.enabled` in Cortex Code. tgrep auto-indexes repositories under 1000 files in the background, so most vaults are covered with no action.
+- **Model access:** tgrep embeds with the `arctic-embed` model via Cortex. If your account lacks access, the first call returns a 403 and tgrep disables itself — search silently falls back to grep.
+
+`setup.sh` prints this reminder on install; `setup.sh status` shows the current note. XO cannot toggle the setting or grant model access for you, so this step is a prompt, not an automated change.
+
+---
+
+## `setup.sh` commands
+
+```
+setup.sh init        First-time setup: create xocortex repo + register plugin
+setup.sh install     Register plugin (set XOCORTEX_HOME with --xocortex)
+setup.sh uninstall   Remove XO plugin (does not touch your vault)
+setup.sh migrate     Move XO between user-profile and workspace
+setup.sh status      Check installation health
+setup.sh help        Usage
+```
+
+Options: `--target <user-profile|workspace>` (default user-profile), `--workspace <path>`, `--xocortex <path>`, `--owner <account-or-org>` (`init` only; default: your GitHub account).
+
+Run the plugin's `setup.sh status` any time to verify the plugin is registered, `XOCORTEX_HOME` resolves, and no legacy config remains.
+
+---
+
+## Vault layout
+
+```
+xocortex/
+  diary/{YYYY-MM}/{YYYY-MM-DD}.md       session momentum log
+  tasks/current/{project}-wi{N}-*.md    active work items
+  tasks/archive/{YYYY-MM}/              completed work items
+  notes/{YYYY-MM}/{project}-wi{N}-*.md  deep investigation notes
+  tmp/                                  scratch space (gitignored)
+```
+
+Work items and notes carry a project prefix so they group by project. `tasks/index.md` is generated automatically by the SessionStart hook.

--- a/plugins/xo/agents/xo-bounded-writer.agent.md
+++ b/plugins/xo/agents/xo-bounded-writer.agent.md
@@ -1,0 +1,48 @@
+---
+name: xo-bounded-writer
+description: Bounded writer — write authority, no codebase exploration. Used for Drafter (writes from findings only, codebase-blind), Compiler (raw evidence → scoping artifact), and Briefer (operator-facing summary). Structurally cannot hallucinate from codebase exploration because it has no explore tools.
+tools:
+  - read
+  - write
+model: claude-opus-4-8
+---
+
+You are a bounded writer. You produce documents — findings briefs, guides, operator summaries — from input material you are given. You cannot explore codebases or run commands. This is deliberate: it structurally prevents you from making claims not grounded in your supplied inputs.
+
+**Operating mode — bounded-generative.** Produce exactly what the inputs and brief require, idiomatically — do not diverge, embellish, or introduce claims beyond your inputs. Open, creative decisions live with the orchestrator, not you.
+
+## Your task
+
+Your TASK INSTRUCTIONS specify:
+- **PERSONA** — the specific role (e.g. Drafter, Compiler, Briefer)
+- **INPUT_PATH** — path to the material you write from (findings brief, raw evidence, implementation summary)
+- **OUTPUT_PATH** — where to write the document you produce
+- **AUDIENCE / STYLE** — who reads this and at what depth
+
+Your input material is your **only source of truth**. Do not add information from memory, inference, or general knowledge about the domain.
+
+## Output artifact
+
+Write your document to OUTPUT_PATH. **Return a completion message in-context** after writing, noting the path and a 2-3 sentence summary for the orchestrator.
+
+## Disciplines
+
+**Input-only sourcing.** Every factual claim in your output must trace to something in your INPUT_PATH. If the input has a gap, omit that topic from your output — do not fill the gap from inference.
+
+**Anti-fabrication.** Do not invent alternatives, risks, or examples that are not in your inputs. If the input notes "no alternatives were considered," say so explicitly — do not fabricate plausible-sounding alternatives. This failure mode is specifically named: fabricated alternatives erode operator trust immediately.
+
+**Honesty over polish.** If coverage is weak, say so. If a decision was arbitrary, say so. If something was not tested, say so. A brief that hides gaps is worse than one that names them.
+
+**Scannable output.** Use tables for structured data, clear headers, key information front-loaded. The reader should find what they need in under 30 seconds per section.
+
+**No ego investment.** If you are writing a brief about work done by another agent, you did not do that work. Be neutral. Do not cheerlead.
+
+**Confine writes to OUTPUT_PATH.** OUTPUT_PATH is your only write target — never write to any other location, including system temp (`/tmp`, `$TMPDIR`, `/var/folders`), `$HOME`, or arbitrary paths. If you have no path for something you need to write, report the gap rather than choosing your own location.
+
+---
+
+## Tool lock
+
+You have access to exactly these tools: `read`, `write`.
+
+Do not invoke any tool outside this list. If a task requires capabilities outside these tools (browsing code, running commands), that is a signal the work should be done by a different template — report the gap.

--- a/plugins/xo/agents/xo-cold-fast.agent.md
+++ b/plugins/xo/agents/xo-cold-fast.agent.md
@@ -1,0 +1,55 @@
+---
+name: xo-cold-fast
+description: "Cold surveyor and executor — read-only, fast model. Used for high-volume, cost-sensitive cold work: Surveyor (breadth discovery), Retriever (knowledge lookup), Tester (run and report). Parameterised at dispatch via PERSONA, INPUTS, OUTPUT_PATH."
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+  - write
+  - tgrep
+model: auto-fast
+---
+
+You are a cold surveyor and executor. Your job is to scan, run, and report — accurately, at speed, across breadth.
+
+**Operating mode — cold.** Deterministic and evidence-bound: report only what you actually found, never fill a gap with plausible inference (flag the gap instead), and say so when you're unsure. Open-ended, creative judgment lives with the orchestrator, not you.
+
+## Your task
+
+Your TASK INSTRUCTIONS specify:
+- **PERSONA** — the specific role (e.g. Surveyor: Existing Patterns, Retriever, Tester)
+- **INPUTS** — what to scan, query, or execute
+- **OUTPUT_PATH** — where to write your results
+
+Apply the PERSONA exactly. If no PERSONA is specified, act as a breadth-first information gatherer.
+
+## Output artifact
+
+Write your results to OUTPUT_PATH by calling the `write` tool directly. The directory already exists (the orchestrator pre-created it), so do **not** run `mkdir` or otherwise create it — the `write` tool needs no directory setup. Write **only** to OUTPUT_PATH. After writing, return a brief in-context pointer — the path plus a 2-3 sentence summary. The written file is the handoff; the orchestrator synthesises across multiple parallel dispatches of this template, so your file is your contribution to that synthesis. Do not return the full results in-context.
+
+Structure: Summary → Findings (each with Source + what you found) → Negative results (what you checked and found nothing) → Gaps.
+
+For test-execution tasks: report pass/fail counts, which tests ran, output for failures, and any environment issues.
+
+## Disciplines
+
+**Breadth over depth.** Cover the territory assigned. If you find something worth deeper investigation, note it under Gaps — don't chase it. Other agents or passes handle depth.
+
+**Record what you checked.** Negative results ("checked X, found nothing relevant for Y") prevent redundant re-traversal in later sessions.
+
+**Null or unexpected results demand a reasoning cycle.** When a search returns nothing or far less than expected, do not accept it. Ask: why might this be wrong — wrong structure? misapplied filter? wrong path? wrong search terms? Test at least one alternative before concluding. Report the chain: *"I searched [X] and found nothing. Because [reason this could be wrong], I tried [A]. I still found [result]. My conclusion is [Y]."* Never collapse to bare absence without this cycle.
+
+**Evidence only.** Report what you actually found, not what you expect or infer. Brief summaries are fine; invented detail is not.
+
+**Accurate counts matter.** For test execution: exact numbers, not approximations.
+
+**Confine writes to OUTPUT_PATH.** OUTPUT_PATH is your only write target. Do not use `bash` to write, redirect (`>`, `>>`, `tee`), or create files anywhere else — not system temp (`/tmp`, `$TMPDIR`, `/var/folders`), not `$HOME`, not arbitrary paths. If a task seems to need an intermediate file, fold it into your OUTPUT_PATH artifact or report the gap; never scatter scratch files across the filesystem.
+
+---
+
+## Tool lock
+
+You have access to exactly these tools: `read`, `grep`, `glob`, `bash`, `write`, `tgrep`. Use `write` solely to create your OUTPUT_PATH artifact — never to edit other files or create directories, and never use `bash` to write, redirect, or create files outside OUTPUT_PATH (see "Confine writes to OUTPUT_PATH" above). `tgrep` is an optional read-only semantic/keyword search over the workspace (vault notes or code); use it when a prebuilt index is available and semantic ranking helps, and fall back to `grep` when tgrep is unavailable, the index is cold (it will say so), or you need exact-literal matching.
+
+Do not invoke any tool outside this list. If a task requires capabilities outside these tools, report the gap.

--- a/plugins/xo/agents/xo-cold-smart.agent.md
+++ b/plugins/xo/agents/xo-cold-smart.agent.md
@@ -1,0 +1,58 @@
+---
+name: xo-cold-smart
+description: Cold assessor and fact-finder — read-only, high intelligence. Used for Explorer (bounded discovery), Critic (evaluation vs reference), Verifier (binary compliance gate), and any persona requiring cold analysis. Parameterised at dispatch via PERSONA, REFERENCE, INPUTS, OUTPUT_PATH.
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+  - write
+  - tgrep
+model: auto
+---
+
+You are a cold assessor and fact-finder. Your job is to find, verify, and report — never to generate, improve, or invent.
+
+**Operating mode — cold.** Deterministic and evidence-bound: prefer precision over covering every possibility, never fill a gap with plausible inference (flag the gap instead), and say so when you're unsure. Open-ended, creative judgment lives with the orchestrator, not you.
+
+## Your task
+
+Your TASK INSTRUCTIONS specify:
+- **PERSONA** — the specific lens to apply (e.g. Critic, Security Reviewer, Verifier, Design Explorer: Edge Cases)
+- **REFERENCE** — what you evaluate against (a spec, a diff, a set of standards, an angle description)
+- **INPUTS** — what you examine
+- **OUTPUT_PATH** — where to write your artifact
+
+Apply the PERSONA exactly. If no PERSONA is specified, act as an objective evidence-gathering assessor.
+
+## Output artifact
+
+Write your findings to OUTPUT_PATH by calling the `write` tool directly. The directory already exists (the orchestrator pre-created it), so do **not** run `mkdir` or otherwise create it — the `write` tool needs no directory setup. Write **only** to OUTPUT_PATH. After writing, return a brief in-context pointer — the path plus a 2-3 sentence summary — so the orchestrator knows what you found without re-reading the whole file. The written file is the canonical handoff artifact; do not return the full results in-context.
+
+Structure: Summary (2-3 sentences) → Findings (each with Evidence + Implication + Confidence: high/medium/low) → Risks (likelihood/impact) → Gaps (what you couldn't determine) → Recommendation.
+
+For evaluation tasks (Critic, Verifier, Security Reviewer): close with a clear verdict in the format your TASK INSTRUCTIONS specify (e.g. APPROVE / REVISE / BLOCK, or VERIFIED / NOT_VERIFIED). If not specified, use PASS / NEEDS_CHANGE.
+
+## Disciplines
+
+**Evidence over opinion.** Every finding must cite a source: file:line, specific text, test name, command output. Unsourced assertions are not findings.
+
+**Anti-fabrication.** Do not invent alternatives, prior attempts, or consequences you did not find in evidence. "I found no evidence of X" is a valid finding; fabricating X to have something to report is a defect that erodes trust.
+
+**Stay on your lens.** If you discover something important outside your assigned PERSONA scope, record it under Gaps as a follow-up item — do not chase it. Depth on your angle beats shallow coverage of everything.
+
+**Negative results count.** "Searched X for Y — no relevant results" is a finding that prevents re-exploration in the next session.
+
+**Null or unexpected results demand a reasoning cycle.** When a search returns nothing or far less than expected, do not accept it. Ask: why might this be wrong — wrong structure? misapplied filter? wrong path? wrong search terms? Form at least one alternative hypothesis and test it before concluding. Report only after that cycle: *"I searched [X] using [method] and found nothing. Because [reason this could be wrong], I tried [A] and [B]. I still found [result]. My conclusion is [Y] because [chain]."* Collapsing to "X does not exist" without this cycle is a fabrication.
+
+**Check foundations, not just surface.** When evaluating an artifact (code, doc, spec, design), assess whether its claims and choices are *grounded* — traceable to evidence, a spec, tested behaviour, or cited sources — not merely whether it compiles or reads plausibly. If something appears built on speculation with no discernible basis, say so plainly (e.g. "this compiles / reads plausibly, but I cannot see the basis for these assertions") and recommend establishing the missing foundation (analysis, findings, or sources) before building further. Plausible-but-ungrounded is a failure, not a pass.
+
+**Write only to OUTPUT_PATH.** Your one write target is your handoff artifact. You have no edit tools and must not modify production code or any file other than OUTPUT_PATH. Do not use `bash` to write, redirect (`>`, `>>`, `tee`), or create files anywhere else either — not system temp (`/tmp`, `$TMPDIR`, `/var/folders`), not `$HOME`, not arbitrary paths. If you identify a gap or needed change, describe it precisely so the appropriate agent can address it.
+
+---
+
+## Tool lock
+
+You have access to exactly these tools: `read`, `grep`, `glob`, `bash`, `write`, `tgrep`. Use `write` solely to create your OUTPUT_PATH artifact — never to edit other files or create directories, and never use `bash` to write, redirect, or create files outside OUTPUT_PATH (see "Write only to OUTPUT_PATH" above). `tgrep` is an optional read-only semantic/keyword search over the workspace (vault notes or code); use it when a prebuilt index is available and semantic ranking helps, and fall back to `grep` when tgrep is unavailable, the index is cold (it will say so), or you need exact-literal matching.
+
+Do not invoke any tool outside this list. If a task requires capabilities outside these tools, report the gap under Gaps.

--- a/plugins/xo/agents/xo-generator.agent.md
+++ b/plugins/xo/agents/xo-generator.agent.md
@@ -1,0 +1,85 @@
+---
+name: xo-generator
+description: Warm generator — full write authority. Used for Proposer (implementation), Test-author, and any role that produces changes against a bounded specification. Parameterised at dispatch via PERSONA, SPECIFICATION, INPUTS, WORKTREE.
+tools:
+  - read
+  - grep
+  - glob
+  - bash
+  - edit
+  - write
+  - multi_edit
+model: openai-gpt-5.4
+---
+
+You are a generator. You produce changes — code, tests, or other files — that satisfy a bounded specification. You are the only template with broad write authority.
+
+**Operating mode — bounded-generative.** Produce exactly what the specification requires, idiomatically — do not diverge, embellish, or add beyond scope. Open, creative decisions live with the orchestrator, not you.
+
+## Your task
+
+Your TASK INSTRUCTIONS specify:
+- **PERSONA** — the specific role (e.g. Proposer, Test-author)
+- **SPECIFICATION** — the bounded contract you must satisfy (spec file, requirements, failing tests)
+- **INPUTS** — existing code, conventions, context discovered upstream
+- **WORKTREE** — the path where you make changes
+
+Work precisely within the specification. Produce the changes it asks for. No more.
+
+## Scope discipline — mandatory
+
+You MUST change only what the specification requires. Do not:
+- Reformat adjacent code
+- Fix unrelated issues you notice
+- Refactor working code outside your specification
+- Add comments unless the codebase convention includes them
+
+If you notice a problem outside your specification scope, report it under OBSERVED in your output — do not edit it.
+
+## Filesystem scope — mandatory
+
+Confine every write to the paths you were given in your TASK INSTRUCTIONS — your **WORKTREE** and any OUTPUT or scratch path specified. Production edits go only to files inside the WORKTREE; intermediate, scratch, or draft files go only inside a path you were given (these all sit under the provisioned per-WI scratch dir `$XOCORTEX_HOME/tmp/wi{N}/`).
+
+Never write, redirect (`>`, `>>`, `tee`), or create files outside those paths — not system temp (`/tmp`, `$TMPDIR`, `/var/folders`), not `$HOME`, not arbitrary paths. If you need a scratch file, keep it inside the WORKTREE or a given scratch path; if you have no suitable write path, report the gap rather than invent a location.
+
+## Output
+
+For each change you make:
+
+```
+REQUIREMENT: [what the specification asked for]
+FILE: [path edited]
+CHANGE: [what you did]
+RATIONALE: [why this satisfies the requirement]
+```
+
+If you noticed issues outside scope:
+```
+OBSERVED: [issue]
+LOCATION: [file:line]
+```
+
+If you cannot satisfy a requirement safely:
+```
+BLOCKED: [requirement]
+REASON: [why]
+ESCALATE: Yes — orchestrator/operator decision needed
+```
+
+## Disciplines
+
+**Specification is your boundary.** The critic and verifier will review your changes against it. Changes outside specification scope are collateral damage — they will be flagged.
+
+**Evidence-based red lines.** If evidence clearly shows a requirement cannot be safely met (test failure, stack trace, security constraint), flag BLOCKED. Do not implement unsafe patterns because the spec implies them.
+
+**Match existing conventions.** Read the code near the change site. Match style, imports, naming exactly.
+
+**Revisions use prior feedback.** If you are re-invoked after a REVISE verdict, use the critic's specific feedback to guide your revision. Implement their concern unless it contradicts evidence.
+
+---
+
+## Tool lock
+
+You have access to exactly these tools: `read`, `grep`, `glob`, `bash`, `edit`, `write`, `multi_edit`.
+
+Do not invoke any tool outside this list.

--- a/plugins/xo/hooks/_common.js
+++ b/plugins/xo/hooks/_common.js
@@ -1,0 +1,131 @@
+'use strict';
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function readInput() {
+    const raw = fs.readFileSync(0, 'utf8');
+    return JSON.parse(raw);
+}
+
+function isoUtc() {
+    return new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function localWallClock() {
+    const now = new Date();
+    const pad = (value) => String(value).padStart(2, '0');
+    const datePart = [
+        now.getFullYear(),
+        pad(now.getMonth() + 1),
+        pad(now.getDate()),
+    ].join('-');
+    const timePart = [
+        pad(now.getHours()),
+        pad(now.getMinutes()),
+    ].join(':');
+
+    try {
+        const zoneParts = new Intl.DateTimeFormat('en-GB', {
+            timeZoneName: 'shortOffset',
+        }).formatToParts(now);
+        const zoneName = zoneParts.find((part) => part.type === 'timeZoneName')?.value;
+        if (zoneName) {
+            return `${datePart} ${timePart} ${zoneName}`;
+        }
+    } catch (_) {}
+
+    const offsetMinutes = -now.getTimezoneOffset();
+    const sign = offsetMinutes >= 0 ? '+' : '-';
+    const offsetHours = pad(Math.floor(Math.abs(offsetMinutes) / 60));
+    const offsetRemainder = pad(Math.abs(offsetMinutes) % 60);
+    return `${datePart} ${timePart} UTC${sign}${offsetHours}:${offsetRemainder}`;
+}
+
+function shortSid(sessionId) {
+    return String(sessionId).slice(0, 8);
+}
+
+function appendLog(logFile, line) {
+    try {
+        fs.mkdirSync(path.dirname(logFile), { recursive: true });
+        fs.appendFileSync(logFile, line + '\n');
+    } catch (_) {}
+}
+
+function atomicWrite(filePath, content) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const tmp = filePath + '.tmp';
+    fs.writeFileSync(tmp, content, 'utf8');
+    fs.renameSync(tmp, filePath);
+}
+
+function logError(msg) {
+    process.stderr.write(msg + '\n');
+}
+
+function buildPaths(input) {
+    const SESSION_ID = input.session_id ?? 'unknown';
+    const SHORT_SID = shortSid(SESSION_ID);
+    const HOOK_EVENT = input.hook_event_name ?? 'unknown';
+    const CWD = input.cwd ?? '';
+
+    const now = new Date();
+    const YYYY_MM_DD = now.toISOString().slice(0, 10);
+    const YYYY_MM = now.toISOString().slice(0, 7);
+
+    const LOG_DIR = path.join(os.homedir(), '.snowflake', 'cortex', 'logs');
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    const LOG_FILE = path.join(LOG_DIR, `${YYYY_MM_DD}-hooks.log`);
+    const TIMESTAMP = isoUtc();
+
+    const XOLOCAL = process.env.XOCORTEX_HOME ?? '';
+    const XOLOCAL_EXPLICIT = !!process.env.XOCORTEX_HOME;
+
+    const snowflakeHome = process.env.SNOWFLAKE_HOME ?? path.join(os.homedir(), '.snowflake');
+
+    let effectiveVault = XOLOCAL;
+    if (!effectiveVault) {
+        effectiveVault = path.join(snowflakeHome, 'cortex', 'memory', 'xocortex');
+        try { fs.mkdirSync(effectiveVault, { recursive: true }); } catch (_) {}
+        try { fs.mkdirSync(path.join(effectiveVault, 'diary'), { recursive: true }); } catch (_) {}
+        try { fs.mkdirSync(path.join(effectiveVault, 'notes'), { recursive: true }); } catch (_) {}
+        try { fs.mkdirSync(path.join(effectiveVault, 'tasks', 'current'), { recursive: true }); } catch (_) {}
+        try { fs.mkdirSync(path.join(effectiveVault, 'tasks', 'archive'), { recursive: true }); } catch (_) {}
+        appendLog(LOG_FILE, `[${TIMESTAMP}] XOCORTEX_HOME not set. Using fallback vault: ${effectiveVault}`);
+    }
+
+    const DIARY_PATH = path.join(effectiveVault, 'diary', YYYY_MM, `${YYYY_MM_DD}.md`);
+    const TASKS_DIR = path.join(effectiveVault, 'tasks');
+
+    const CONTEXT_STATE_DIR = path.join(snowflakeHome, 'cortex', 'memory', 'context-state');
+    fs.mkdirSync(CONTEXT_STATE_DIR, { recursive: true });
+
+    return {
+        SESSION_ID,
+        SHORT_SID,
+        HOOK_EVENT,
+        CWD,
+        TIMESTAMP,
+        LOG_DIR,
+        LOG_FILE,
+        XOLOCAL: effectiveVault,
+        XOLOCAL_EXPLICIT,
+        DIARY_PATH,
+        TASKS_DIR,
+        CONTEXT_STATE_DIR,
+        YYYY_MM_DD,
+        YYYY_MM,
+    };
+}
+
+module.exports = {
+    readInput,
+    isoUtc,
+    localWallClock,
+    shortSid,
+    appendLog,
+    atomicWrite,
+    logError,
+    buildPaths,
+};

--- a/plugins/xo/hooks/_context-monitor.js
+++ b/plugins/xo/hooks/_context-monitor.js
@@ -1,0 +1,188 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { appendLog, atomicWrite, isoUtc } = require('./_common.js');
+
+function levelRank(level) {
+    switch (level) {
+        case 'final':    return 4;
+        case 'critical': return 3;
+        case 'urgent':   return 2;
+        case 'routine':  return 1;
+        default:         return 0;
+    }
+}
+
+function ceil(n) {
+    return Math.ceil(n);
+}
+
+function checkContext(input, contextStateDir, sessionId, opts) {
+    const {
+        promptTokensEst = 0,
+        responseBuffer = 0,
+        hookSource = 'unknown',
+        logFile = null,
+        shortSid = '',
+        incrementTurns = true,
+    } = opts ?? {};
+
+    const TIMESTAMP = isoUtc();
+
+    const meta = input.response_metadata;
+    if (!meta) {
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: no response_metadata`);
+        return { result: 'no_metadata' };
+    }
+
+    const consumed = meta?.usage?.tokens_consumed?.[0] ?? {};
+    const CONTEXT_WINDOW = consumed.context_window ?? 0;
+    const INPUT_TOKENS = consumed.input_tokens?.total ?? 0;
+    const OUTPUT_TOKENS = consumed.output_tokens?.total ?? 0;
+    const CACHE_READ = consumed.input_tokens?.cache_read ?? 0;
+    const CACHE_WRITE = consumed.input_tokens?.cache_write ?? 0;
+    const UNCACHED = consumed.input_tokens?.uncached ?? 0;
+    const MODEL_NAME = consumed.model_name ?? '?';
+
+    if (!CONTEXT_WINDOW || CONTEXT_WINDOW === 'null') {
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: response_metadata present but no context_window`);
+        return { result: 'no_context_window' };
+    }
+
+    if (!INPUT_TOKENS || INPUT_TOKENS === 'null') {
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: no_input_tokens`);
+        return { result: 'no_input_tokens' };
+    }
+
+    const reportedTotal = INPUT_TOKENS + OUTPUT_TOKENS;
+    const reportedPct = ((reportedTotal / CONTEXT_WINDOW) * 100).toFixed(1);
+    const reportedPctInt = ceil((reportedTotal / CONTEXT_WINDOW) * 100);
+
+    const projectedTotal = reportedTotal + promptTokensEst + responseBuffer;
+    const projectedPct = ((projectedTotal / CONTEXT_WINDOW) * 100).toFixed(1);
+    const projectedPctInt = ceil((projectedTotal / CONTEXT_WINDOW) * 100);
+
+    const stateFile = path.join(contextStateDir, sessionId);
+
+    let lastContextPct = 0;
+    let outputAccum = 0;
+    let turnAccum = 0;
+    let sessionStartEpoch = 0;
+
+    if (fs.existsSync(stateFile)) {
+        try {
+            const raw = fs.readFileSync(stateFile, 'utf8').trim();
+            if (raw.includes('|')) {
+                const parts = raw.split('|');
+                lastContextPct = parseInt(parts[0], 10) || 0;
+                outputAccum = parseInt(parts[1], 10) || 0;
+                turnAccum = parseInt(parts[2], 10) || 0;
+                sessionStartEpoch = parseInt(parts[3], 10) || 0;
+            } else {
+                lastContextPct = parseInt(raw, 10) || 0;
+            }
+        } catch (_) {}
+    }
+
+    const nowEpoch = Math.floor(Date.now() / 1000);
+    if (sessionStartEpoch === 0) sessionStartEpoch = nowEpoch;
+
+    function writeState(pct, outAccum, turns) {
+        try {
+            atomicWrite(stateFile, `${pct}|${outAccum}|${turns}|${sessionStartEpoch}`);
+        } catch (e) {
+            if (logFile) appendLog(logFile, `[${isoUtc()}] [${shortSid}] ERROR writing state: ${e.message}`);
+        }
+    }
+
+    if (!lastContextPct) {
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: baseline_set ${reportedPctInt}% input=${INPUT_TOKENS} output=${OUTPUT_TOKENS} window=${CONTEXT_WINDOW} model=${MODEL_NAME}`);
+        writeState(reportedPctInt, 0, 0);
+        return { result: 'baseline_set', reportedPct, projectedPct, reportedPctInt, projectedPctInt };
+    }
+
+    const contextDelta = projectedPctInt - lastContextPct;
+
+    if (contextDelta < 0) {
+        // Update the pct baseline but preserve turn/output accumulators.
+        // A context drop (jitter or real summarisation) does not mean the agent has
+        // recorded. Zeroing accumulators would delay the next checkpoint by another
+        // full cycle — the opposite of what we want after a compaction event.
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: baseline_reset old=${lastContextPct}% new=${reportedPctInt}% delta=${contextDelta}% (context dropped, accumulators preserved: output=${outputAccum} turns=${turnAccum})`);
+        writeState(reportedPctInt, outputAccum, turnAccum);
+        return { result: 'baseline_reset', reportedPct, projectedPct, reportedPctInt, projectedPctInt, contextDelta };
+    }
+
+    if (incrementTurns) turnAccum += 1;
+    outputAccum += OUTPUT_TOKENS;
+    const outputSinceLast = outputAccum;
+    const turnsSinceLast = turnAccum;
+
+    let pctLevel = '';
+    if (projectedPctInt >= 85)                                         pctLevel = 'final';
+    else if (projectedPctInt >= 80)                                    pctLevel = 'critical';
+    else if (projectedPctInt >= 70)                                    pctLevel = 'urgent';
+    else if (projectedPctInt >= 50 && contextDelta >= 10)              pctLevel = 'routine';
+
+    let outputLevel = '';
+    if (outputSinceLast >= 110000)      outputLevel = 'final';
+    else if (outputSinceLast >= 70000)  outputLevel = 'critical';
+    else if (outputSinceLast >= 40000)  outputLevel = 'urgent';
+    else if (outputSinceLast >= 20000)  outputLevel = 'routine';
+
+    let turnLevel = '';
+    if (turnsSinceLast >= 75)      turnLevel = 'final';
+    else if (turnsSinceLast >= 50) turnLevel = 'critical';
+    else if (turnsSinceLast >= 25) turnLevel = 'urgent';
+    else if (turnsSinceLast >= 10) turnLevel = 'routine';
+
+    let level = '';
+    let trigger = '';
+    let bestRank = 0;
+    for (const [name, lvl] of [['pct', pctLevel], ['output_delta', outputLevel], ['turns', turnLevel]]) {
+        if (!lvl) continue;
+        const rank = levelRank(lvl);
+        if (rank > bestRank) {
+            bestRank = rank;
+            level = lvl;
+            trigger = name;
+        }
+    }
+
+    const monitorResult = level ? 'fire' : 'skip';
+
+    if (monitorResult === 'fire') {
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: cycle_check reported=${reportedPct}% projected=${projectedPct}% last=${lastContextPct}% delta=+${contextDelta}% output_since=${outputSinceLast} turns_since=${turnsSinceLast} input=${INPUT_TOKENS} output=${OUTPUT_TOKENS} window=${CONTEXT_WINDOW} cache_read=${CACHE_READ} uncached=${UNCACHED} model=${MODEL_NAME} → fire [${level}] trigger=${trigger}`);
+        writeState(projectedPctInt, 0, 0);
+    } else {
+        let skipReason = '';
+        if (projectedPctInt < 50 && outputSinceLast < 20000 && turnsSinceLast < 15) {
+            skipReason = 'below_all';
+        } else {
+            skipReason = 'no_signal_met';
+        }
+        if (logFile) appendLog(logFile, `[${TIMESTAMP}] [${shortSid}] ${hookSource}: cycle_check reported=${reportedPct}% projected=${projectedPct}% last=${lastContextPct}% delta=+${contextDelta}% output_since=${outputSinceLast} turns_since=${turnsSinceLast} input=${INPUT_TOKENS} output=${OUTPUT_TOKENS} window=${CONTEXT_WINDOW} model=${MODEL_NAME} → skip (${skipReason})`);
+        writeState(lastContextPct, outputSinceLast, turnsSinceLast);
+    }
+
+    return {
+        result: monitorResult,
+        level,
+        trigger,
+        reportedPct,
+        reportedPctInt,
+        projectedPct,
+        projectedPctInt,
+        reportedTotal,
+        lastContextPct,
+        contextDelta,
+        contextWindow: CONTEXT_WINDOW,
+        inputTokens: INPUT_TOKENS,
+        outputTokens: OUTPUT_TOKENS,
+        outputSinceLast,
+        turnsSinceLast,
+        modelName: MODEL_NAME,
+    };
+}
+
+module.exports = { checkContext };

--- a/plugins/xo/hooks/hooks.json
+++ b/plugins/xo/hooks/hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CORTEX_PLUGIN_ROOT}/hooks/sessionstart.js",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CORTEX_PLUGIN_ROOT}/hooks/userpromptsubmit.js",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CORTEX_PLUGIN_ROOT}/hooks/posttooluse.js"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/xo/hooks/posttooluse.js
+++ b/plugins/xo/hooks/posttooluse.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+'use strict';
+const { readInput, buildPaths } = require('./_common.js');
+const { checkContext } = require('./_context-monitor.js');
+
+function main() {
+    let input;
+    try {
+        input = readInput();
+    } catch (e) {
+        process.stdout.write('{"continue": true}');
+        return;
+    }
+
+    const ctx = buildPaths(input);
+    const { SHORT_SID, LOG_FILE, CONTEXT_STATE_DIR, SESSION_ID } = ctx;
+
+    const r = checkContext(input, CONTEXT_STATE_DIR, SESSION_ID, {
+        promptTokensEst: 0,
+        responseBuffer: 0,
+        hookSource: 'posttool',
+        logFile: LOG_FILE,
+        shortSid: SHORT_SID,
+        incrementTurns: false,
+    });
+
+    // When a skill loads, append a short reminder that the skill is domain knowledge
+    // for the current XO stage, not a replacement for the XO process. This lands at the
+    // tail of the skill tool result (after the skill body), so it is a supplement to the
+    // stronger reminder the UserPromptSubmit hook emits at the top of the next turn.
+    const skillNudge = input.tool_name === 'skill'
+        ? `XO [silent]: you just loaded skill '${(input.tool_input && input.tool_input.command) || '?'}' as domain knowledge for your CURRENT XO stage/pathway — it does not replace the XO process. Keep your stage, gates, and recording in force; if the skill's instructions pulled your focus, re-read your task/pathway before proceeding. Surface nothing about this note itself.`
+        : '';
+
+    let checkpointMsg = '';
+    if (r.result === 'fire') {
+        switch (r.level) {
+            case 'routine':
+                checkpointMsg = `Context ${r.projectedPct}% (trigger: ${r.trigger}; output since last ${r.outputSinceLast}, turns ${r.turnsSinceLast}) — consider checkpointing at your next milestone.`;
+                break;
+            case 'urgent':
+                checkpointMsg = `Context ${r.projectedPct}% [urgent] (trigger: ${r.trigger}; output since last ${r.outputSinceLast}, turns ${r.turnsSinceLast}) — write a checkpoint soon. Update your notes file and task file.`;
+                break;
+            case 'critical':
+                checkpointMsg = `Context ${r.projectedPct}% [critical] (trigger: ${r.trigger}; output since last ${r.outputSinceLast}, turns ${r.turnsSinceLast}) — checkpoint NOW. Write notes file, task file, and diary before continuing.`;
+                break;
+            case 'final':
+                checkpointMsg = `Context ${r.projectedPct}% [FINAL] (trigger: ${r.trigger}; output since last ${r.outputSinceLast}, turns ${r.turnsSinceLast}) — compaction imminent. STOP and write checkpoint immediately: notes file, task file, diary, /memories/.`;
+                break;
+            default:
+                checkpointMsg = `Context ${r.projectedPct}% [${r.level}] — checkpoint may be needed.`;
+        }
+    }
+
+    const parts = [skillNudge, checkpointMsg].filter(Boolean);
+    if (parts.length === 0) {
+        process.stdout.write('{"continue": true}');
+        return;
+    }
+
+    process.stdout.write(JSON.stringify({ additionalContext: parts.join('\n\n') }));
+}
+
+main();

--- a/plugins/xo/hooks/reindex-tasks.js
+++ b/plugins/xo/hooks/reindex-tasks.js
@@ -1,0 +1,114 @@
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { isoUtc, atomicWrite, appendLog } = require('./_common.js');
+
+function reindexTasks(tasksDir, logFile, shortSid) {
+    const currentDir = path.join(tasksDir, 'current');
+    const archiveDir = path.join(tasksDir, 'archive');
+    const indexFile = path.join(tasksDir, 'index.md');
+
+    if (!fs.existsSync(currentDir)) return;
+
+    const ts = isoUtc();
+
+    const stateOrd = { Now: 1, Next: 2, Later: 3 };
+    const statusOrd = s => (s && s.startsWith('InProgress') ? 1 : s && s.startsWith('Shipped') ? 2 : s === 'Ready' ? 3 : 4);
+
+    const entries = [];
+    const wiGlob = fs.readdirSync(currentDir).filter(n => /(?:^|-)wi\d+.*\.md$/.test(n));
+    for (const fname of wiGlob) {
+        const fpath = path.join(currentDir, fname);
+        if (!fs.statSync(fpath).isFile()) continue;
+        const base = path.basename(fname, '.md');
+        const wiNumMatch = base.match(/(?:^|-)wi0*(\d+)/);
+        const wiNum = wiNumMatch ? parseInt(wiNumMatch[1], 10) : 0;
+
+        const lines = fs.readFileSync(fpath, 'utf8').split('\n');
+        let title = '', state = '', wi_status = '', status_note = '';
+        for (const line of lines) {
+            if (!title && /^# WI-/.test(line)) {
+                title = line.replace(/^# WI-\d+: /, '');
+            } else if (/^- Priority: /.test(line)) {
+                state = line.replace(/^- Priority: /, '');
+            } else if (/^- Status: /.test(line)) {
+                wi_status = line.replace(/^- Status: /, '');
+            } else if (/^- StatusNote: /.test(line)) {
+                status_note = line.replace(/^- StatusNote: */, '');
+                break;
+            } else if (/^- Blocker: /.test(line)) {
+                break;
+            }
+        }
+
+        const so = stateOrd[state] ?? 3;
+        const sto = statusOrd(wi_status);
+        const wiPad = String(wiNum).padStart(4, '0');
+        entries.push({ so, sto, wiPad, wiNum, state, wi_status, status_note, title });
+    }
+
+    entries.sort((a, b) => a.so - b.so || a.sto - b.sto || a.wiPad.localeCompare(b.wiPad));
+
+    const archiveEntries = [];
+    if (fs.existsSync(archiveDir)) {
+        const archiveDirs = fs.readdirSync(archiveDir).filter(n => {
+            return fs.statSync(path.join(archiveDir, n)).isDirectory();
+        });
+        for (const subdir of archiveDirs) {
+            const subdirPath = path.join(archiveDir, subdir);
+            const files = fs.readdirSync(subdirPath).filter(n => /(?:^|-)wi\d+.*\.md$/.test(n));
+            for (const fname of files) {
+                const fpath = path.join(subdirPath, fname);
+                if (!fs.statSync(fpath).isFile()) continue;
+                const base = path.basename(fname, '.md');
+                const wiNumMatch = base.match(/(?:^|-)wi0*(\d+)/);
+                const wiNum = wiNumMatch ? parseInt(wiNumMatch[1], 10) : 0;
+                const wiPad = String(wiNum).padStart(4, '0');
+                const lines = fs.readFileSync(fpath, 'utf8').split('\n');
+                let title = '';
+                for (const line of lines) {
+                    if (/^# WI-/.test(line)) {
+                        title = line.replace(/^# WI-\d+: /, '');
+                        break;
+                    }
+                }
+                archiveEntries.push({ wiPad, wiNum, title });
+            }
+        }
+    }
+    archiveEntries.sort((a, b) => a.wiPad.localeCompare(b.wiPad));
+
+    const header = [
+        '---',
+        `generated: ${ts}`,
+        `active_count: ${entries.length}`,
+        `archived_count: ${archiveEntries.length}`,
+        '---',
+        '',
+        '# Work Items Index',
+        '',
+        '| WI | Priority | Status | StatusNote | Description |',
+        '|-----|-------|--------|------------|-------------|',
+    ].join('\n');
+
+    const activeRows = entries
+        .map(e => `| ${e.wiNum} | ${e.state} | ${e.wi_status} | ${e.status_note} | ${e.title} |`)
+        .join('\n');
+
+    let content = header + '\n' + activeRows + '\n';
+
+    if (archiveEntries.length > 0) {
+        const archiveRows = archiveEntries
+            .map(e => `| ${e.wiNum} | - | Done | | ${e.title} |`)
+            .join('\n');
+        content += '\n### Archived\n| WI | Priority | Status | StatusNote | Description |\n|-----|-------|--------|------------|-------------|\n' + archiveRows + '\n';
+    }
+
+    atomicWrite(indexFile, content);
+
+    if (logFile && shortSid) {
+        appendLog(logFile, `[${isoUtc()}] [${shortSid}] reindexed ${entries.length} active + ${archiveEntries.length} archived work items -> ${indexFile}`);
+    }
+}
+
+module.exports = { reindexTasks };

--- a/plugins/xo/hooks/sessionstart.js
+++ b/plugins/xo/hooks/sessionstart.js
@@ -1,0 +1,404 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execSync } = require('child_process');
+const { readInput, appendLog, atomicWrite, isoUtc, localWallClock, buildPaths } = require('./_common.js');
+const { reindexTasks } = require('./reindex-tasks.js');
+
+function buildStandingDirectives(ctx) {
+    const { XOLOCAL, XOLOCAL_EXPLICIT } = ctx;
+    const pluginRoot = process.env.CORTEX_PLUGIN_ROOT || path.dirname(__dirname);
+    const setupScript = path.join(pluginRoot, 'setup.sh');
+    const setupGuide = path.join(pluginRoot, 'SETUP.md');
+
+    const lines = [
+        '# XO Agent Instructions',
+        '',
+        'You are an XO-enabled agent. XO is an operator workflow system with persistent memory, structured recording, and specialised skills for software engineering work.',
+        '',
+        '## Skill Routing',
+        '',
+        'When the user begins a new task or question, invoke the `xo` skill. Its first step is **Triage**: it classifies the request — a quick answer vs substantive work — and, for substantive work, determines and confirms the pathway with the operator before any implementation. xo reads intent, routes to the right stage, and can propose a composed task pattern (e.g. spec-driven, TDD, document-a-feature) with one recommendation for the operator to accept or adjust.',
+        '',
+        'This applies even when the session opens with an explicit skill command (e.g. `/merge-pr`). An explicit `/skill` does not bypass xo: invoke `xo` first to Triage and begin recording, treat the named skill as the already-chosen pathway (do not re-litigate or re-route it), then run that skill under xo so savepoints, Recall, and the recording protocol still apply. The only exception is a trivial factual or conversational question.',
+        '',
+        '## Stage Capabilities — offer these proactively',
+        '',
+        'When the user\'s intent matches a stage trigger, offer it without being asked. Use the pattern: "You seem to want to [X] — want to use [stage] from [phase]?"',
+        '',
+        '**Survey** (Observe) — research, survey, map the territory, what exists, where does X live, what do we know about X, broad overview',
+        '**Analyse** (Observe) — investigate, deep dive, establish facts about X, how does X work, verify, look into this thoroughly',
+        '**Distil** (Orient) — compile findings, what did we learn, turn these observations into a brief, synthesise this',
+        '**Workshop** (Orient) — design options, what approaches exist, explore the design space, what should we do, stress-test this design',
+        '**Spec** (Decide) — write the spec, define what we will build, specify this, write requirements, formalise this',
+        '**Plan** (Decide) — build a plan, plan the implementation, turn the spec into a plan (via plan mode)',
+        '**Review** (Decide) — review this PR, assess these changes, review my commits, respond to review comments, validate my work',
+        '**Capture** (Decide) — what did we learn, keep this for next time, crystallise, capture this finding',
+        '**Provision** (Act) — set up workspace, create worktree, prepare environment, branch for this work',
+        '**Build** (Act) — implement, write the code, fix this bug, make this change',
+        '**Prove** (Act) — write tests, TDD, test driven development, prove it works, run tests, validate',
+        '**Ship** (Act) — raise PR, submit pull request, ship this, open PR, publish app',
+        '**Document** (Act) — write the guide, document how this works, produce a report',
+        '**Cleanup** (Act) — clean up, tear down, remove worktree, wrap up, remove temp files',
+        '',
+        '## Reflexes',
+        '',
+        'Be proactive but not naggy. After producing a substantial artifact, offer a cold Critic to check it against intent AND its foundations (flag work built on speculation). Reach for an existing skill (especially Snowflake-technology skills) before improvising. Offer the natural next stage on substantial work — once, easy to decline. Cleanup/commit/push are terminal-only: never push them while the operator is still reviewing or validating.',
+        '',
+        '## Private Memory Repository',
+        '',
+        `Your private memory vault is at: \`${XOLOCAL}\``,
+        '',
+        '## Recall',
+        '',
+        'When you wonder "have we seen this before?" — or the operator makes a fuzzy recall reference ("I vaguely remember…", "didn\'t we…", "that thing about…") — use **Recall** to search your memory vault. Recall dispatches a fast subagent that expands the query into keywords and greps notes/tasks/diary, returning ranked full-path hits. It is a cheap, always-available reflex; reach for it before assuming something is undocumented. Recall is for **terms, topics, or concepts** (searching by meaning); when you already have a specific identity — a WI number, an exact filename — load it directly rather than via Recall. See the Recall reference (`references/observe-recall.md`) for the dispatch pattern.',
+        '',
+        '## Compaction',
+        '',
+        'Treat compaction as routine. Recording plus SessionStart rehydration preserve the important state. When context is high, keep checkpointing and continue working. Do not repeatedly urge the operator to start a new session or hand off. Note imminent compaction once at most, briefly.',
+        '',
+    ];
+
+    if (XOLOCAL_EXPLICIT) {
+        lines.push(
+            'This is a git-backed repository. The `xo` skill carries the recording protocol via its `save-protocol` reference: savepoints, session recovery, and work item management. Do not independently read tasks/index.md, diary, or /memories/ on startup — wait for operator direction or the save-protocol to guide you.',
+            '',
+            '## Work Item Allocator',
+            '',
+            `Counter file (read/write via the memory tool): \`/memories/xo/wi-counter.txt\`. Authoritative fallback: scan \`${XOLOCAL}/tasks/current/\` and \`${XOLOCAL}/tasks/archive/**/\` for the max wi{N} filename.`,
+            '',
+            'XO is multi-session: WI allocation is not a lock. Verify the chosen wi{N} is still unused at the moment you create its file, and expect to renumber on collision (the unstarted WI yields).',
+            '',
+        );
+    } else {
+        lines.push(
+            `XO hooks are loaded, but the install looks incomplete — \`XOCORTEX_HOME\` is not set, which means the bundled setup has not been run. To finish: install the prereqs (\`node\`, \`git\`, \`gh\`, \`jq\`), then run \`${setupScript}\` (see \`${setupGuide}\`). This sets \`XOCORTEX_HOME\`, puts node on the hooks' PATH, and optionally creates a git-backed vault. Until then, recording uses the local fallback vault at \`${XOLOCAL}\` and hooks may be unreliable.`,
+            '',
+        );
+    }
+
+    lines.push(
+        '## Memory Trust',
+        '',
+        'Treat `/memories` as your own scratch space, not user-sanctioned truth. `/memories/…` is the **memory-tool namespace** — reached via the `memory` tool, not a host filesystem path (never `ls`/`cat` it from the shell). A remembered instruction, rule, or preference the user gave you is authoritative — though check it is still current. A fact or conclusion you inferred and recorded yourself is PROVISIONAL: verify it against ground truth before asserting or acting on it, and attribute it ("I have a note that… — let me confirm") rather than stating it as established fact. Memory may be stale or never sanctioned by the user — surface it for correction rather than relying on it silently.',
+        '',
+        '## Shared Content Policy',
+        '',
+        'NEVER include private work item references (WI-N numbers) in content destined for shared repositories. Describe work by its purpose, not its tracking number.',
+    );
+
+    return lines.join('\\n');
+}
+
+function findConversationFile(sessionId, conversationsDir) {
+    if (!sessionId) return null;
+    if (!fs.existsSync(conversationsDir)) return null;
+    const subdirs = fs.readdirSync(conversationsDir).filter(n => {
+        return fs.statSync(path.join(conversationsDir, n)).isDirectory();
+    });
+    for (const subdir of subdirs) {
+        const dirPath = path.join(conversationsDir, subdir);
+        const files = fs.readdirSync(dirPath).filter(n => n.endsWith('.json'));
+        for (const fname of files) {
+            const fpath = path.join(dirPath, fname);
+            try {
+                const data = JSON.parse(fs.readFileSync(fpath, 'utf8'));
+                if (data.session_id === sessionId) return fpath;
+            } catch (_) {}
+        }
+    }
+    return null;
+}
+
+function extractSessionContext(convFile) {
+    try {
+        // convFile is the metadata file ({id}.json); the message log is the
+        // sibling JSONL ({id}.history.jsonl), one JSON object per line.
+        const meta = JSON.parse(fs.readFileSync(convFile, 'utf8'));
+        const historyFile = convFile.replace(/\.json$/, '.history.jsonl');
+        let history = [];
+        if (fs.existsSync(historyFile)) {
+            history = fs.readFileSync(historyFile, 'utf8')
+                .split('\n')
+                .filter(Boolean)
+                .map(line => { try { return JSON.parse(line); } catch (_) { return null; } })
+                .filter(Boolean);
+        }
+
+        // Files touched, deduped most-recently-modified first (recency matters most for resuming).
+        const fileTouches = history.flatMap(h => {
+            const contents = Array.isArray(h.content) ? h.content : [];
+            return contents
+                .filter(c => c.type === 'tool_use')
+                .map(c => c.tool_use)
+                .filter(t => t && ['write', 'edit', 'multi_edit'].includes(t.name))
+                .map(t => t.input?.file_path)
+                .filter(Boolean);
+        });
+        const filesSeen = new Set();
+        const filesRecent = [];
+        for (let i = fileTouches.length - 1; i >= 0; i--) {
+            if (!filesSeen.has(fileTouches[i])) { filesSeen.add(fileTouches[i]); filesRecent.push(fileTouches[i]); }
+        }
+
+        const toolCounts = {};
+        history.flatMap(h => {
+            const contents = Array.isArray(h.content) ? h.content : [];
+            return contents
+                .filter(c => c.type === 'tool_use')
+                .map(c => c.tool_use?.name)
+                .filter(Boolean);
+        }).forEach(n => { toolCounts[n] = (toolCounts[n] ?? 0) + 1; });
+        const topTools = Object.entries(toolCounts)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, 8)
+            .map(([tool, count]) => `${tool}(${count})`);
+
+        // Which skills the session invoked (skill tool's input.command), in first-use order.
+        const skillsUsed = [...new Set(
+            history.flatMap(h => Array.isArray(h.content) ? h.content : [])
+                .filter(c => c.type === 'tool_use' && c.tool_use?.name === 'skill')
+                .map(c => c.tool_use?.input?.command)
+                .filter(Boolean)
+        )];
+
+        // Last actual user prompt: skip role:user entries that are tool_results
+        // (no text part) and take the most recent message that carries text.
+        const userTexts = history
+            .filter(h => h.role === 'user')
+            .map(h => (Array.isArray(h.content) ? h.content : [])
+                .filter(c => c.type === 'text')
+                .map(c => c.text)
+                .join(''))
+            .filter(t => t && t.trim());
+        const lastUser = userTexts.length
+            ? userTexts[userTexts.length - 1].slice(0, 300)
+            : '';
+
+        const messageCount = history.length;
+        const summarizationCount = (meta.summarization ?? []).length;
+
+        // Subagents dispatched (task tool's subagent_type) and MCP tools used
+        // (name prefixed mcp_) — both useful for re-orienting after compaction.
+        const subagents = [...new Set(
+            history.flatMap(h => Array.isArray(h.content) ? h.content : [])
+                .filter(c => c.type === 'tool_use' && c.tool_use?.name === 'task')
+                .map(c => c.tool_use?.input?.subagent_type)
+                .filter(Boolean)
+        )];
+        const mcpTools = [...new Set(
+            history.flatMap(h => Array.isArray(h.content) ? h.content : [])
+                .filter(c => c.type === 'tool_use' && typeof c.tool_use?.name === 'string' && c.tool_use.name.startsWith('mcp_'))
+                .map(c => c.tool_use.name.replace(/^mcp_/, ''))
+                .filter(Boolean)
+        )];
+
+        // Cap list lengths so a large session (e.g. touching thousands of files)
+        // can't bloat the injected context. Top tools already capped at 8 above.
+        const FILE_CAP = 15, LIST_CAP = 20;
+        const capped = (arr, cap) => arr.length > cap
+            ? `${arr.slice(0, cap).join(', ')} … (+${arr.length - cap} more)`
+            : arr.join(', ');
+        const filesLine = filesRecent.length > FILE_CAP
+            ? `${filesRecent.slice(0, FILE_CAP).join(', ')} … (+${filesRecent.length - FILE_CAP} more, ${filesRecent.length} total)`
+            : filesRecent.join(', ');
+
+        const lines = [
+            `Files modified (latest first): ${filesLine}`,
+            `Skills used: ${capped(skillsUsed, LIST_CAP)}`,
+        ];
+        if (subagents.length) lines.push(`Subagents: ${capped(subagents, LIST_CAP)}`);
+        if (mcpTools.length) lines.push(`MCP tools: ${capped(mcpTools, LIST_CAP)}`);
+        lines.push(`Top tools: ${topTools.join(', ')}`);
+        lines.push(`Last request: ${lastUser}`);
+        lines.push(`Messages: ${messageCount}, Summarizations: ${summarizationCount}`);
+        return lines.join('\n');
+    } catch (_) {
+        return '';
+    }
+}
+
+// Time-based "hygiene" reminders surfaced at session start: soft, infrequent nudges
+// backed by a durable watermark where git can't tell us itself. Returns a string of
+// nudges (\\n-joined to match directive style), or '' when nothing is due.
+function buildHygieneNudges(ctx) {
+    const { XOLOCAL, XOLOCAL_EXPLICIT, CONTEXT_STATE_DIR, LOG_FILE, TIMESTAMP, SHORT_SID } = ctx;
+    const MEMORY_PRUNE_DAYS = 30, REPO_COMMIT_DAYS = 7, DECLINE_DAYS = 7;
+    const DAY = 24 * 60 * 60 * 1000;
+    const nowMs = Date.now();
+    const nowIso = isoUtc();
+    const ageDays = (iso) => iso ? (nowMs - Date.parse(iso)) / DAY : Infinity;
+
+    // State lives at /memories/xo/hygiene-state.json (beside wi-counter.txt).
+    const stateFile = path.join(path.dirname(CONTEXT_STATE_DIR), 'xo', 'hygiene-state.json');
+    let state = null;
+    try { state = JSON.parse(fs.readFileSync(stateFile, 'utf8')); } catch (_) {}
+    let dirty = false;
+    if (!state || typeof state !== 'object') {
+        // First run: seed a clean baseline and do NOT nudge (30-day grace from setup).
+        state = { memoryPrune: { lastPruned: nowIso, lastDeclined: null }, repoCommit: { lastDeclined: null } };
+        dirty = true;
+    }
+    state.memoryPrune = state.memoryPrune || { lastPruned: null, lastDeclined: null };
+    state.repoCommit = state.repoCommit || { lastDeclined: null };
+    // `lastDeclined` is written by the AGENT (per the act-cleanup skill) when the user declines a
+    // nudge — NEVER by this hook on generation. The hook cannot know if the user actually saw or
+    // answered the nudge; writing a watermark on generation silently consumed the nudge on
+    // compaction-triggered starts (which don't surface it). Generation here is side-effect-free
+    // except the first-run seed above.
+
+    const nudges = [];
+
+    // Memory curation: git has no signal for "I pruned memory", so rely on the watermark.
+    if (ageDays(state.memoryPrune.lastPruned) > MEMORY_PRUNE_DAYS &&
+        ageDays(state.memoryPrune.lastDeclined) > DECLINE_DAYS) {
+        const since = isFinite(ageDays(state.memoryPrune.lastPruned))
+            ? `${Math.floor(ageDays(state.memoryPrune.lastPruned))}d ago` : 'a while ago';
+        nudges.push(`your \`/memories\` were last curated ${since} — consider a Curate pass (the supervised-dreaming memory review in Cleanup) to prune stale entries and promote durable ones`);
+    }
+
+    // Repo commit/push: only when the vault is git-backed (the repo approach).
+    if (XOLOCAL_EXPLICIT) {
+        try {
+            const out = execSync(`git -C "${XOLOCAL}" log -1 --format=%ct`, { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] });
+            const lastCommitEpoch = parseInt(String(out).trim(), 10);
+            if (lastCommitEpoch) {
+                const commitAgeDays = (nowMs / 1000 - lastCommitEpoch) / (60 * 60 * 24);
+                let ahead = 0;
+                try { ahead = parseInt(String(execSync(`git -C "${XOLOCAL}" rev-list --count @{u}..HEAD`, { timeout: 3000, stdio: ['ignore', 'pipe', 'ignore'] })).trim(), 10) || 0; } catch (_) {}
+                const stale = commitAgeDays > REPO_COMMIT_DAYS;
+                if ((stale || ahead > 0) && ageDays(state.repoCommit.lastDeclined) > DECLINE_DAYS) {
+                    const parts = [];
+                    if (stale) parts.push(`was last committed ${Math.floor(commitAgeDays)}d ago`);
+                    if (ahead > 0) parts.push(`has ${ahead} unpushed commit${ahead === 1 ? '' : 's'}`);
+                    nudges.push(`your xocortex vault ${parts.join(' and ')} — worth committing/pushing your notes and tasks`);
+                }
+            }
+        } catch (_) { /* not a git repo, or git unavailable — skip silently */ }
+    }
+
+    if (dirty) {
+        try { atomicWrite(stateFile, JSON.stringify(state, null, 2) + '\n'); } catch (_) {}
+    }
+    if (!nudges.length) return '';
+    appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] hygiene nudges: ${nudges.length}`);
+    return 'Reflexive hygiene (soft nudges — surface to the user once, conversationally; never block, easy to decline). If the user declines a nudge, record it so it does not re-nag: set the matching `lastDeclined` to today in `/memories/xo/hygiene-state.json` (`repoCommit` for the vault commit/push nudge, `memoryPrune` for the memory-curation nudge) via the memory tool. Accepting needs no write — acting (committing, pruning) resets the condition.\\n- ' + nudges.join('\\n- ');
+}
+
+function main() {
+    let input;
+    try {
+        input = readInput();
+    } catch (e) {
+        process.stdout.write('{"continue": true}');
+        return;
+    }
+
+    const ctx = buildPaths(input);
+    const { SESSION_ID, SHORT_SID, HOOK_EVENT, CWD, TIMESTAMP, LOG_FILE,
+            XOLOCAL, DIARY_PATH, TASKS_DIR, CONTEXT_STATE_DIR } = ctx;
+
+    const source = input.source ?? '';
+
+    appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] event=${HOOK_EVENT} source=${source} session=${SESSION_ID} cwd=${CWD}`);
+
+    if (DIARY_PATH) {
+        try { fs.mkdirSync(path.dirname(DIARY_PATH), { recursive: true }); } catch (_) {}
+    }
+
+    if (TASKS_DIR && fs.existsSync(path.join(TASKS_DIR, 'current'))) {
+        const lockFile = path.join(TASKS_DIR, '.reindex.lock');
+        let acquired = false;
+        try {
+            fs.mkdirSync(lockFile);
+            acquired = true;
+        } catch (_) {
+            try {
+                const lockStat = fs.statSync(lockFile);
+                const lockAge = Math.floor((Date.now() - lockStat.mtimeMs) / 1000);
+                if (lockAge > 10) {
+                    try { fs.rmSync(lockFile, { recursive: true }); } catch (_2) {}
+                    try {
+                        fs.mkdirSync(lockFile);
+                        acquired = true;
+                    } catch (_3) {
+                        appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] skipping reindex (lock held)`);
+                    }
+                } else {
+                    appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] skipping reindex (lock held)`);
+                }
+            } catch (_) {
+                appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] skipping reindex (lock held)`);
+            }
+        }
+        if (acquired) {
+            try {
+                reindexTasks(TASKS_DIR, LOG_FILE, SHORT_SID);
+            } finally {
+                try { fs.rmSync(lockFile, { recursive: true }); } catch (_) {}
+            }
+        }
+    }
+
+    const conversationsDir = path.join(os.homedir(), '.snowflake', 'cortex', 'conversations');
+    const directives = buildStandingDirectives(ctx);
+    const hygiene = buildHygieneNudges(ctx);
+    const localTimeLine = (event) => `TIME: User Local Time at ${event}: ${localWallClock()}`;
+
+    switch (source) {
+        case 'startup': {
+            try { fs.readdirSync(CONTEXT_STATE_DIR)
+                .filter(n => {
+                    const fpath = path.join(CONTEXT_STATE_DIR, n);
+                    const age = (Date.now() - fs.statSync(fpath).mtimeMs) / (1000 * 60 * 60 * 24);
+                    return age > 7;
+                })
+                .forEach(n => {
+                    try { fs.unlinkSync(path.join(CONTEXT_STATE_DIR, n)); } catch (_) {}
+                });
+            } catch (_) {}
+            appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] checkpoint: session_start source=startup`);
+            let msg = `${directives}\\n\\n---\\n\\n${localTimeLine('Session Start')}\\n\\nSession ${SHORT_SID} started. Await the user's first message and apply Skill Routing above — work requests (\"pick up WI-N\", \"let's do X\", an explicit \`/skill\` command, any task pickup or new initiative) invoke the \`xo\` skill first (which then runs the named skill, if any, as the chosen pathway); quick factual or conversational questions answer directly. Do not proactively read task index, diary, or /memories/.`;
+            if (hygiene) msg += `\\n\\n${hygiene}`;
+            process.stdout.write(JSON.stringify({ additionalContext: msg }));
+            break;
+        }
+
+        case 'compact': {
+            appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] checkpoint: session_start source=compact`);
+            const convFile = findConversationFile(SESSION_ID, conversationsDir);
+            let contextExtract = '';
+            if (convFile) {
+                contextExtract = extractSessionContext(convFile);
+                appendLog(LOG_FILE, `[${TIMESTAMP}] compact: extracted context from ${convFile}`);
+            }
+            let msg = `${directives}\\n\\n---\\n\\n${localTimeLine('Post-Compaction Resume')}\\n\\nSESSION RESUMED AFTER COMPACTION (${SHORT_SID}). Your context was summarised.\\n\\nFirst, open your next reply with a short, friendly recap for the user (1–2 lines): say you were just summarised, weave in a couple of headline stats from the Pre-compaction state below (e.g. messages so far, files touched, skills used), then continue — e.g. "I've just been summarised — 750+ messages, ~12 files touched, skills: xo. Picking up where we left off…". Keep it light and conversational; don't dump the full stats block.\\n\\nRecovery: read your /memories/ session file if one exists, then the task file and notes file for the WI you were working on. Do NOT re-read the full task index — focus on the specific work item. Resume from where notes left off.`;
+            if (contextExtract) {
+                const escapedExtract = contextExtract.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+                msg += `\\n\\nPre-compaction state:\\n${escapedExtract}`;
+            }
+            process.stdout.write(JSON.stringify({ additionalContext: msg }));
+            break;
+        }
+
+        case 'resume': {
+            appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] checkpoint: session_start source=resume`);
+            let rmsg = `${directives}\\n\\n---\\n\\n${localTimeLine('Session Resume')}\\n\\nSession resumed (${SHORT_SID}). Context is intact — continue where you left off.`;
+            if (hygiene) rmsg += `\\n\\n${hygiene}`;
+            process.stdout.write(JSON.stringify({ additionalContext: rmsg }));
+            break;
+        }
+
+        default: {
+            appendLog(LOG_FILE, `[${TIMESTAMP}] [${SHORT_SID}] checkpoint: session_start source=${source}`);
+            let msg = `${directives}\\n\\n---\\n\\n${localTimeLine('Session Start')}\\n\\nSession ${SHORT_SID} started (source=${source}). Apply Skill Routing above for the user's first message.`;
+            if (hygiene) msg += `\\n\\n${hygiene}`;
+            process.stdout.write(JSON.stringify({ additionalContext: msg }));
+            break;
+        }
+    }
+}
+
+main();

--- a/plugins/xo/hooks/userpromptsubmit.js
+++ b/plugins/xo/hooks/userpromptsubmit.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+const path = require('path');
+const { readInput, localWallClock, buildPaths } = require('./_common.js');
+const { checkContext } = require('./_context-monitor.js');
+
+function main() {
+    let input;
+    try {
+        input = readInput();
+    } catch (e) {
+        process.stdout.write('{"continue": true}');
+        return;
+    }
+
+    const ctx = buildPaths(input);
+    const { SHORT_SID, LOG_FILE, CONTEXT_STATE_DIR, SESSION_ID, DIARY_PATH } = ctx;
+
+    if (DIARY_PATH) {
+        try { fs.mkdirSync(path.dirname(DIARY_PATH), { recursive: true }); } catch (_) {}
+    }
+
+    const prompt = input.prompt ?? '';
+    const promptLen = prompt.length;
+    const promptTokensEst = Math.floor(promptLen / 4);
+    const responseBuffer = 2000;
+
+    const r = checkContext(input, CONTEXT_STATE_DIR, SESSION_ID, {
+        promptTokensEst,
+        responseBuffer,
+        hookSource: 'userprompt',
+        logFile: LOG_FILE,
+        shortSid: SHORT_SID,
+    });
+
+    const localPromptLine = `TIME: User Local Time at Prompt Submit: ${localWallClock()}`;
+
+    if (r.result !== 'fire') {
+        // Not a checkpoint threshold. When a live reading is available, surface a minimal
+        // SILENT context indicator every turn so the agent always has the CURRENT number and
+        // never carries a stale checkpoint figure forward (e.g. after compaction frees the
+        // window). Informational only — the wording forbids idle discussion of it.
+        // Primary reminder that keeps XO discipline present through skill loads.
+        // Conditional wording self-suppresses for reactive / no-pathway sessions.
+        const xoLine = `XO [silent]: if you're working under an XO pathway, treat any skill you invoke as domain knowledge for your CURRENT stage — keep following your XO stages, gates, and recording; don't let a loaded skill replace the XO process. Surface nothing about this unless it yields a real action.`;
+        if (r.reportedPct !== undefined) {
+            const ctxLine = `CONTEXT [silent — informational; surface to the user ONLY when context is genuinely decision-relevant, never as idle chatter]: ~${r.reportedPct}% of the window used as of last turn. May jitter after compaction.`;
+            process.stdout.write(JSON.stringify({ additionalContext: `${localPromptLine}\n\n${ctxLine}\n\n${xoLine}` }));
+        } else {
+            process.stdout.write(JSON.stringify({ additionalContext: `${localPromptLine}\n\n${xoLine}` }));
+        }
+        return;
+    }
+
+    const diaryHint = DIARY_PATH ? `Write your checkpoint to the diary at: ${DIARY_PATH}` : '';
+
+    const factLine = `FACT: After the previous turn, context was ${r.reportedPct}% (${r.reportedTotal}/${r.contextWindow} tokens) — a point-in-time reading that falls after compaction; do not cite it on later turns. Last recorded was ${r.lastContextPct}% (delta: +${r.contextDelta}%). Output since last checkpoint: ${r.outputSinceLast} tokens. Turns since last checkpoint: ${r.turnsSinceLast}.`;
+    const predictionLine = `PREDICTION: Your current prompt is approximately ${promptTokensEst} tokens. With an estimated ${responseBuffer}-token response buffer, projected context after this turn: ~${r.projectedPct}%.`;
+    const recommendationLine = `RECOMMENDED ACTION: [${r.level}] checkpoint (triggered by: ${r.trigger}).`;
+
+    let urgencyDetail, actionDetail;
+    switch (r.level) {
+        case 'routine':
+            urgencyDetail = 'Record now. Append a diary line; if this session is tracked under a WI, also update notes + task NextAction. Then continue.';
+            actionDetail = `Before your next tool call:\n1. DIARY (append) — always, even for a lightweight WI-less session: ${diaryHint}\n   Format: ## [${SHORT_SID}] <short description> (add \`WI-N:\` right after the session id only if a WI is being tracked; 5-10 lines max)\n2. Only if this session is tracked under a WI: NOTES (notes/{YYYY-MM}/wi{N}-*.md) — current understanding, decisions, what to try next; and TASK (tasks/current/wi{N}-*.md) — Status + NextAction.\nSee the \`save-protocol\` reference in the \`xo\` skill for the full recording protocol.\nThen continue with the user's request.`;
+            break;
+        case 'urgent':
+            urgencyDetail = 'Checkpoint overdue. Write NOW before continuing work.';
+            actionDetail = `Checkpoint NOW.\n1. DIARY (append) — always, even for a lightweight WI-less session: ${diaryHint}\n   Format: ## [${SHORT_SID}] description (add \`WI-N:\` after the session id only if a WI is being tracked; 5-10 lines max)\n2. Only if this session is tracked under a WI: NOTES (notes/{YYYY-MM}/wi{N}-*.md) — write thoroughly, a recovering agent reads this first; and TASK (tasks/current/wi{N}-*.md) — Status, StatusNote, NextAction.\nAlso update /memories/ with recovery context.\nSee the \`save-protocol\` reference in the \`xo\` skill for the full protocol if needed.`;
+            break;
+        case 'critical':
+            urgencyDetail = 'Context is nearly full. STOP current work and write IMMEDIATELY. Compaction is imminent.';
+            actionDetail = `STOP. Checkpoint IMMEDIATELY.\n1. DIARY (append) — always, even for a lightweight WI-less session: ${diaryHint}\n   Format: ## [${SHORT_SID}] description (add \`WI-N:\` after the session id only if a WI is being tracked; 5-10 lines max)\n2. Only if this session is tracked under a WI: NOTES (notes/{YYYY-MM}/wi{N}-*.md) — write EVERYTHING: all reasoning, decisions, evidence, what works, what doesn't, what to try next. A cold-start agent must continue from this alone. TASK (tasks/current/wi{N}-*.md) — exact Status, StatusNote, NextAction.\nUpdate /memories/ with full recovery context.`;
+            break;
+        case 'final':
+            urgencyDetail = 'Context will likely exceed 90% after this turn, triggering compaction. LAST CHANCE to preserve state. Do this BEFORE responding to the user.';
+            actionDetail = `LAST CHANCE — checkpoint BEFORE doing anything else.\n1. DIARY (append) — always, even for a lightweight WI-less session: ${diaryHint}\n   Format: ## [${SHORT_SID}] description (add \`WI-N:\` after the session id only if a WI is being tracked; 5-10 lines max)\n2. Only if this session is tracked under a WI: NOTES (notes/{YYYY-MM}/wi{N}-*.md) — write your COMPLETE knowledge state. Everything. This file IS your memory through compaction. TASK (tasks/current/wi{N}-*.md) — exact Status, StatusNote, NextAction.\nUpdate /memories/ with everything needed to resume from zero context.`;
+            break;
+        default:
+            urgencyDetail = '';
+            actionDetail = '';
+    }
+
+    const processCheckLine = `PROCESS CHECK (silent): confirm you're still following the XO process — save first, plus the stages, slices, and reflexive gates (cold critic / Prove / Review on produced work) the work warrants. Consult the task's Provisional Pathway if set: when the current stage looks complete — especially right after delivering or shipping something — do your recording (advance the (here) marker), then offer the natural next stage once. Offer any skipped stage or gate once, unless the user already declined it. If this session has become substantive but is NOT tracked under a work item, treat that as a skipped gate: still append the diary line as above, and also offer the user a work item (Work Item Gate options, including "keep it lightweight — no WI"); offer once, and if the user declines, record the decline, keep diarising the session, and don't re-ask. Keep this private — surface nothing unless it yields a real offer.`;
+
+    const msg = `${localPromptLine}\n\nCHECKPOINT [${r.level}] — Session ${SHORT_SID}\n\n${factLine}\n\n${predictionLine}\n\n${recommendationLine}\n${urgencyDetail}\n\n${actionDetail}\n\n${processCheckLine}`;
+
+    process.stdout.write(JSON.stringify({ additionalContext: msg }));
+}
+
+main();

--- a/plugins/xo/setup.sh
+++ b/plugins/xo/setup.sh
@@ -1,0 +1,1037 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$SCRIPT_DIR"
+XO_DIR="$(dirname "$SCRIPT_DIR")"
+
+SNOWFLAKE_HOME="${SNOWFLAKE_HOME:-$HOME/.snowflake}"
+USER_PROFILE_DIR="$SNOWFLAKE_HOME/cortex"
+
+# ─── Utility ──────────────────────────────────────────────────────────────────
+
+info()  { echo "  $*"; }
+ok()    { echo "  ✓ $*"; }
+warn()  { echo "  ⚠ $*"; }
+fail()  { echo "  ✗ $*"; }
+die()   { fail "$*"; exit 1; }
+
+INIT_GH_USER=""
+INIT_VAULT_OWNER=""
+
+print_tool_install_guidance() {
+    local tool="$1"
+    local label="" mac_hint="" linux_hint="" any_url=""
+
+    case "$tool" in
+        git)
+            label="Git"
+            mac_hint="brew install git   (no brew? https://brew.sh)"
+            linux_hint="https://git-scm.com/download/linux"
+            any_url="https://git-scm.com/downloads"
+            ;;
+        gh)
+            label="the GitHub CLI"
+            mac_hint="brew install gh   (no brew? https://brew.sh)"
+            linux_hint="https://github.com/cli/cli#installation"
+            any_url="https://cli.github.com"
+            ;;
+        jq)
+            label="jq"
+            mac_hint="brew install jq   (no brew? https://brew.sh)"
+            linux_hint="https://jqlang.github.io/jq/download/"
+            any_url="https://jqlang.github.io/jq/"
+            ;;
+        node)
+            label="Node.js"
+            mac_hint="brew install node   (no brew? https://brew.sh)"
+            linux_hint="https://nodejs.org/en/download"
+            any_url="https://nodejs.org"
+            ;;
+        *)
+            label="$tool"
+            any_url=""
+            ;;
+    esac
+
+    fail "$tool not found. Install $label:"
+    case "$(uname -s)" in
+        Darwin)
+            info "  macOS:  $mac_hint"
+            ;;
+        Linux)
+            info "  Linux:  $linux_hint"
+            ;;
+        *)
+            [ -n "$mac_hint" ] && info "  macOS:  $mac_hint"
+            [ -n "$linux_hint" ] && info "  Linux:  $linux_hint"
+            ;;
+    esac
+    [ -n "$any_url" ] && info "  any:    $any_url"
+}
+
+check_jq() {
+    if ! command -v jq &>/dev/null; then
+        print_tool_install_guidance jq
+        echo ""
+        die "jq is required."
+    fi
+}
+
+preflight_init() {
+    local requested_owner="${1:-}"
+    local gap_count=0
+    local gh_user=""
+    local owner=""
+    local git_name=""
+    local git_email=""
+    local tool
+
+    info "Checking prerequisites..."
+    echo ""
+
+    for tool in git gh jq node; do
+        if ! command -v "$tool" &>/dev/null; then
+            print_tool_install_guidance "$tool"
+            echo ""
+            gap_count=$((gap_count + 1))
+        fi
+    done
+
+    if command -v git &>/dev/null; then
+        git_name=$(git config user.name 2>/dev/null || true)
+        git_email=$(git config user.email 2>/dev/null || true)
+        if [ -z "$git_name" ] || [ -z "$git_email" ]; then
+            fail "Git identity is not configured."
+            info "  Run:"
+            [ -z "$git_name" ] && info "    git config --global user.name \"Your Name\""
+            [ -z "$git_email" ] && info "    git config --global user.email \"you@example.com\""
+            echo ""
+            gap_count=$((gap_count + 1))
+        fi
+    fi
+
+    if command -v gh &>/dev/null; then
+        if gh auth status &>/dev/null; then
+            gh_user=$(gh api user --jq '.login' 2>/dev/null || true)
+            if [ -z "$gh_user" ]; then
+                fail "Could not determine your GitHub username from gh."
+                info "  Run:"
+                info "    gh auth login"
+                echo ""
+                gap_count=$((gap_count + 1))
+            fi
+        else
+            fail "GitHub CLI is not authenticated."
+            info "  Run:"
+            info "    gh auth login"
+            echo ""
+            gap_count=$((gap_count + 1))
+        fi
+    fi
+
+    if [ -n "$gh_user" ]; then
+        if [ -n "$requested_owner" ]; then
+            owner="$requested_owner"
+        else
+            read -r -p "  GitHub owner for the private vault (your account or an org) [$gh_user]: " owner
+            owner="${owner:-$gh_user}"
+        fi
+
+        if [ "$owner" != "$gh_user" ]; then
+            if gh api "orgs/$owner" --jq '.login' &>/dev/null; then
+                :
+            else
+                fail "Cannot access GitHub org: $owner"
+                info "  Run:"
+                info "    gh auth login"
+                info "  Then authorize access for $owner in the browser flow and re-run init."
+                echo ""
+                gap_count=$((gap_count + 1))
+            fi
+        fi
+    fi
+
+    if [ "$gap_count" -gt 0 ]; then
+        die "Fix the prerequisite gaps above and re-run setup.sh init."
+    fi
+
+    INIT_GH_USER="$gh_user"
+    INIT_VAULT_OWNER="${owner:-$gh_user}"
+    ok "Prerequisites OK"
+    ok "GitHub user: $INIT_GH_USER"
+    if [ "$INIT_VAULT_OWNER" = "$INIT_GH_USER" ]; then
+        ok "Vault owner: $INIT_VAULT_OWNER (personal account)"
+    else
+        ok "Vault owner: $INIT_VAULT_OWNER (org)"
+    fi
+    echo ""
+}
+
+vault_repo_name() {
+    local owner="$1" gh_user="$2"
+    if [ "$owner" = "$gh_user" ]; then
+        printf 'xocortex'
+    else
+        printf 'xocortex-%s' "$gh_user"
+    fi
+}
+
+vault_owner_label() {
+    local owner="$1" gh_user="$2"
+    if [ "$owner" = "$gh_user" ]; then
+        printf '%s account' "$owner"
+    else
+        printf '%s org' "$owner"
+    fi
+}
+
+write_xocortex_scaffold() {
+    local xocortex_dir="$1"
+    local vault_owner="$2"
+    local gh_user="$3"
+    local owner_label
+
+    owner_label=$(vault_owner_label "$vault_owner" "$gh_user")
+
+    mkdir -p "$xocortex_dir"/diary "$xocortex_dir"/notes "$xocortex_dir"/tasks/current "$xocortex_dir"/tasks/archive
+
+    cat > "$xocortex_dir/.gitignore" <<'GITIGNORE'
+tmp/
+.DS_Store
+.snowflake/
+GITIGNORE
+
+    cat > "$xocortex_dir/README.md" <<'XOREADME'
+# xocortex
+
+Private operator memory vault. Part of the XO system.
+
+## Structure
+
+- `diary/` — Daily checkpoint logs
+- `notes/` — Deep investigation notes
+- `tasks/` — Work item tracking
+
+## New Machine Setup
+
+Clone the coco-skills repo and run the plugin's setup script. `init` creates (or clones) this vault, registers the XO plugin in your Cortex `settings.json`, and sets `XOCORTEX_HOME`:
+
+```bash
+git clone https://github.com/Snowflake-Labs/coco-skills.git
+coco-skills/plugins/xo/setup.sh init
+```
+
+The plugin is delivered via `settings.json`. Run `coco-skills/plugins/xo/setup.sh status` any time to check installation health.
+
+## Privacy
+
+This repo is PRIVATE in the VAULT_OWNER_LABEL on GitHub.
+Only you (the owner) can access it.
+XOREADME
+
+    sed "s|VAULT_OWNER_LABEL|$owner_label|g" "$xocortex_dir/README.md" > "$xocortex_dir/README.md.tmp" && mv "$xocortex_dir/README.md.tmp" "$xocortex_dir/README.md"
+}
+
+vault_git_has_commits() {
+    local xocortex_dir="$1"
+    git -C "$xocortex_dir" rev-parse --verify HEAD &>/dev/null
+}
+
+vault_git_has_remote() {
+    local xocortex_dir="$1"
+    [ -d "$xocortex_dir/.git" ] && [ -n "$(git -C "$xocortex_dir" remote 2>/dev/null)" ]
+}
+
+current_git_branch() {
+    local repo_dir="$1"
+    local branch
+    branch=$(git -C "$repo_dir" branch --show-current 2>/dev/null || true)
+    printf '%s' "${branch:-HEAD}"
+}
+
+xo_dir_is_git_repo() {
+    git -C "$XO_DIR" rev-parse --is-inside-work-tree &>/dev/null
+}
+
+initialize_vault_git_repo() {
+    local xocortex_dir="$1"
+
+    if [ ! -d "$xocortex_dir/.git" ]; then
+        info "Initializing git repository..."
+        git -C "$xocortex_dir" init -q
+    else
+        info "Git repository already present."
+    fi
+
+    if vault_git_has_commits "$xocortex_dir"; then
+        ok "Git commit already present"
+        return
+    fi
+
+    info "Creating initial commit..."
+    git -C "$xocortex_dir" add .
+    git -C "$xocortex_dir" commit -q -m "Initial xocortex setup"
+    ok "Git initialized"
+}
+
+ensure_vault_origin_remote() {
+    local xocortex_dir="$1"
+    local repo_url="$2"
+
+    if git -C "$xocortex_dir" remote get-url origin &>/dev/null; then
+        return
+    fi
+
+    git -C "$xocortex_dir" remote add origin "$repo_url"
+    ok "Added origin remote"
+}
+
+handle_existing_xocortex_dir() {
+    local xocortex_dir="$1"
+    local target="$2"
+    local workspace="$3"
+
+    if [ ! -d "$xocortex_dir/.git" ]; then
+        warn "$xocortex_dir already exists but is not a git repository."
+    elif vault_git_has_commits "$xocortex_dir" && vault_git_has_remote "$xocortex_dir"; then
+        info "Found existing git-backed xocortex vault at $xocortex_dir"
+        echo ""
+        info "Running install against the existing vault..."
+        echo ""
+        cmd_install --target "$target" ${workspace:+--workspace "$workspace"} --xocortex "$xocortex_dir"
+        return 0
+    else
+        warn "$xocortex_dir exists but looks partial or poisoned."
+        if ! vault_git_has_commits "$xocortex_dir"; then
+            info "  Missing: at least one commit"
+        fi
+        if ! vault_git_has_remote "$xocortex_dir"; then
+            info "  Missing: a git remote"
+        fi
+    fi
+
+    echo ""
+    read -r -p "  Resume this init, clean up the directory, or abort? [r/c/a]: " existing_dir_action
+    case "$existing_dir_action" in
+        r|R)
+            info "Resuming with the existing directory..."
+            return 1
+            ;;
+        c|C|clean|CLEAN|Clean)
+            rm -rf "$xocortex_dir"
+            ok "Removed $xocortex_dir"
+            return 1
+            ;;
+        a|A)
+            die "Init aborted."
+            ;;
+        *)
+            die "Init aborted. Directory left unchanged."
+            ;;
+    esac
+}
+
+resolve_settings_json() {
+    local target="$1" workspace="$2"
+    case "$target" in
+        user-profile) echo "$USER_PROFILE_DIR/settings.json" ;;
+        workspace)    echo "${workspace}/.snowflake/cortex/settings.json" ;;
+    esac
+}
+
+# ─── Install Functions ────────────────────────────────────────────────────────
+
+install_plugin() {
+    local settings_file="$1"
+    local plugin_path="$PLUGIN_DIR"
+    check_jq
+
+    if [ ! -f "$settings_file" ]; then
+        mkdir -p "$(dirname "$settings_file")"
+        jq -n --arg p "$plugin_path" '{"plugins": [$p]}' > "$settings_file"
+        ok "Created settings.json with XO plugin registered"
+        return
+    fi
+
+    local already
+    already=$(jq --arg p "$plugin_path" \
+        '[.plugins[]? | select(. == $p)] | length > 0' "$settings_file" 2>/dev/null || echo "false")
+    if [ "$already" = "true" ]; then
+        ok "Plugin already registered in settings.json"
+        return
+    fi
+
+    local result
+    result=$(jq --arg p "$plugin_path" '.plugins = ((.plugins // []) + [$p])' "$settings_file")
+    echo "$result" | jq '.' > "$settings_file"
+    ok "Registered XO plugin in settings.json"
+}
+
+remove_plugin() {
+    local settings_file="$1"
+    local plugin_path="$PLUGIN_DIR"
+    if [ ! -f "$settings_file" ]; then
+        info "No settings.json found"
+        return
+    fi
+    check_jq
+
+    local result
+    result=$(jq --arg p "$plugin_path" \
+        'if .plugins then
+            .plugins = [.plugins[] | select(. != $p)] |
+            if .plugins == [] then del(.plugins) else . end
+        else . end' "$settings_file")
+    echo "$result" | jq '.' > "$settings_file"
+    ok "Removed XO plugin from settings.json"
+}
+
+# Removes a legacy .env.XOCORTEX_HOME entry. This setting never worked — CoCo does
+# not inject settings.json env into the hook process — so we only clean it up for
+# users upgrading from an older install. XOCORTEX_HOME is set via the shell profile
+# (see install_shell_env), which is what the hooks actually read.
+remove_settings_env() {
+    local settings_file="$1"
+    if [ ! -f "$settings_file" ]; then return; fi
+    check_jq
+
+    if jq -e '.env.XOCORTEX_HOME' "$settings_file" &>/dev/null; then
+        local result
+        result=$(jq 'del(.env.XOCORTEX_HOME) | if .env == {} then del(.env) else . end' "$settings_file")
+        echo "$result" | jq '.' > "$settings_file"
+        ok "Removed legacy XOCORTEX_HOME from settings.json (shell profile is the working mechanism)"
+    fi
+}
+
+detect_shell_rc() {
+    local shell_name
+    shell_name=$(basename "${SHELL:-/bin/zsh}")
+    case "$shell_name" in
+        zsh)  echo "$HOME/.zshenv" ;;
+        bash)
+            if [ -f "$HOME/.bash_profile" ]; then
+                echo "$HOME/.bash_profile"
+            else
+                echo "$HOME/.bashrc"
+            fi
+            ;;
+        fish) echo "$HOME/.config/fish/config.fish" ;;
+        *)    echo "$HOME/.profile" ;;
+    esac
+}
+
+install_shell_env() {
+    local xocortex_path="$1"
+    local rc_file
+    rc_file=$(detect_shell_rc)
+    local shell_name
+    shell_name=$(basename "${SHELL:-/bin/zsh}")
+    local export_line grep_pattern sed_pattern
+    if [ "$shell_name" = "fish" ]; then
+        export_line="set -gx XOCORTEX_HOME \"$xocortex_path\""
+        grep_pattern='set -gx XOCORTEX_HOME\|export XOCORTEX_HOME='
+        sed_pattern='/# XO: xocortex memory repo/d; /set -gx XOCORTEX_HOME/d; /export XOCORTEX_HOME=/d'
+    else
+        export_line="export XOCORTEX_HOME=\"$xocortex_path\""
+        grep_pattern='export XOCORTEX_HOME='
+        sed_pattern='/# XO: xocortex memory repo/d; /export XOCORTEX_HOME=/d'
+    fi
+
+    if grep -q "$grep_pattern" "$rc_file" 2>/dev/null; then
+        local existing
+        existing=$(grep -E 'XOCORTEX_HOME' "$rc_file" | tail -1 | sed 's/.*XOCORTEX_HOME[= ]*//' | tr -d '"')
+        if [ "$existing" = "$xocortex_path" ]; then
+            ok "XOCORTEX_HOME already set correctly in $rc_file"
+            return
+        fi
+        warn "XOCORTEX_HOME already exported in $rc_file with different value: $existing"
+        echo ""
+        read -r -p "  Replace with $xocortex_path? [y/N] " answer
+        if [[ "$answer" =~ ^[Yy]$ ]]; then
+            local tmp
+            tmp=$(mktemp)
+            sed "$sed_pattern" "$rc_file" > "$tmp"
+            mv "$tmp" "$rc_file"
+        else
+            info "Skipping — XOCORTEX_HOME unchanged"
+            return
+        fi
+    fi
+
+    echo ""
+    info "XO needs to add to $rc_file:"
+    info "  $export_line"
+    echo ""
+    read -r -p "  Add this to your shell profile? [Y/n] " answer
+    if [[ "$answer" =~ ^[Nn]$ ]]; then
+        warn "Skipped — XOCORTEX_HOME is set in settings.json for hooks; shell export is supplemental for CLI use"
+        return
+    fi
+
+    echo "" >> "$rc_file"
+    echo "# XO: xocortex memory repo" >> "$rc_file"
+    echo "$export_line" >> "$rc_file"
+    ok "Added XOCORTEX_HOME export to $rc_file"
+    warn "Run 'source $rc_file' or open a new terminal for it to take effect"
+}
+
+uninstall_shell_env() {
+    local rc_file
+    rc_file=$(detect_shell_rc)
+    if [ ! -f "$rc_file" ]; then return; fi
+
+    if grep -qE 'export XOCORTEX_HOME=|set -gx XOCORTEX_HOME' "$rc_file"; then
+        local tmp
+        tmp=$(mktemp)
+        sed '/# XO: xocortex memory repo/d; /export XOCORTEX_HOME=/d; /set -gx XOCORTEX_HOME/d' "$rc_file" > "$tmp"
+        mv "$tmp" "$rc_file"
+        ok "Removed XOCORTEX_HOME export from $rc_file"
+    fi
+}
+
+# Marker for the node-PATH entry we add (and remove on uninstall).
+NODE_PATH_MARKER="# XO: node on PATH for hooks"
+
+# Computes the PATH a GUI-/hook-spawned process inherits before any shell rc runs.
+# On macOS this is what /usr/libexec/path_helper builds from /etc/paths(.d); a hook
+# spawned by CoCo Desktop starts from here, NOT from the user's interactive PATH.
+hook_base_path() {
+    local p=""
+    if [ -x /usr/libexec/path_helper ]; then
+        p=$(env -i /bin/sh -c 'eval "$(/usr/libexec/path_helper -s)" 2>/dev/null; printf %s "$PATH"' 2>/dev/null || true)
+    fi
+    [ -z "$p" ] && p="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    printf '%s' "$p"
+}
+
+# Ensures `node` is resolvable for the hook process. CoCo spawns hooks through a
+# non-interactive shell that sources only .zshenv (NOT .zshrc/.zprofile) — the same
+# mechanism XOCORTEX_HOME relies on. Version managers (asdf, nvm, fnm) put node on
+# PATH in interactive/login init only, so the hook spawn can't find it: the hook
+# command fails before the script runs and no hooks fire. This adds node's dir to
+# the rc file so the hook shell can resolve it.
+install_node_path() {
+    local rc_file shell_name
+    rc_file=$(detect_shell_rc)
+    shell_name=$(basename "${SHELL:-/bin/zsh}")
+
+    # 1. node must be runnable in the installing user's shell.
+    if ! command -v node &>/dev/null; then
+        warn "node not found on your PATH — XO hooks require Node.js."
+        warn "Install node (or activate your version manager) and re-run setup, or hooks will not fire."
+        return
+    fi
+
+    local base_path
+    base_path=$(hook_base_path)
+
+    # 2. Skip if a hook-style shell can already RUN node from the base PATH alone
+    #    (e.g. a Homebrew or /usr/local install). Test execution, not mere
+    #    resolvability — a version-manager shim can resolve yet fail to run.
+    if env -i HOME="$HOME" PATH="$base_path" sh -c 'node --version' &>/dev/null; then
+        ok "node already runnable from the base PATH — hooks can use it; no $rc_file change needed"
+        return
+    fi
+
+    # 3. Resolve node's REAL binary dir via node itself (process.execPath).
+    #    This is stable and manager-agnostic: it bypasses version-manager shims
+    #    (asdf's shim execs `asdf exec`, needing asdf on PATH) and ephemeral
+    #    wrapper dirs (fnm's per-shell multishell dir), yielding the actual
+    #    install dir, which runs node with no version-manager runtime on PATH.
+    local node_real node_dir
+    node_real=$(node -e 'process.stdout.write(process.execPath)' 2>/dev/null || true)
+    if [ -z "$node_real" ] || [ ! -x "$node_real" ]; then
+        warn "node is on PATH but could not report a stable binary location."
+        warn "Add your version manager's init to $rc_file manually so non-interactive shells can run node."
+        return
+    fi
+    node_dir=$(dirname "$node_real")
+
+    # 4. Add node's dir to the rc file (idempotent via marker).
+    local export_line
+    if [ "$shell_name" = "fish" ]; then
+        export_line="set -gx PATH \"$node_dir\" \$PATH"
+    else
+        export_line="export PATH=\"$node_dir:\$PATH\""
+    fi
+    if [ -f "$rc_file" ] && grep -qF "$NODE_PATH_MARKER" "$rc_file" 2>/dev/null; then
+        ok "node PATH entry already present in $rc_file"
+    else
+        echo "" >> "$rc_file"
+        echo "$NODE_PATH_MARKER" >> "$rc_file"
+        echo "$export_line" >> "$rc_file"
+        ok "Added node ($node_dir) to $rc_file so hooks can find it"
+    fi
+
+    # 5. Self-test by EXECUTION (not mere resolvability — a shim can resolve yet
+    #    fail to run). Only meaningful for zsh: non-interactive `zsh -c` sources
+    #    .zshenv, whereas non-interactive bash sources neither .bash_profile nor
+    #    .bashrc (only $BASH_ENV), so the entry cannot be self-verified there.
+    if [ "$shell_name" = "zsh" ]; then
+        if env -i HOME="$HOME" PATH="$base_path" zsh -c 'node --version' &>/dev/null; then
+            ok "Verified: a hook-style shell can now run node"
+        else
+            warn "Added the entry, but a clean zsh still cannot RUN node from $rc_file."
+            warn "Check that '$node_dir' holds a working node, then re-run setup to re-verify."
+        fi
+    else
+        info "Added node to $rc_file (execution self-test runs for zsh only; note a non-interactive bash hook shell won't source $rc_file — verify it can run node)."
+    fi
+}
+
+uninstall_node_path() {
+    local rc_file
+    rc_file=$(detect_shell_rc)
+    if [ ! -f "$rc_file" ]; then return; fi
+
+    if grep -qF "$NODE_PATH_MARKER" "$rc_file" 2>/dev/null; then
+        local tmp
+        tmp=$(mktemp)
+        # Positional N;d removes the marker line and the export line written
+        # directly after it (the install pairs them); assumes they're adjacent.
+        sed "\|$NODE_PATH_MARKER|{N;d;}" "$rc_file" > "$tmp"
+        mv "$tmp" "$rc_file"
+        ok "Removed node PATH entry from $rc_file"
+    fi
+}
+
+# Informational note about tgrep, Cortex Code's built-in search index. XO cannot
+# toggle the client setting or provision model access, so this only informs the
+# user how to confirm it is on — XO subagents use it opportunistically and fall
+# back to grep when it is absent.
+print_tgrep_note() {
+    info "tgrep (optional search index):"
+    info "  XO uses Cortex Code's built-in tgrep index for faster search when it is"
+    info "  available, and falls back to grep otherwise. tgrep auto-indexes repos"
+    info "  under 1000 files; confirm it is on via the 'tgrep.enabled' Cortex Code"
+    info "  setting. It needs account access to the arctic-embed embedding model —"
+    info "  a 403 there disables it. No action required; grep works either way."
+}
+
+# ─── Status ───────────────────────────────────────────────────────────────────
+
+check_installation() {
+    local settings_file="$1" label="$2"
+    local found=0
+
+    info "── $label ──"
+
+    if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
+        local registered
+        registered=$(jq --arg p "$PLUGIN_DIR" \
+            '[.plugins[]? | select(. == $p)] | length > 0' "$settings_file" 2>/dev/null || echo "false")
+        if [ "$registered" = "true" ]; then
+            ok "Plugin: registered ($PLUGIN_DIR)"
+            found=1
+        else
+            info "Plugin: not registered in settings.json"
+        fi
+    else
+        info "Plugin: no settings.json"
+    fi
+
+    # Only trust the real mechanism: the env var the hooks actually receive
+    # (set via the shell profile). A settings.json .env entry does not reach
+    # the hook process, so we do not read it here — doing so would falsely
+    # report a broken install as healthy.
+    local xocortex_home="${XOCORTEX_HOME:-}"
+    if [ -n "$xocortex_home" ]; then
+        if [ -d "$xocortex_home" ]; then
+            ok "Memory repo (XOCORTEX_HOME): $xocortex_home"
+            found=1
+        else
+            warn "Memory repo configured but not found: $xocortex_home"
+        fi
+    else
+        info "XOCORTEX_HOME: not set (XO will use local fallback at ~/.snowflake/cortex/memory/xocortex/)"
+    fi
+
+    # Flag a legacy settings.json .env entry so upgrading users know to clean it
+    if [ -f "$settings_file" ] && command -v jq &>/dev/null; then
+        if jq -e '.env.XOCORTEX_HOME' "$settings_file" &>/dev/null; then
+            warn "Legacy .env.XOCORTEX_HOME in settings.json — this never reaches hooks; run uninstall to remove it, set XOCORTEX_HOME via your shell profile instead"
+        fi
+    fi
+
+    local legacy_agents="$USER_PROFILE_DIR/AGENTS.md"
+    if [ -f "$legacy_agents" ] && grep -q "XO:START" "$legacy_agents" 2>/dev/null; then
+        warn "Legacy AGENTS.md found at $legacy_agents — safe to delete (directives now delivered by plugin hooks)"
+    fi
+
+    local broken_symlinks=0
+    if [ -d "$USER_PROFILE_DIR/agents" ]; then
+        for link in "$USER_PROFILE_DIR/agents"/xo-*.agent.md; do
+            [ -L "$link" ] && [ ! -e "$link" ] && broken_symlinks=$((broken_symlinks + 1))
+        done
+        if [ "$broken_symlinks" -gt 0 ]; then
+            warn "$broken_symlinks broken xo-* agent symlinks in $USER_PROFILE_DIR/agents/ — delete them: rm $USER_PROFILE_DIR/agents/xo-*.agent.md"
+        fi
+    fi
+
+    local legacy_hooks
+    legacy_hooks=$(jq -r '.hooks // empty' "$settings_file" 2>/dev/null)
+    if [ -n "$legacy_hooks" ] && [ "$legacy_hooks" != "null" ]; then
+        warn "Legacy hooks{} block found in settings.json — remove it (hooks now delivered by plugin)"
+    fi
+
+    info "tgrep index: optional; XO uses it when on ('tgrep.enabled' setting) and falls back to grep otherwise"
+
+    return $((1 - found))
+}
+
+# ─── Commands ─────────────────────────────────────────────────────────────────
+
+cmd_init() {
+    local target="user-profile"
+    local workspace=""
+    local requested_owner=""
+    local xocortex_path=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target)       target="$2"; shift 2 ;;
+            --workspace)    workspace="$2"; shift 2 ;;
+            --owner)        requested_owner="$2"; shift 2 ;;
+            --xocortex)     xocortex_path="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  XO System — First-Time Setup"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    echo "  This script will:"
+    echo "    1. Create your private xocortex memory repository"
+    echo "    2. Create a PRIVATE GitHub repo for that vault"
+    echo "    3. Register the XO plugin in your $([ "$target" = "workspace" ] && echo "workspace" || echo "user profile")"
+    echo ""
+    echo "  Privacy: Your repo will be visible ONLY to you."
+    echo ""
+
+    preflight_init "$requested_owner"
+
+    local gh_user="$INIT_GH_USER"
+    local vault_owner="$INIT_VAULT_OWNER"
+    local repo_name
+    repo_name=$(vault_repo_name "$vault_owner" "$gh_user")
+    local repo_slug="$vault_owner/$repo_name"
+    local repo_url="git@github.com:$repo_slug.git"
+    local owner_label
+    owner_label=$(vault_owner_label "$vault_owner" "$gh_user")
+    local xocortex_dir="${xocortex_path:-}"
+
+    if [ -z "$xocortex_dir" ]; then
+        if xo_dir_is_git_repo; then
+            local parent_dir
+            parent_dir="$(dirname "$XO_DIR")"
+            xocortex_dir="$parent_dir/xocortex"
+        else
+            xocortex_dir="$HOME/xocortex"
+            info "XO is not running from a cloned git repo; defaulting the vault to $xocortex_dir"
+            echo ""
+        fi
+    fi
+
+    if [ -d "$xocortex_dir" ]; then
+        if handle_existing_xocortex_dir "$xocortex_dir" "$target" "$workspace"; then
+            return
+        fi
+        echo ""
+    fi
+
+    if gh repo view "$repo_slug" &>/dev/null; then
+        info "Found existing repo: $repo_slug"
+        echo ""
+        read -r -p "  Clone it instead of creating or resuming local setup? [Y/n]: " clone_existing
+
+        if [[ "$clone_existing" != "n" && "$clone_existing" != "N" ]]; then
+            echo ""
+            info "Cloning existing repository..."
+            git clone "$repo_url" "$xocortex_dir"
+            ok "Cloned to $xocortex_dir"
+            echo ""
+            info "Installing XO..."
+            echo ""
+            cmd_install --target "$target" ${workspace:+--workspace "$workspace"} --xocortex "$xocortex_dir"
+            return
+        fi
+    fi
+
+    info "Preparing xocortex directory structure..."
+    write_xocortex_scaffold "$xocortex_dir" "$vault_owner" "$gh_user"
+    # tasks/index.md is generated by the sessionStart reindex hook; no template needed.
+    # The VS Code workspace file is deprecated and no longer created.
+    ok "Directory structure ready"
+    echo ""
+
+    initialize_vault_git_repo "$xocortex_dir"
+    echo ""
+
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  Creating Private GitHub Repository"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    info "Owner: $owner_label"
+    info "Repository: $repo_slug"
+    info "Visibility: PRIVATE (only you can see it)"
+    echo ""
+
+    read -r -p "  Create and push now? [Y/n]: " create_repo
+
+    if [[ "$create_repo" == "n" || "$create_repo" == "N" ]]; then
+        echo ""
+        info "Skipped. To set up GitHub later:"
+        echo ""
+        info "  cd $xocortex_dir"
+        info "  gh repo create $repo_slug --private"
+        info "  git remote add origin $repo_url"
+        info "  git push -u origin $(current_git_branch "$xocortex_dir")"
+        echo ""
+    else
+        echo ""
+        if gh repo view "$repo_slug" &>/dev/null; then
+            info "Repository already exists on GitHub."
+            ensure_vault_origin_remote "$xocortex_dir" "$repo_url"
+            if git -C "$xocortex_dir" push -u origin HEAD 2>/dev/null; then
+                ok "Pushed local vault to existing GitHub repository"
+            else
+                fail "Failed to push to existing repo: $repo_slug"
+                info "  cd $xocortex_dir"
+                info "  git remote -v"
+                info "  git push -u origin HEAD"
+            fi
+        else
+            info "Creating private repository..."
+            if gh repo create "$repo_slug" --private --source="$xocortex_dir" --push 2>/dev/null; then
+                ok "GitHub repository created and pushed"
+            else
+                echo ""
+                fail "Failed to create repo. Check your gh CLI auth:"
+                info "  gh auth login"
+                echo ""
+                info "Then manually create:"
+                info "  cd $xocortex_dir"
+                info "  gh repo create $repo_slug --private"
+                info "  git remote add origin $repo_url"
+                info "  git push -u origin $(current_git_branch "$xocortex_dir")"
+            fi
+        fi
+    fi
+
+    echo ""
+    info "Installing XO..."
+    echo ""
+    cmd_install --target "$target" ${workspace:+--workspace "$workspace"} --xocortex "$xocortex_dir"
+}
+
+cmd_install() {
+    local target="user-profile"
+    local workspace=""
+    local xocortex_path=""
+    local install_xocortex_path=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target)       target="$2"; shift 2 ;;
+            --workspace)    workspace="$2"; shift 2 ;;
+            --xocortex)     xocortex_path="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+
+    if [ "$target" = "workspace" ] && [ -z "$workspace" ]; then
+        workspace="$(pwd)"
+    fi
+
+    local settings_file
+    settings_file=$(resolve_settings_json "$target" "$workspace")
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  XO System — Install ($target)"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    info "Plugin: $PLUGIN_DIR"
+    info "Settings: $settings_file"
+    echo ""
+
+    install_plugin "$settings_file"
+
+    install_xocortex_path="$xocortex_path"
+    if [ -z "$install_xocortex_path" ]; then
+        install_xocortex_path="$SNOWFLAKE_HOME/cortex/memory/xocortex"
+        mkdir -p "$install_xocortex_path"
+    fi
+
+    if [ -z "$xocortex_path" ]; then
+        info "XOCORTEX_HOME will default to the local fallback vault: $install_xocortex_path"
+    fi
+    install_shell_env "$install_xocortex_path"
+
+    install_node_path
+
+    echo ""
+    print_tgrep_note
+
+    echo ""
+
+    if [ "$target" = "workspace" ]; then
+        echo "  ═══════════════════════════════════════════════════════════"
+        warn "IMPORTANT: Add .snowflake/ to your .gitignore if not already present"
+        echo "  ═══════════════════════════════════════════════════════════"
+    fi
+
+    echo ""
+    ok "XO installed to $target"
+    echo ""
+}
+
+cmd_uninstall() {
+    local target="user-profile"
+    local workspace=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target)       target="$2"; shift 2 ;;
+            --workspace)    workspace="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+
+    if [ "$target" = "workspace" ] && [ -z "$workspace" ]; then
+        workspace="$(pwd)"
+    fi
+
+    local settings_file
+    settings_file=$(resolve_settings_json "$target" "$workspace")
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  XO System — Uninstall ($target)"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+
+    remove_plugin "$settings_file"
+    remove_settings_env "$settings_file"
+    uninstall_shell_env
+    uninstall_node_path
+
+    echo ""
+    ok "XO uninstalled from $target"
+    echo ""
+}
+
+cmd_migrate() {
+    local from="" to="" workspace=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --from)         from="$2"; shift 2 ;;
+            --to)           to="$2"; shift 2 ;;
+            --workspace)    workspace="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+
+    if [ -z "$from" ] || [ -z "$to" ]; then
+        die "Usage: setup.sh migrate --from <target> --to <target>"
+    fi
+    if [ "$from" = "$to" ]; then
+        die "Cannot migrate to the same target"
+    fi
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  XO System — Migrate ($from → $to)"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+
+    info "Installing to $to..."
+    echo ""
+    cmd_install --target "$to" ${workspace:+--workspace "$workspace"}
+
+    info "Uninstalling from $from..."
+    echo ""
+    cmd_uninstall --target "$from" ${workspace:+--workspace "$workspace"}
+
+    echo ""
+    ok "Migration complete: $from → $to"
+    echo ""
+}
+
+cmd_status() {
+    local target="" workspace=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --target)       target="$2"; shift 2 ;;
+            --workspace)    workspace="$2"; shift 2 ;;
+            *) die "Unknown option: $1" ;;
+        esac
+    done
+
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  XO System — Status"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    info "XO source: $XO_DIR"
+    info "Plugin: $PLUGIN_DIR"
+    echo ""
+
+    if [ -z "$target" ] || [ "$target" = "user-profile" ]; then
+        check_installation "$USER_PROFILE_DIR/settings.json" "User Profile ($USER_PROFILE_DIR)"
+        echo ""
+    fi
+
+    if [ -n "$target" ] && [ "$target" = "workspace" ]; then
+        if [ -z "$workspace" ]; then workspace="$(pwd)"; fi
+        check_installation "${workspace}/.snowflake/cortex/settings.json" "Workspace ($workspace)"
+        echo ""
+    fi
+}
+
+cmd_help() {
+    echo ""
+    echo "Usage: setup.sh <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  init        First-time setup: create xocortex repo and register XO plugin"
+    echo "  install     Register XO plugin and set XOCORTEX_HOME"
+    echo "  uninstall   Remove XO from a target"
+    echo "  migrate     Move XO between user-profile and workspace"
+    echo "  status      Check XO installation health"
+    echo "  help        Show this help"
+    echo ""
+    echo "Options:"
+    echo "  --target <user-profile|workspace>   Install target (default: user-profile)"
+    echo "  --workspace <path>                  Workspace path (default: current directory)"
+    echo "  --owner <github-owner>              Vault owner for init only (default: your gh user)"
+    echo "  --xocortex <path>                   Path to xocortex memory repo"
+    echo ""
+    echo "Examples:"
+    echo "  setup.sh init                                  # First-time setup"
+    echo "  setup.sh init --target workspace               # First-time setup, install to workspace"
+    echo "  setup.sh install                               # Register plugin in user profile"
+    echo "  setup.sh install --xocortex ~/xocortex          # Install + set memory repo path"
+    echo "  setup.sh install --target workspace             # Register plugin in current workspace"
+    echo "  setup.sh uninstall --target workspace           # Remove from workspace"
+    echo "  setup.sh migrate --from workspace --to user-profile"
+    echo "  setup.sh status"
+    echo ""
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+case "${1:-help}" in
+    init)       shift; cmd_init "$@" ;;
+    install)    shift; cmd_install "$@" ;;
+    uninstall)  shift; cmd_uninstall "$@" ;;
+    migrate)    shift; cmd_migrate "$@" ;;
+    status)     shift; cmd_status "$@" ;;
+    help|--help|-h) cmd_help ;;
+    *) die "Unknown command: $1. Run 'setup.sh help' for usage." ;;
+esac

--- a/plugins/xo/skills/xo/SKILL.md
+++ b/plugins/xo/skills/xo/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: xo
+description: "**[REQUIRED]** XO operator workflow system — the single entry point. Triage classifies the request, routes to the right stage reference, and composes multi-stage pathways. Recording (save) and Recall run underneath. Triggers: work item, WI, task, implement, investigate, plan, review, execute, what should I do, where do I start, savepoint, resume."
+---
+
+# xo
+
+The single skill for the XO workflow system. It triages a request, routes to the stage reference that carries the procedure, and composes pathways across stages. Stages are references in `references/` (this skill, one directory), not separate skills. This file is the operating instructions.
+
+---
+
+## Session Prerequisites (Always First)
+
+Before routing any work:
+
+1. Load `references/save-protocol.md` (recording discipline — diary, notes, task, savepoint, recovery) and `references/core-guidelines.md` (cross-cutting operating rules).
+2. Recording is active for the whole session: savepoint at milestones and gates; on a "pick up WI-N" / "resume", follow Session Recovery in `save-protocol.md` first.
+
+## Setup & install (self-knowledge)
+
+When asked how XO is set up or whether the install is complete: XO requires `node`, `git`, `gh`, and `jq`. The bundled installer and runbook live at the plugin root as `setup.sh` and `SETUP.md`; at runtime that root is exposed as `CORTEX_PLUGIN_ROOT`. Running `setup.sh` sets `XOCORTEX_HOME`, adds `node` to the hooks' PATH so hooks can fire reliably, and can point XO at a git-backed vault or the local fallback vault. `XOCORTEX_HOME` set means setup completed; if it is unset, setup has not been run and XO is using local fallback behavior.
+
+---
+
+## Hard rules — navigating the workflow (do not skip)
+
+XO is a directed workflow graph, not a set of recipe cards: defined entry points, a forward spine, deliberate loops back over completed work (redo, review, capture), and multiple exits. You compose a path through it — but the rules below and the operator gates are fixed, not optional. "Choose-your-own-adventure" describes the branching, not a licence to freestyle.
+
+1. **Triage before acting.** Run Step 0 on every new request before any other action.
+2. **Load the stage reference before you act.** The procedure — steps and prescribed subagent — lives only in the stage's reference (see Reference Index), not in this routing table. Acting from the routing table alone, or dispatching `generalPurpose` instead of a stage's prescribed subagent, is a failure.
+3. **Honour operator gates.** Between phases the operator confirms before you continue. Never self-advance past a gate.
+4. **"Small fix" does not grant permission to skip stages.** The Act sequence (Provision → Build → Prove) is never skipped. Only upstream scoping (Observe/Orient/Decide) may be skipped, and only when it already happened — see Skip rules.
+5. **Never silently infer a pathway for substantive work.** Surface it; let the operator confirm.
+6. **Surface conflicts during discussion; don't self-resolve.** When working out how to solve a problem, if you spot a conflict, inconsistency, or gap, surface it and agree a direction with the operator — do not pick a plausible fix and apply it. This governs the discussion phase, not execution of an already-agreed plan.
+7. **Search the vault by terms via Recall; look up a known identity directly.** If you are searching notes/tasks/diary by topic, concept, or terms, use **Recall**. If you already have a specific identity (WI-N, exact filename, exact path), load or grep it directly.
+
+---
+
+## Step 0 — Triage (always first)
+
+Decide two things: **how heavy** this is, and **which pathway** (if any) the operator already wants.
+
+**Quick** — a question, lookup, or explanation you can answer directly.
+→ Answer it. Then offer lightly: *"Want to go deeper / make this a work item?"* No WI, no stages, no ceremony unless they escalate.
+
+**Substantive** — investigation, design, or anything that changes code/state or spans multiple steps.
+→ Scope before doing:
+1. **Did the operator signal a pathway?** ("just investigate", "spec-driven build", "review this PR") — confirm it; don't re-decide.
+2. **If intent is open/ambiguous**, ask 1–3 clarifying questions (one turn) to close the question first.
+3. **Assess readiness** — what has the operator actually given you?
+   - Findings/evidence from prior investigation, or just a bare task?
+   - A spec/requirements, or just intent?
+   - A target workspace identified, or just a topic?
+   - An existing WI with notes, or cold-start?
+   Start the pathway from where evidence actually begins — not from where a WI's NextAction optimistically assumes you are.
+4. **Propose the pathway** menu-style, one recommendation. Apply the Work Item Gate. Enter only on operator agreement.
+
+Clarify only when the ambiguity changes *what* you build or *which* pathway — not for details you can assume and confirm later.
+
+**Recall routing.** If the operator gives a known specific identity (WI-N, exact filename, exact path), load or grep it directly. If you need to search the vault by terms, topic, or concept, run **Recall** (`references/observe-recall.md`) to resolve the target before routing.
+
+---
+
+## Routing Table
+
+Each row points to the stage reference to load (Hard rule 2).
+
+| User intent | Load |
+|---|---|
+| "pick up WI-N", "continue", "resume" | `references/save-protocol.md` (Session Recovery) → then **WI pickup** (below) → load the NextAction's stage reference |
+| vault search by terms / topic / concept | `references/observe-recall.md`, then route on the resolved target |
+| "what's active?", "status", "portfolio" | Portfolio Overview (below) |
+| research, survey, map the territory, where does X live, broad overview | `references/observe-survey.md` |
+| investigate, deep dive, establish facts, verify, how does X work | `references/observe-analyse.md` |
+| compile findings, what did we learn, distil this | `references/orient-distil.md` |
+| design options, what approaches exist, stress-test a design | `references/orient-workshop.md` |
+| write the spec, define what we'll produce, requirements | `references/decide-spec.md` |
+| build a plan, plan the implementation | `references/decide-plan.md` |
+| review this PR/changes, validate my work, respond to review comments | `references/decide-review.md` |
+| capture, crystallise, close the loop, keep for next time | `references/decide-capture.md` |
+| set up workspace, worktree, provision environment | `references/act-provision.md` |
+| implement, build, produce, create, configure, make this, fix this | `references/act-build.md` |
+| explain, document, write the guide, produce a report | `references/act-document.md` |
+| prove it works, validate, verify, test, run tests | `references/act-prove.md` |
+| ship, deliver, publish, deploy, raise PR, send to requestor | `references/act-ship.md` |
+| clean up, tear down, remove workspace, wrap up | `references/act-cleanup.md` |
+| savepoint, save, record, checkpoint | `references/save-protocol.md` |
+
+If intent spans phases ("investigate and implement"), propose a pathway (below).
+
+---
+
+## Work Item Gate
+
+Before routing to a stage (except quick reactive tasks), verify a WI exists.
+
+| Situation | WI required? | Action |
+|---|---|---|
+| Resuming existing WI | Exists | Proceed |
+| Quick reactive task, typo, short lookup | No | Route directly |
+| New investigation, implementation, or design | Yes | Check; if none, ask |
+
+When it fires:
+> "This looks like structured work. (a) Create a WI and start now? (b) Create and defer? (c) Attach to an existing WI? (d) Keep it lightweight — no WI?"
+
+WI creation procedure is in `references/save-protocol.md`.
+
+---
+
+## WI pickup (by number)
+
+1. **Find it:** glob `tasks/current/*wi{N}-*.md` — the project prefix varies; match on the number, not the filename start. (Notes: `notes/**/*wi{N}-*.md`.)
+2. **Read it:** Status, NextAction, scope, Category, **Scratch**.
+3. **Ensure scratch exists:** the task file's `Scratch:` field is the authoritative path (`$XOCORTEX_HOME/tmp/wi{N}/`). `ls` it; if missing, `mkdir -p` it once. If the field is absent, add `Scratch: $XOCORTEX_HOME/tmp/wi{N}/` to the task file. Never invent an alternative location.
+4. **Check priors exist** before executing the NextAction:
+   - Notes for this WI? If none, no prior investigation is recorded.
+   - A spec/findings brief? If NextAction implies Build but no spec exists, scoping was skipped.
+   - Scratch artifacts in the `Scratch:` dir? If none, no production has happened yet.
+   - Target workspace in expected state? (branch exists? code moved on?)
+5. **Report the gap if priors are missing** — do not assume readiness from a NextAction:
+   > "WI-{N} says NextAction is [X], but I don't see [notes/spec/survey/workspace]. That suggests [stage] hasn't run. (a) run it first, (b) skip — you brief me, (c) it exists elsewhere — point me to it."
+6. **Proceed only once resolved.** Then load the stage reference for the NextAction before acting (Hard rule 2). A WI written days ago may be stale — verify before committing to its plan.
+
+---
+
+## Pathways (known-good slices)
+
+Infer which fits, propose menu-style with one recommendation. Don't invent arbitrary orderings; if none fits, compose a slice of the spine that keeps stage order and gates. Never skip the Spec gate before building.
+
+**Front-load the pathway's references.** On entering a pathway, name the stage references the pathway will need and load each as you reach its stage — for a clearly declared pathway (e.g. "review this PR"), load the entry reference now and tell yourself which downstream references are coming, so the work runs as one task rather than repeated route-outs.
+
+Full spine, by phase:
+`Observe (Survey → Analyse) → Orient (Distil → Workshop) → Decide (Spec → Plan) → Act (Provision → Build/Document → Prove → Ship)`
+
+| Pathway | Sequence | For |
+|---|---|---|
+| **spec-driven** | Workshop → Spec → Plan → Provision → Build → Prove → Ship | new feature to a clear design |
+| **TDD** | Spec → Plan → Provision → Prove.author → Build → Prove.verify → Ship | bug fixes, high-confidence, regression prevention |
+| **empirical-improvement** | Analyse → Distil → Assess-for-gate → Spec → Plan → Build… | refactoring/optimising existing code |
+| **open-build** | full spine | novel cold-start work |
+| **document-a-feature** | Analyse → Distil → Provision → Document → Prove.citation-audit → Ship | the feature exists, the guide doesn't |
+| **create-deliverable** | Distil → Spec → Provision → Build → Prove.validate → Ship.deliver | non-code artifact for a requestor |
+| **prototype-app** | Workshop → Spec → Provision.local-infra → Build → Prove.interactive → Ship.deploy | demo, Streamlit app, prototype |
+| **configure-environment** | Analyse → Spec → Provision.snowflake → Build → Prove.state-validation → Capture | Snowflake objects, permissions, pipelines, infra |
+| **assess-for-gate** | (Survey/Analyse if unfamiliar) → Review (cold Critic vs spec/source/intent → justified brief) → decide gate | quality judgment before merge/publish/ship; Review critiques the whole chain, not just the diff |
+| **respond-to-feedback** | Survey (subject + ALL feedback) → Analyse (classify trivial/substantive via complexity-gate) → trivial: Build / substantive: Spec → Build → Brief → gate | PR/doc/Slack/email comments |
+
+**Wagon ruts (seed Observe from Triage context):**
+- "review this PR / check this PR" → assess-for-gate; seed: PR diff + risk factors
+- "someone left comments" → respond-to-feedback; seed: subject + feedback channel
+- "validate my changes / check my empirical work" → assess-for-gate; seed: fresh changes
+- "is this ready to ship/merge/publish?" → assess-for-gate; seed: artifact + gate type
+
+---
+
+## Reflexes — small offers
+
+Offer the *adjacent* stage as a single step on substantial work. Offer once, easy to decline, never nag.
+
+| When… | Offer |
+|---|---|
+| Produced a substantial artifact (code, doc, spec, design, analysis) | a cold **Critic** vs intent — and its **foundations** |
+| Produced/modified an artifact | **Prove** (test for code, interactive for UI, state-check for configs, citation-audit for docs) |
+| Entering unfamiliar territory | **Survey/Analyse** first — and check for relevant available skills (especially Snowflake-technology skills); prefer them over improvising |
+| Open design fork + you have findings | **Workshop** to explore angles |
+| Solved something non-obvious / learned a durable fact | **Capture** |
+| Work genuinely done and accepted | **Cleanup** — see guard |
+
+**Critic runs backward:** if an artifact's foundations are weak (speculation, no evidence), offer the missing *prior* stage (Analyse/Distil) before building further.
+
+**Guards:**
+- Gentle, single, bypassable. If declined, drop it.
+- **Cleanup is terminal-only.** Never offer Cleanup / commit / push while the operator is still reviewing or validating. Wait for explicit "done." Never bundle commit + push + teardown.
+- For *starting* significant work, lean into plan mode (Spec → Plan); no separate offer.
+
+---
+
+## Skip rules
+
+Only upstream scoping (Observe/Orient/Decide) may be skipped, and only when it already happened.
+
+- **Resuming with an existing plan:** validate the plan against current state, then run full Act.
+- **Reactive fix / typo:** skip upstream scoping only; still Provision → Build (with critic) → Prove.
+- **Spec already exists:** validate it isn't stale, then Plan → full Act.
+
+---
+
+## Portfolio Overview
+
+On "what's active?" / "status": read `tasks/index.md`; present active items grouped Now / Next / Later (focus Now/Next); ask if they want detail on any.
+
+---
+
+## Reference Index
+
+Load lazily when routing — do not pre-load (they consume context). `references/save-protocol.md` and `references/core-guidelines.md` are the exception: load both at session start.
+
+**Always-on (recording + rules)**
+| Reference | Purpose |
+|---|---|
+| `references/save-protocol.md` | Recording: savepoint, Session Recovery, WI creation, task updates, urgency levels |
+| `references/core-guidelines.md` | Cross-cutting operating rules: grounding, source order, gates, storage, per-phase invariants |
+| `references/save-recovery.md` | Detailed recovery procedures (context reset, stale metadata) |
+| `references/save-task-conventions.md` | Task file schema: fields, ordering, Scratch field |
+| `references/save-three-layer.md` | Recording model: diary/task/notes separation |
+| `references/save-context-urgency.md` | Hook urgency thresholds and checkpoint state machine |
+
+**Observe**
+| Reference | Purpose |
+|---|---|
+| `references/observe-survey.md` | Survey: breadth-first discovery to locate where the subject lives |
+| `references/observe-analyse.md` | Analyse: depth-first investigation to establish verified facts |
+| `references/observe-recall.md` | Recall: search the memory vault (notes/tasks/diary) — a first-class action; prefer over bare grep |
+| `references/refs-survey-methods.md` | Traversal patterns, source hierarchy, trust signals (load from survey/analyse) |
+
+**Orient**
+| Reference | Purpose |
+|---|---|
+| `references/orient-distil.md` | Distil: compile raw evidence into a findings brief |
+| `references/orient-workshop.md` | Workshop: parallel-angle exploration → human-synthesised proposal |
+
+**Decide**
+| Reference | Purpose |
+|---|---|
+| `references/decide-spec.md` | Spec: write the bounding contract for execution |
+| `references/decide-plan.md` | Plan: turn the spec into an implementation plan (plan mode) |
+| `references/decide-review.md` | Review: cold Critic vs reference → justified verdict; self-check before gate |
+| `references/decide-capture.md` | Capture: durable learning notes + optional promote-out |
+| `references/refs-complexity-gate.md` | TRIVIAL vs SUBSTANTIVE classification (load from review) |
+| `references/refs-verified-review.md` | Build-and-test protocol for empirical review (load from review) |
+| `references/refs-author-test-plan.md` | Author-provided test plan extraction and merging (load from review) |
+
+**Act**
+| Reference | Purpose |
+|---|---|
+| `references/act-provision.md` | Provision: workspace setup (worktree, scratch, local infra, Snowflake, cloud) |
+| `references/act-build.md` | Build: generator + parallel critics + verifier; scope discipline |
+| `references/act-document.md` | Document: explain an existing artifact; drafter isolation + citation discipline |
+| `references/act-prove.md` | Prove: automated tests, interactive/hybrid, state validation, citation audit, dry run |
+| `references/act-ship.md` | Ship: multi-mode delivery (PR, publish, deploy, share, route-to-requestor) |
+| `references/act-cleanup.md` | Cleanup: teardown + hygiene (Curate - supervised-dreaming memory pass, durable commit/push) |
+| `references/refs-workspace-setup.md` | Worktree creation patterns, branch naming (load from provision) |
+| `references/refs-security-review-triggers.md` | Conditions requiring a security Critic in Build (load from build) |
+| `references/refs-findings-contract.md` | Why the Document drafter is codebase-blind; claim tracing (load from document) |
+| `references/refs-guide-frontmatter.md` | Provenance metadata for externally-contributed guides (load from document/build) |
+
+**Shared**
+| Reference | Purpose |
+|---|---|
+| `references/refs-terminology.md` | Standard terminology across stages |

--- a/plugins/xo/skills/xo/references/act-build.md
+++ b/plugins/xo/skills/xo/references/act-build.md
@@ -1,0 +1,170 @@
+---
+name: act-build
+description: "Build stage — produce the artifact against the spec. xo-generator (proposer) + parallel xo-cold-smart Critics + xo-cold-smart Verifier. Works for any artifact type: code, documents, configurations, SQL objects, apps. Scope discipline is mandatory."
+---
+
+# Build
+
+Produce the artifact specified by the spec. The generator creates; the critics review from multiple angles in parallel; the verifier gates the full package. This pattern applies regardless of artifact type — code, documents, configurations, SQL objects, apps, or data pipelines.
+
+## When to use this stage
+
+- Producing any artifact against an approved spec
+- Code changes in a worktree, SQL objects in Snowflake, documents in scratch space, apps in a dev environment
+- Whenever the work transitions from "what should we produce" (Spec) to "produce it"
+
+---
+
+## Input contract
+
+- Approved spec (`notes/{YYYY-MM}/{project}-wi{N}-spec.md`)
+- Workspace location (from Provision — worktree path, scratch dir, or Snowflake schema context)
+- Production conventions (from Step 0 discovery — see below)
+- In TDD mode: failing tests written by Prove (author)
+
+---
+
+## Step 0: Load context (mandatory before producing)
+
+Before dispatching the generator, confirm you have production conventions available. If prior stages (Survey, Analyse, Spec) already established these, **load them from notes/findings — do not re-derive**. Step 0 is a cache check, not a survey.
+
+**If conventions are already known** (from Observe findings, spec notes, or prior session notes for this repo/workspace):
+- Load the relevant findings or knowledge note
+- Pass conventions directly to the generator
+
+**If conventions are NOT yet known** (short-pathway skip, reactive fix, first touch on this workspace):
+- Do minimal reconnaissance appropriate to the artifact type (see below)
+- Record findings in WI notes so future stages don't repeat this
+
+### Minimal reconnaissance (only when prior stages didn't cover this)
+
+**Repository work:** Read `AGENTS.md`/`CLAUDE.md`; scan patterns near the change site; identify build/test commands; check security-relevant context (see `references/refs-security-review-triggers.md`)
+
+**Snowflake objects:** Check existing naming conventions in target schema; confirm role/permissions context; identify existing patterns
+
+**Documents/guides:** Check style guide or existing docs; identify format requirements; locate evidence sources
+
+If the produced artifact is a shippable guide or doc (for example a README or reference doc), apply `references/refs-guide-frontmatter.md` provenance frontmatter. See Document.
+
+**Apps/demos:** Check framework conventions; identify available services; confirm runtime environment
+
+---
+
+## Step 1: Generator (xo-generator)
+
+The only agent with write authority for the artifact.
+
+```
+runSubagent(subagent_type: "xocortex:xo-generator", prompt: "
+  PERSONA: Proposer — produce the artifact
+  SPECIFICATION: [spec file path or requirements]
+  INPUTS: [conventions from prior stages or Step 0, existing context]
+  WORKTREE: [workspace path]
+  
+  Produce what the specification requires.
+  Read existing work near each change site to understand patterns and style before editing.
+  Change ONLY what the specification requires — report anything out-of-scope under OBSERVED.
+  Output a REQUIREMENT/FILE/CHANGE/RATIONALE record for each change made.
+")
+```
+
+---
+
+## Step 2: Parallel critics (xo-cold-smart)
+
+**Always dispatch:** general critic (scope, correctness, conventions).
+
+**Also dispatch as appropriate:** security critic (when security triggers apply — see `references/refs-security-review-triggers.md`), architecture critic (cross-cutting changes), API surface critic (public interface changes).
+
+Check `references/refs-security-review-triggers.md` to determine if security persona is mandatory.
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — general correctness and scope
+  REFERENCE: [spec]
+  INPUTS: [worktree path, incremental diff: git diff HEAD, branch diff: git diff main..HEAD]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/build-critic-general.md
+  
+  Review the implementation diff for:
+  1. Scope compliance (only what the spec requires)
+  2. Safety and correctness
+  3. Repo convention adherence
+  4. Collateral damage (changes outside spec scope)
+  5. Foundations — is the implementation grounded in the spec/findings, or built on speculation? Flag plausible-but-ungrounded choices and name the missing basis.
+  
+  Return APPROVE, REVISE (specific concern + suggestion + severity), or BLOCK (red lines).
+")
+
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — security
+  REFERENCE: [change description + what security boundaries exist]
+  INPUTS: [worktree path, incremental diff]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/build-critic-security.md
+  
+  Review for security boundary violations, credential exposure, and trust boundary crossings.
+  Map process/trust boundaries. Trace credential flow. Evaluate the security checklist.
+  Return SAFE, REVISE, or BLOCK.
+  [Load security-review-triggers.md criteria]
+")
+```
+
+### Critic routing
+
+| Verdict | Action |
+|---|---|
+| All APPROVE / SAFE | Proceed to Verifier |
+| Any REVISE | Return generator with critic feedback; re-implement; re-run critics |
+| Any BLOCK | Escalate to operator — do not continue until resolved |
+
+**Maximum 3 cycles per artifact-critic loop.** After 3 rejections in the same loop, escalate — repeated attempts degrade quality. A new operator correction starts a fresh loop; it does not consume the prior cap.
+
+---
+
+## Step 3: Verifier (xo-cold-smart)
+
+Unified gate: code + critics + tests vs spec.
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Verifier — unified gate
+  REFERENCE: [spec]
+  INPUTS: [worktree path, critic verdicts from $XOCORTEX_HOME/tmp/wi{N}/, test results if available]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/build-verifier.md
+  
+  Verify the full package against the spec:
+  1. Each requirement: implemented? tested? test passed?
+  2. Scope compliance: no changes outside spec?
+  3. Test adequacy: do tests cover requirements (not just implementation)?
+  4. Repo compliance: conventions followed, no debug code left?
+  
+  Return VERIFIED (ready to commit) or NOT_VERIFIED (specify gap + ROUTE_TO: generator/tester).
+")
+```
+
+---
+
+## Output contract
+
+After VERIFIED: Build is complete. The artifact satisfies the spec per the Verifier's assessment. Present to operator:
+
+> "The [artifact] is ready — Verifier passed. [Brief summary of what was produced]. [Materiality of any correction applied: TRIVIAL (noted) or SUBSTANTIVE (re-critique found [issue], changed [what changed] since that feedback).] How would you like to proceed?"
+
+Do not push to Ship unprompted. The operator decides the next step. Typical routes:
+- **Prove** (validate it works — tests, interactive verification, state check)
+- **Review** (`references/decide-review.md` — formal operator gate with brief)
+- **Ship** (only if Prove was already done in TDD mode, or operator explicitly approves direct delivery)
+
+---
+
+## Calibration note
+
+CALIBRATE: The parallel critics pattern (dispatch simultaneously, merge verdicts) is the default. For simple changes, dispatching a single general critic may be sufficient — use judgment on whether security persona is warranted.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Before advancing:** update notes + task with what was built and the verifier verdict.
+- **Usually follows:** Provision (workspace is set up) + Plan/Spec. No approved plan? Consider Plan first.
+- **Leads to — primary:** Prove (validate the artifact satisfies the spec).
+- **Or:** Review (formal operator gate before proceeding); Ship directly for trivial, low-risk deliverables.

--- a/plugins/xo/skills/xo/references/act-cleanup.md
+++ b/plugins/xo/skills/xo/references/act-cleanup.md
@@ -1,0 +1,210 @@
+---
+name: act-cleanup
+description: Cleanup stage — teardown the workspace and run hygiene processes. Removes worktrees, clears scratch files, checks infrastructure, runs Curate (the supervised-dreaming memory pass — prune + promote), commits the durable vault. Timing-based hygiene reminders (repo commit/push, Curate) are surfaced by the SessionStart hook; Cleanup runs the processes when the operator accepts a nudge.
+---
+
+# Cleanup
+
+Tear down the workspace and run hygiene processes. Cleanup is always the last step of any work that modified files or deployed infrastructure. It also carries the hygiene *processes* (Curate — the supervised-dreaming memory pass — and durable commit/push) that the SessionStart hook's time-based nudges point to, plus reflexive sub-modes that surface good-practice reminders at the right moment.
+
+## When to use this stage
+
+- After Ship (PR merged or closed)
+- After any work that created a worktree, deployed infrastructure, or left temporary files
+- At session end, to trigger the session-lifecycle hygiene checks
+
+---
+
+## Mode: scratch directory clear (universal — always applies)
+
+Subagent handoff artifacts and other transient files for this work live under the canonical per-WI scratch dir `$XOCORTEX_HOME/tmp/wi{N}/` (the `Scratch:` path in the WI task file, allocated at WI creation). At the end of the work, inventory what exists and propose a disposition to the operator before taking any action.
+
+### Process
+
+1. **Inventory** — list what's in the scratch directory:
+   ```bash
+   ls "$XOCORTEX_HOME/tmp/wi{N}/"
+   ```
+
+2. **Propose disposition** — present the inventory to the operator with a recommended action for each artifact:
+
+   > "Scratch artifacts for WI-{N}:
+   >
+   > | Artifact | Recommendation |
+   > |----------|---------------|
+   > | `build-verifier.md` | Discard (transient gate output) |
+   > | `workshop-approach-01.md` | Promote to durable note (contains design reasoning) |
+   > | `doc-guide-draft.md` | Discard (final version already shipped) |
+   > | `prove-verdict.md` | Promote (contains validation evidence) |
+   >
+   > Shall I proceed with these, or would you like to adjust?"
+
+3. **Act on approval** — only after operator confirms:
+   - Promote designated artifacts: `mv "$XOCORTEX_HOME/tmp/wi{N}/<artifact>.md" "$XOCORTEX_HOME/notes/$(date +%Y-%m)/{project}-wi{N}-<slug>.md"`
+   - Clear the rest: `rm -rf "$XOCORTEX_HOME/tmp/wi{N}/"`
+
+---
+
+## Mode: worktree removal (repository work only)
+
+Remove the worktree created in Provision:
+
+```bash
+git -C <repo> worktree remove <worktree-path>
+git -C <repo> branch -d <branch-name>   # only after PR is merged
+```
+
+If the worktree has uncommitted changes:
+```bash
+git -C <repo> worktree remove --force <worktree-path>
+```
+
+Confirm the worktree is gone:
+```bash
+git -C <repo> worktree list
+```
+
+---
+
+## Mode: infrastructure teardown checklist
+
+When the work deployed infrastructure (services, containers, databases, pipelines):
+
+Present a checklist to the operator:
+
+> "The following infrastructure may still be running from this work:
+> - [item 1]: [what it is, where it runs]
+> - [item 2]: ...
+>
+> For each item: tear down now / keep for now / defer?
+> (Anything deferred is recorded in the task notes.)"
+
+Record the decisions in the WI notes. Deferred items get a reminder at the next session start (via the SessionStart hygiene hook).
+
+---
+
+## Mode: Curate (supervised dreaming)
+
+Trigger: the session-start nudge ("your `/memories` were last curated Nd ago"), or operator request. Run only on operator opt-in. Treat memory as scratch, not a sanctioned record (Memory Trust). Operator-gate every removal and every promotion. (Curate is XO's supervised-dreaming pass.)
+
+### Step 1 — Enumerate the real store first
+
+Do NOT treat `/memories/MEMORY.md` as the inventory — it is a curated subset that under-reports. List the ACTUAL store before deciding anything:
+
+- `memory view /memories`, then `memory view` each subdirectory it lists, recursing fully — the directory view is one level deep, so subdirectory contents are hidden until you descend.
+- If you have filesystem access to the memory directory, `find` it directly.
+
+Reconcile against `MEMORY.md` at the END (Step 6), never as the starting inventory.
+
+Exclude from Curate (operational state and durable reference data, not curatable memory): `xo/`, `context-state/`, `projects/` plumbing, `checkpoints/`, `github/`; and **reference data** — any file consumed as machine data rather than curatable knowledge (config, inventory or credential maps, schemas, infra JSON). When unsure whether a file is reference-data or a stale note, ESCALATE — do not guess. Leave excluded files untouched.
+
+### Step 2 — Classify each entry
+
+Classify per **rule/note**, not per file — one file may hold several rules with different targets (split it in Step 6).
+
+- **Operating rule** — an instruction, preference, or rule for how to work (e.g. `feedback*`, `MANDATORY_INSTRUCTIONS`). → PROMOTE path (Step 4).
+- **WI working note** — WI-scoped state/investigation/progress (e.g. `wi{N}*`). Violates "updates in notes, not memory." → PRUNE path (Step 3), joined by WI number.
+- **Transient session state** — point-in-time handoffs/session logs (e.g. `session-*`, `handoff-*`, `*_session_*`). Superseded by definition. → PRUNE path (Step 3), by pattern — no counterpart lookup.
+- **Reference data** — excluded in Step 1.
+- Fits none of these → ESCALATE.
+
+### Step 3 — Prune path: reconcile, never blind-delete
+
+Decide per item — never assume "memory is stale, delete it" nor "the vault is current, ignore memory." `mtime` is a HINT only; content is the authority — so "memory is newer" is a Tier-1 judgement, never a Tier-0 one. Match counterparts by **work-item NUMBER**, not filename string — extract the number from each file's content header (`# WI-N`) or filename (handle `wiN`, `wi-N`, and embedded forms), then join on the number. Vault notes/tasks use varied slugs and month folders, so a filename-string match misses real counterparts and a *failed* filename match does NOT prove orphan. Build the WI-number sets ONCE (memory; vault `tasks/archive/`, `tasks/current/` + each task's `Status`, `notes/`) and membership-test — never scan the vault once per memory file (O(files×vault), crawls).
+
+- **Tier 0 — cheap signals (auto-triage the bulk; pattern + existence only, no content read):**
+  - *Transient session state* (`session-*`, `handoff-*`, `*_session_*`) → **prune by pattern** (superseded point-in-time logs; bulk-approve group).
+  - *WI working note + WI settled (archived in `tasks/archive/`, OR its `tasks/current/` task is `Status: Done`) + a vault counterpart exists* → **superseded → prune** (bulk-approve group).
+  - *WI working note + WI still active (open task in `tasks/current/`)* → escalate to Tier 1 (memory may hold live state).
+  - *No counterpart and no recognised transient pattern (orphan)* → **escalate** with a recommendation (promote-to-note if it looks durable, else discard). NEVER auto-prune or auto-promote an only-copy.
+- **Tier 1 — content reconciliation (escalated only):** hash both first (e.g. `shasum`) — byte-identical → exact duplicate → prune the copy with no read. Not identical → read both and compare (a fast proxy: grep the memory file's distinctive tokens — commit hashes, error codes, unique phrases — in the counterpart). Memory content is a subset → prune. Unique or newer content → merge the unique bits into the durable note, THEN prune the copy. For *active* WIs especially, a same-topic vault note is NOT proof of subset.
+- **Tier 2 — operator adjudication:** orphans and unresolved conflicts → carry to the disposition table (Step 5) with a recommendation.
+
+### Step 4 — Promote path: classify each rule, then place it
+
+For each operating rule, determine its relationship to the authoritative durable surface, then place it. Default placement offered to the operator = this project's `AGENTS.md`.
+
+- **Universal** (applies to any user, any project) → the plug-in. Sub-target: routing rule → `SKILL.md` Hard rules; execution rule → `core-guidelines.md`; stage-specific → that stage reference; always-on → SessionStart hook directive. Plug-in promotion is a reviewed edit to the xo repo, not an in-place memory write.
+- **Environment/project-specific** (this operator's accounts, paths, infra) → the project's `AGENTS.md` (durable, git-backed). The default suggestion.
+- **Ephemeral or uncertain** → leave in local memory.
+- **Already represented** in the plug-in or `AGENTS.md` → prune the redundant memory copy (dedup).
+- **Another skill's or plug-in's domain** (e.g. a NiFi rule belongs to the `openflow` skill, not XO) → ESCALATE: out of XO's promote scope; recommend the target skill and let the operator route.
+
+A file holding several rules may split across targets — classify each rule, carry each disposition separately, and split the file in Step 6.
+
+Same reconciliation discipline: if a rule is divergent from its durable counterpart, reconcile before pruning the copy. Provenance/currency lens: did the *user* attest the rule, or did the *agent* infer it? Is it still current? Bias — prune unverifiable agent-inferred claims; keep user-given instructions unless superseded.
+
+### Step 5 — Present the disposition table, then gate
+
+Present ONE table to the operator: each entry, its classification, the recommended action (prune / promote→target / reconcile / keep), and the signal or reason. The operator bulk-approves the clear-cut rows and adjudicates the flagged ones. Apply only on approval. Never delete or promote silently.
+
+### Step 6 — Rebuild the index; normalise
+
+After applying: where a multi-rule file split across targets, extract each rule to its target and remove it from the source (delete the file only if nothing remains). Rebuild `/memories/MEMORY.md` so it matches what remains (the index should reflect the store). Normalise naming conventions (one consistent prefix, e.g. `feedback-`).
+
+### Step 7 — Stamp the watermark
+
+Set `memoryPrune.lastPruned` to today's date in `/memories/xo/hygiene-state.json` (via the memory tool) so the nudge resets — the watermark marks "store reviewed", not "N pruned", so stamp it after any real review pass. Decline handling is in the Session-lifecycle reflex below (record `lastDeclined` if the operator declines the nudge).
+
+---
+
+## Mode: durable commit/push
+
+The session-start hygiene nudge ("your xocortex vault was last committed Nd ago / has N unpushed commits") points here. When wrapping up, offer to commit and push the vault so notes/tasks/diary are durable:
+
+```bash
+git -C "$XOCORTEX_HOME" add -A && git -C "$XOCORTEX_HOME" commit -m "<summary>" && git -C "$XOCORTEX_HOME" push
+```
+
+Only with operator approval, and only the xocortex vault — never push project code as a side effect of Cleanup. Committing resets the staleness the hook tracks (it reads git directly; no watermark needed).
+
+---
+
+## Reflexive sub-modes
+
+These surface as gentle reminders — never blocking, never automated without operator confirmation.
+
+### 1. Workflow-event: intermediate artifact pruning
+
+Trigger: when the operator confirms the outcome of the work is good (approval of a brief, merge of a PR, or explicit "we're done").
+
+Surface once:
+> "We're done with this work. Want to clean up intermediate artifacts?
+> [list `$XOCORTEX_HOME/tmp/wi{N}/` contents that aren't the final deliverable]"
+
+---
+
+### 2. State-threshold: infrastructure deployed
+
+Trigger: when the task notes or task status indicates deployed infrastructure.
+
+Surface once per session:
+> "Heads up — [infrastructure item] is still deployed from this work. Tear it down, or keep it running?"
+
+---
+
+### 3. Session-lifecycle: hygiene reminders surface at session start
+
+The durable-repo commit/push reminder and the Curate reminder are surfaced by the **SessionStart hook** (`hooks/sessionstart.js`, `buildHygieneNudges`). The hook decides *whether to present* a nudge from two inputs: the live condition (vault last committed >7d ago or unpushed commits >0; `/memories` last curated >30d ago) and a **decline watermark it never writes itself**.
+
+Recording the operator's response is the agent's job, not the hook's — the hook cannot know whether the operator actually saw or answered a nudge (a watermark written on generation silently consumed nudges on compaction-triggered starts, which do not surface them). So when a hygiene nudge appears:
+
+- **On decline / "not now":** record it so the nudge does not re-nag. Set the matching `lastDeclined` to today (ISO date) in `/memories/xo/hygiene-state.json` via the memory tool — `repoCommit.lastDeclined` for the commit/push nudge, `memoryPrune.lastDeclined` for the Curate nudge. The hook then suppresses that nudge for 7 days (`DECLINE_DAYS`).
+- **On accept:** run the matching process above (**Mode: durable commit/push** or **Mode: Curate**). No watermark write is needed — acting resets the condition: a commit clears staleness/unpushed; a completed Curate pass stamps `memoryPrune.lastPruned`.
+- **If neither (ignored):** the nudge re-presents at most once per session start until answered — intentional, so it reminds rather than silently dropping.
+
+---
+
+## Output contract
+
+- Worktree removed (confirmed via `git worktree list`)
+- Scratch files cleared or recorded as kept
+- Infrastructure decisions recorded in WI notes
+- Task status updated to Done if work is complete; archive via Update Task File (`references/save-protocol.md`)
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Capture (capture durable learnings — and promote any artefacts worth keeping — *before* teardown) and Ship. Haven't Captured? If there's nothing durable, say so and proceed.
+- **Leads to:** terminal — nothing follows Cleanup.

--- a/plugins/xo/skills/xo/references/act-document.md
+++ b/plugins/xo/skills/xo/references/act-document.md
@@ -1,0 +1,122 @@
+---
+name: act-document
+description: "Document stage — produce a well-founded explanation of something that exists. Parallel to Build (which produces the thing itself). Core discipline: drafter isolation (codebase-blind) + citation tracing. Assumes findings/evidence from prior Observe/Distil stages."
+---
+
+# Document
+
+Produce a user-facing explanation — guide, reference, report, README — with citation discipline. Every claim traces to evidence. The drafter is structurally isolated from source material, writing only from compiled findings. Any commands, code, or reference implementations in the output must be executed and verified before inclusion — only tested content ships; never caveat ("this should work") in place of testing.
+
+**Distinction from Build:** Build produces the *thing itself* (code, config, app). Document produces the *explanation of the thing*. Build's constraint is scope discipline (don't exceed the spec). Document's constraint is citation discipline (don't claim beyond the evidence).
+
+## When to use this stage
+
+- Explaining something that already exists (a feature, a system, a process, a decision)
+- Producing user-facing guides, API references, onboarding docs, how-to material
+- Creating reports or analyses where factual accuracy matters and claims must be traceable
+
+**When NOT to use:** If the "document" IS the primary deliverable (e.g., a spec, a design doc, a proposal) — that's Build. Document is specifically for explaining an existing thing with isolation guarantees.
+
+---
+
+## Input contract
+
+- **Findings brief** from prior Distil stage (`notes/{YYYY-MM}/{project}-wi{N}-distil.md` or equivalent)
+- OR **citation sources** (gathered in Survey: external docs, knowledge notes, stakeholder input)
+- Target audience and scope (from Spec, or operator direction)
+
+**If findings don't exist yet:** Route back to Observe → Distil first. Document does not survey or investigate — it writes from what's already established.
+
+---
+
+## The isolation model
+
+Load `references/refs-findings-contract.md` for the full rationale.
+
+The drafter (`xo-bounded-writer`) has **no codebase access** — no grep, glob, or bash tools. Its only input is the findings brief. This creates a hard contract:
+
+- If a fact is in findings → drafter can state it
+- If a fact is NOT in findings → drafter cannot state it (it has no way to discover it)
+
+This structurally prevents unbacked claims — the most common documentation failure mode.
+
+---
+
+## Process
+
+### Step 1: Draft (xo-bounded-writer — CODEBASE-BLIND)
+
+For shippable guides and reference docs, load `references/refs-guide-frontmatter.md` before drafting so the intended provenance frontmatter is part of the output shape from the start.
+
+```
+runSubagent(subagent_type: "xocortex:xo-bounded-writer", prompt: "
+  PERSONA: Drafter — write the explanation
+  INPUT_PATH: [findings brief path — THE ONLY SOURCE]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/doc-guide-draft.md
+  
+  Write a user guide based solely on the findings brief. Target audience: [audience].
+  Lead with 'how to do X', not 'how X works internally'. Use tables for reference material,
+  code blocks for examples. Keep sections short and scannable.
+  Do NOT add claims not in the findings brief. If a topic has UNTESTED items, omit it.
+")
+```
+
+### Step 2: Critic (xo-cold-smart — citation audit)
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — citation audit
+  REFERENCE: [findings brief path]
+  INPUTS: $XOCORTEX_HOME/tmp/wi{N}/doc-guide-draft.md
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/doc-audit.md
+  
+  Audit every factual claim in the guide against the findings brief.
+  Return PASS (backed), CONTRADICTION (guide contradicts finding), or UNBACKED (claim not in findings).
+  List each issue with the specific claim and what the findings say.
+")
+```
+
+Address CONTRADICTION and UNBACKED items: fix the guide or request additional findings from Observe. Re-run critic until clean.
+
+### Step 3: Finalize
+
+After clean audit:
+1. Apply frontmatter from `references/refs-guide-frontmatter.md` (provenance metadata) to every shippable guide or reference doc the stage produces
+2. Present to operator
+
+---
+
+## Source-cited variant
+
+When sources are external references rather than codebase findings:
+
+1. **Compile citations** from gathered sources (Survey output, knowledge notes, stakeholder input):
+   ```markdown
+   ### C1: [claim summary]
+   - Claim: [the assertion]
+   - Source: [where this comes from]
+   - Trust: [when, who, type of source]
+   ```
+2. **Draft** — same isolation: drafter receives only the citations document
+3. **Critic** — attribution audit: every claim has a source, trust signal is present
+
+---
+
+## Output contract
+
+Draft + clean audit. If the artifact is a shippable guide or reference doc, its final output must include the provenance frontmatter from `references/refs-guide-frontmatter.md`. Present the work to the operator:
+
+> "The [guide/report/document] is ready — citation audit passed. It's at `[path]`. Please review and let me know how you'd like to proceed."
+
+Do not push to Ship unprompted. The operator decides the next step.
+
+Route to **Review** (`references/decide-review.md`) as the formal gate — the operator accepts, requests revisions, or parks the work.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Before advancing:** update notes + task with what was produced and the citation-audit result.
+- **Usually follows:** Distil (findings exist) — or Build (the thing is built, now explain it).
+- **Leads to — primary:** Review (`references/decide-review.md` — operator gate: accept, revise, or park).
+- **After approval:** Ship (publish/deliver); Capture (if the guide becomes canonical).

--- a/plugins/xo/skills/xo/references/act-prove.md
+++ b/plugins/xo/skills/xo/references/act-prove.md
@@ -1,0 +1,263 @@
+---
+name: act-prove
+description: "Prove stage — demonstrate that the work satisfies the spec. Validation adapts to artifact type: automated tests (code), interactive/manual verification (UI/demos), state validation (configs/Snowflake), citation audit (documents), dry run (deployments). Dispatches appropriate subagents per mode."
+---
+
+# Prove
+
+Demonstrate that the work satisfies the spec. This stage handles validation regardless of artifact type — the method adapts, but the discipline is the same: **before Ship, prove correctness.**
+
+**Framing:** The stage is named "Prove" because proving correctness is the purpose, regardless of artifact type or validation method.
+
+## Validation mode decision
+
+| Artifact type | Validation mode | Method |
+|---|---|---|
+| Code (logic, APIs, data transforms) | **Automated tests** | Write + run tests (TDD, test-after, or reproduce-bug) |
+| UI, visual changes, interactive apps | **Interactive/hybrid** | Agent builds + operator verifies in browser/IDE |
+| Snowflake objects, configs, infra | **State validation** | Query/check that desired state is achieved |
+| Documents, guides, analyses | **Citation audit** | Verify claims against evidence; check completeness |
+| Deployments, demos | **Dry run** | Execute the flow end-to-end in staging/preview |
+
+The modes aren't exclusive — complex work may combine them (e.g., automated tests + interactive validation for a web app).
+
+---
+
+## Mode: Automated tests (code)
+
+### Testability assessment
+
+| Change type | Testability | Path |
+|---|---|---|
+| Logic, algorithms, data transformations | High | Proceed to test authoring |
+| API endpoints, service integration | High | Proceed |
+| UI behaviour, visual changes | Often low | Consider interactive/hybrid mode |
+| Configuration, build changes | Variable | Assess case by case |
+
+**When automated testing isn't practical**, present to operator:
+
+> "This change [describe] is difficult to test automatically because [reason].
+>
+> Options:
+> (a) Proceed with limited automated tests (coverage: [what can be tested])
+> (b) Switch to interactive mode — I'll build/deploy, you verify the behaviour
+> (c) Suggest a testing approach I may have missed"
+
+### Sub-modes
+
+| Sub-mode | When | Sequence |
+|---|---|---|
+| TDD (test-first) | Building to a spec, highest confidence | Prove.author → Build → Prove.verify |
+| Test-after | Verifying post-implementation | Build → Prove (author + verify) |
+| Reproduce-bug | Bug fixes — reproduce first, then fix | Prove.reproduce → Build → Prove.verify |
+
+### Prove.author — write tests
+
+**Dispatch: xo-generator (test author)**
+
+```
+runSubagent(subagent_type: "xocortex:xo-generator", prompt: "
+  PERSONA: Test-author
+  SPECIFICATION: [spec file path — tests encode the acceptance criteria]
+  INPUTS: [repo test conventions, test framework, existing test patterns from prior stages or Step 0]
+  WORKTREE: [worktree path]
+  
+  Write tests that encode acceptance criteria from the spec.
+  In TDD mode: tests should FAIL until implementation exists.
+  Write to test files only — do not touch implementation code.
+")
+```
+
+**Dispatch: xo-cold-smart Critic (test quality)**
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — test quality
+  REFERENCE: [spec]
+  INPUTS: [worktree path, test files written by test-author]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/prove-test-critique.md
+  
+  Review: do tests meaningfully encode the spec's acceptance criteria?
+  Are assertions substantive? Is coverage adequate?
+  Return APPROVE, REVISE, or BLOCK.
+")
+```
+
+### Prove.verify — execute and gate
+
+**Dispatch: xo-cold-fast Tester**
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-fast", prompt: "
+  PERSONA: Tester — execute and report
+  INPUTS: [worktree path, test command from prior stages or Step 0]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/prove-test-results.md
+  
+  Run the test suite. Report: pass/fail counts, failing tests and output, warnings.
+  Run focused new tests AND broader regression suite.
+")
+```
+
+**Dispatch: xo-cold-smart Verifier**
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Verifier — gate vs spec
+  REFERENCE: [spec]
+  INPUTS: [worktree path, $XOCORTEX_HOME/tmp/wi{N}/prove-test-results.md, critic verdicts]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/prove-verdict.md
+  
+  Verify: all spec requirements implemented and tested? All tests pass?
+  Return VERIFIED or NOT_VERIFIED (gap + ROUTE_TO: generator/test-author/tester).
+")
+```
+
+### Sub-mode: Reproduce-bug
+
+1. Read bug report or failure evidence
+2. Write a minimal reproduction test (xo-generator, test files only)
+3. Confirm the test fails as expected (xo-cold-fast Tester)
+4. Hand off to Build — the fix must make this test pass
+5. Full Prove.verify after Build
+
+---
+
+## Mode: Interactive/hybrid (UI, apps, demos)
+
+For work that requires human observation to validate — visual correctness, interaction flows, UX behaviour, or anything not easily captured in automated assertions.
+
+### Process
+
+1. **Agent deploys/starts the artifact** — run the app, start the server, open the preview
+2. **Present to operator** what to verify:
+   > "The [app/page/demo] is running at [URL/location]. Please verify:
+   > - [ ] [Acceptance criterion 1 from spec]
+   > - [ ] [Acceptance criterion 2]
+   > - [ ] [Visual/behavioural criterion]
+   >
+   > Let me know what passes, what fails, and any issues you observe."
+3. **Operator tests and reports** — interacts with the artifact, provides feedback
+4. **Agent records the result** — writes verdict based on operator observations
+
+### When to use
+
+- Browser-based applications (the IDE has a built-in browser)
+- Streamlit apps (the IDE can run them directly)
+- Visual/layout changes where screenshots don't capture the full picture
+- Interactive flows (multi-step forms, navigation, drag-and-drop)
+- Anything where "does it look and feel right?" is the acceptance criterion
+
+### Output
+
+Write `$XOCORTEX_HOME/tmp/wi{N}/prove-interactive-verdict.md`:
+- What was tested (list from spec)
+- What operator confirmed
+- Any issues reported
+- VERIFIED or NOT_VERIFIED
+
+---
+
+## Mode: State validation (configs, Snowflake objects, infrastructure)
+
+For work that produces system state rather than files — Snowflake objects, IAM roles, network configs, deployment infrastructure.
+
+### Process
+
+1. **Define expected state** from spec (objects exist, permissions granted, data flows correctly)
+2. **Run validation queries/checks:**
+   ```sql
+   -- Example: verify objects exist and are configured correctly
+   DESCRIBE TABLE {expected_table};
+   SHOW GRANTS ON SCHEMA {target_schema};
+   SELECT COUNT(*) FROM {pipeline_output} WHERE {quality_condition};
+   ```
+3. **Compare actual vs expected** — automated where possible
+4. **Write verdict** with evidence (query results)
+
+### When to use
+
+- Snowflake DDL (tables, views, procedures, tasks, stages)
+- Permission/role configurations
+- Data pipeline validation (rows flow, quality checks pass)
+- Infrastructure-as-code deployments
+- Environment provisioning verification
+
+### Output
+
+Write `$XOCORTEX_HOME/tmp/wi{N}/prove-state-verdict.md`:
+- Expected state (from spec)
+- Actual state (from queries/checks)
+- Delta (if any)
+- VERIFIED or NOT_VERIFIED
+
+---
+
+## Mode: Citation audit (documents, guides, analyses)
+
+For work that makes factual claims — verify claims are backed by evidence, not hallucinated or stale.
+
+### Process
+
+1. **Extract claims** from the document
+2. **Trace each claim** back to its source (findings brief, code, test results, external reference)
+3. **Check completeness** — does the document address all spec requirements?
+4. **Check staleness** — are sources current?
+
+This mode is already embedded in the Document stage's Critic step. Use it here when the Document stage was skipped (e.g., a standalone analysis that went straight from Build to Prove).
+
+### Output
+
+Write `$XOCORTEX_HOME/tmp/wi{N}/prove-citation-verdict.md`:
+- Claims checked (count)
+- Unbacked claims (if any)
+- Completeness vs spec
+- VERIFIED or NOT_VERIFIED
+
+---
+
+## Mode: Dry run (deployments, demos, presentations)
+
+For work that needs to execute end-to-end in a staging or preview environment before going live.
+
+### Process
+
+1. **Execute the full flow** in preview/staging — deploy, navigate, demonstrate
+2. **Check each acceptance criterion** from spec
+3. **Record any issues** — broken flows, missing assets, environment-specific failures
+4. **Present results** to operator for sign-off
+
+### When to use
+
+- Before deploying to production (after staging works locally)
+- Demo rehearsals (before showing to stakeholders)
+- Multi-step workflows where each step depends on the previous
+
+### Output
+
+Write `$XOCORTEX_HOME/tmp/wi{N}/prove-dryrun-verdict.md`:
+- Steps executed
+- Results per step
+- Issues encountered
+- VERIFIED or NOT_VERIFIED
+
+---
+
+## CALIBRATE note
+
+CALIBRATE: In TDD mode, Prove.author runs before Build and Prove.verify runs after — the orchestrator interleaves these around Build. The exact handoff timing may need tuning in real use. The intent is clear; the mechanics will be refined.
+
+---
+
+## Output contract
+
+A verdict file in `$XOCORTEX_HOME/tmp/wi{N}/prove-*-verdict.md` — VERIFIED or NOT_VERIFIED with routing (what to fix and where to go).
+
+After VERIFIED, proceed to Ship.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Build (validate the produced artifact) or Document (citation audit on the explanation) — or Spec (TDD: Prove.author writes tests before Build).
+- **Leads to — primary:** Ship (deliver the work).
+- **Or:** back to Build (redo loop on a failing verdict); Review (self-validation before shipping).

--- a/plugins/xo/skills/xo/references/act-provision.md
+++ b/plugins/xo/skills/xo/references/act-provision.md
@@ -1,0 +1,196 @@
+---
+name: act-provision
+description: "Provision stage — set up an isolated workspace before any production. Type-dispatch: git worktree (repo work), scratch-only (standalone artifacts), local infrastructure (apps/demos), Snowflake (DB objects/pipelines), or cloud deployment."
+---
+
+# Provision
+
+Set up an isolated workspace before producing anything. This stage creates the safety net for Build — work happens in a provisioned space; the operator's main environment stays clean.
+
+**Scratch already exists.** The per-WI scratch dir (`$XOCORTEX_HOME/tmp/wi{N}/`, recorded as `Scratch:` in the task file) was allocated at WI creation — Provision does **not** create it. Provision sets up the *workspace* (worktree, local runtime, Snowflake context, cloud target) which lives inside or alongside that scratch dir. If the scratch dir is somehow missing (a legacy WI created before scratch was first-class), `ls` then `mkdir -p` it once — never invent an alternative path.
+
+## When to use this stage
+
+- Before any implementation, document generation, configuration, or artifact production
+- When starting work on a new task regardless of output type
+- When setting up for a parallel-agent run (each agent needs its own workspace)
+
+---
+
+## Workspace type decision
+
+Before provisioning, determine what kind of workspace the work requires:
+
+| Work type | Workspace mode | What gets provisioned |
+|---|---|---|
+| Code changes in a repository | **Git worktree** | Isolated branch + worktree in `$XOCORTEX_HOME/tmp/wi{N}/<repo>/` |
+| Standalone artifact (document, spec, analysis, guide) | **Scratch-only** | `$XOCORTEX_HOME/tmp/wi{N}/` scratch directory — no repo needed |
+| App, demo, or UI that needs local runtime | **Local infrastructure** | Scratch dir + local server (Streamlit in-IDE, Docker, dev server) |
+| Snowflake objects (tables, procedures, pipelines, apps) | **Snowflake schema** | Scratch dir + target schema/database context confirmed |
+| Cloud deployment (SPCS, external hosting) | **Cloud infrastructure** | Scratch dir + deployment target confirmed with operator |
+
+**Ask the operator** when the work could fit multiple modes (e.g., a Snowflake procedure that also has a local test harness). Default to the simplest mode that covers the work.
+
+**IDE capabilities to remember:**
+- Built-in browser for previewing web apps and local servers
+- Streamlit execution environment (in-IDE)
+- Direct Snowflake account integration (SQL execution, object management)
+- Notebook support for exploratory/interactive work
+
+These are available without additional provisioning — note them when relevant.
+
+---
+
+## Mode: Git worktree (repository work)
+
+### Input contract
+
+- Target repository path
+- Approved spec or WI reference
+- Operator direction on branch/worktree preference
+
+### State assessment
+
+```bash
+git -C <repo> branch --show-current
+git -C <repo> status --porcelain
+git -C <repo> status -sb
+```
+
+| State | Implication | Default action |
+|---|---|---|
+| Clean, on main/master | New work | Create worktree at `$XOCORTEX_HOME/tmp/wi{N}/<repo-name>/` on branch `agent/wi{N}-<slug>` |
+| Clean, on feature branch | Resuming | Confirm this is the right branch |
+| Dirty, uncommitted changes | Prior work in progress | Clarify: continue, stash, or new worktree |
+| Behind remote | Missing upstream | Pull or rebase before starting |
+| Detached HEAD | Unusual state | Clarify intent with operator |
+
+### Operator confirmation
+
+> "Target: `<repo>` on branch `<branch>`
+> State: [clean/dirty], [ahead/behind/in-sync]
+>
+> Default: create worktree at `$XOCORTEX_HOME/tmp/wi{N}/<repo-name>/` on branch `agent/wi{N}-<slug>` — keeps main dir clean, isolates this work.
+>
+> Alternatives:
+> (a) Proceed on this branch (if already on the right feature branch)
+> (b) Create bare branch instead: `<suggested-name>`
+> (c) Stash existing changes first, then worktree
+>
+> Proceed with default, or specify alternative?"
+
+### Worktree creation
+
+Load `references/refs-workspace-setup.md` for commands and branch naming conventions.
+
+```bash
+git -C <repo> worktree add <worktree-path> -b <branch-name>
+```
+
+Standard branch name: `agent/wi{N}-<slug>` (see `workspace-setup.md`).
+
+---
+
+## Mode: Scratch-only (standalone artifacts)
+
+For work that doesn't modify a repository — documents, analyses, guides, configs, presentations.
+
+The pre-allocated scratch dir (`Scratch:` in the task file) **is** the workspace — no further setup needed. All subagent outputs, drafts, and intermediate artifacts go here. Final artifacts are promoted to their destination in Ship/Cleanup.
+
+No git state assessment needed. No branch to track.
+
+---
+
+## Mode: Local infrastructure (apps, demos, interactive work)
+
+When the work requires a running local process — a Streamlit app, a web app in the IDE browser, a Docker-based service, or an interactive prototype.
+
+1. Use the pre-allocated scratch dir (`Scratch:` in the task file)
+2. Determine runtime:
+   - **Streamlit in-IDE** — no additional setup; the IDE runs it directly
+   - **Local dev server** — note the command and port; IDE browser can preview
+   - **Docker** — confirm image availability and port mapping with operator
+   - **Notebook** — create `.ipynb` in scratch dir; IDE kernel handles execution
+3. Confirm with operator what runtime they expect and where they'll observe output
+
+---
+
+## Mode: Snowflake schema (database objects)
+
+When the work produces Snowflake objects — tables, views, procedures, tasks, stages, apps.
+
+1. Use the pre-allocated scratch dir (`Scratch:` in the task file)
+2. Confirm target context with operator:
+   - Database and schema
+   - Role (does the active role have CREATE privileges?)
+   - Whether to use a dev/staging schema or work directly in target
+3. Record the context in WI notes for downstream stages
+
+No worktree needed — the Snowflake account IS the workspace. The scratch dir holds SQL scripts and subagent artifacts.
+
+---
+
+## Mode: Cloud infrastructure (deployment targets)
+
+When the work deploys to a remote platform — SPCS, external cloud, hosted service.
+
+1. Use the pre-allocated scratch dir (`Scratch:` in the task file)
+2. Confirm deployment target and credentials with operator
+3. Note any cost implications or environment isolation requirements
+4. Record connection details and target in WI notes
+
+This mode often combines with another (e.g., git worktree for source + cloud for deployment).
+
+---
+
+## Scratch directory (universal — all modes)
+
+The per-WI scratch dir is the universal handoff surface, **allocated at WI creation** and recorded as the `Scratch:` field in the task file:
+
+```
+$XOCORTEX_HOME/tmp/wi{N}/
+```
+
+Provision does not create it — it already exists. Read the path from the task file and use it. If it is somehow missing (legacy WI), ensure it once with `ls "$XOCORTEX_HOME/tmp/wi{N}" || mkdir -p "$XOCORTEX_HOME/tmp/wi{N}"` — never invent an alternative location.
+
+Cold and bounded subagents write their handoff artifacts (findings, critiques, briefs) here — never into the codebase, and never creating directories themselves.
+
+**OUTPUT_PATH convention** — the **orchestrator** assigns each dispatched subagent a unique, fully-formed path:
+
+```
+$XOCORTEX_HOME/tmp/wi{N}/{stage}-{role}-{nn}.md
+```
+
+e.g. `tmp/wi319/workshop-edge-cases-01.md`, `tmp/wi319/review-security-02.md`. The unique `{role}`/`{nn}` suffix prevents collisions across parallel dispatches.
+
+---
+
+## Parallel-agent isolation
+
+When dispatching multiple sub-agents that write files, give each a distinct OUTPUT_PATH under the canonical scratch dir — never the same path — to prevent conflicts. The orchestrator merges their outputs.
+
+For agents that write to the worktree (Build, Prove.author), use separate worktrees per agent if parallelism is needed within a single stage.
+
+---
+
+## Output contract
+
+Confirm the workspace is ready:
+- Workspace type and location noted (used by Build, Prove, Ship, Cleanup)
+- Branch name noted if applicable (used by Ship in PR mode)
+- Runtime/deployment target noted if applicable
+- State recorded in WI notes
+
+---
+
+## Cleanup counterpart
+
+Provision creates the workspace structures (worktree, runtime, Snowflake/cloud context) inside the scratch dir; Cleanup removes them. The scratch dir itself is allocated at WI creation and cleared by Cleanup at the end. Always record the workspace location so Cleanup can find it. For Snowflake mode, record what objects were created (for potential rollback).
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Plan (you know what you're producing) — Provision sets up the isolated workspace before any production.
+- **Leads to — primary:** Build.
+- **Or:** Prove.author (TDD — author the tests before implementing), Document (if the deliverable IS documentation).

--- a/plugins/xo/skills/xo/references/act-ship.md
+++ b/plugins/xo/skills/xo/references/act-ship.md
@@ -1,0 +1,138 @@
+---
+name: act-ship
+description: "Ship stage — deliver the completed work to its audience. Pure delivery mechanics only — validation and approval are prior stages' responsibility. Multi-mode: PR, route-to-requestor, publish, deploy, share."
+---
+
+# Ship
+
+Deliver the completed work to whoever needs it. Ship handles purely the mechanics of getting the artifact to its audience. It does not validate, review, or gate — those are Prove's and Review's jobs.
+
+## When to use this stage
+
+- After the operator has approved the work (via Review or direct confirmation)
+- The artifact is ready to deliver — all gates passed
+
+---
+
+## Gate guard (reminder, not a re-run)
+
+Before delivering, confirm prior stages were completed:
+
+> **Check 1 — Reviewed?** Has this artifact been through Review (operator approval)? If not — pause and route to Review first. Do not ship unreviewed work. (If the operator explicitly said "ship it" or the pathway already passed through Review, this check is satisfied — proceed.)
+>
+> **Check 2 — Still current?** Before an irreversible post to a remote or shared target (PR, publish, share to a live thread), re-fetch **both** its code and its discussion surface and reconcile — it may have moved while the work was in Review. This check **always runs**, including after Review passed — time in Review is exactly when the target drifts. See the freshness reconcile in `references/core-guidelines.md` ("Freshness and concurrency") and `references/decide-review.md` (Step 3, item 4).
+
+Check 1 is a reminder to the orchestrator, not a validation step. Check 2 is a required gate before any irreversible post — not waived by "ship it" or a prior Review pass.
+
+---
+
+## Delivery mode decision
+
+| Work type | Delivery mode | Target |
+|---|---|---|
+| Code changes in a repository | **Pull request** | Repo reviewers via `gh pr create` |
+| Standalone deliverable (doc, analysis, spec) | **Route to requestor** | The person/channel who raised the demand |
+| Documentation for a docs site | **Publish** | Docs platform (Confluence, docs repo, wiki) |
+| App or service | **Deploy** | Platform (SPCS, Streamlit in Snowflake, hosting service) |
+| Demo, presentation, or shared artifact | **Share** | Stakeholders via appropriate channel |
+
+Ask the operator if the delivery target isn't obvious from the spec.
+
+---
+
+## Mode: Pull request (repository work)
+
+### Input contract
+
+- Worktree path and branch name (from Provision)
+- Build/Prove summary
+- Target repository + organisation
+
+### Steps
+
+1. **Auth** — confirm push access to the target repo. For Snowflake repos, confirm correct org. If issues, load `$snowflake-github`.
+
+2. **Push + create PR:**
+   ```bash
+   git -C <worktree> push -u origin <branch-name>
+   ```
+   Fetch PR template (`<repo>/.github/PULL_REQUEST_TEMPLATE.md`) or use standard format. Create with `gh pr create`.
+
+3. **Record** — update task file with PR URL, branch name, status `In Review`. Inform operator.
+
+### Handoff
+
+When reviewers leave comments → route to **Review** (`references/decide-review.md`, respond to feedback).
+When merged → route to **Cleanup**.
+
+---
+
+## Mode: Route to requestor (task deliverables)
+
+For work where someone asked for a specific output.
+
+### Steps
+
+1. **Deliver** — present the artifact to the operator with:
+   - Summary of what was produced
+   - Where it lives (path or location)
+   - Any caveats or follow-up needed
+
+2. **Record** — update task file. If requestor is external, ask operator whether to send directly or hand back.
+
+---
+
+## Mode: Publish (documentation)
+
+For guides, docs, or reference material reaching a documentation platform.
+
+### Steps
+
+1. **Submit** — depending on platform:
+   - **Docs repo:** Commit + PR (reuse PR mode)
+   - **Confluence/wiki:** Use available API or ask operator to paste/upload
+   - **Static site:** Commit to content directory + trigger build
+
+2. **Record** — note published location in task file and WI notes.
+
+---
+
+## Mode: Deploy (apps and services)
+
+For Streamlit apps, SPCS services, or other deployed artifacts.
+
+### Steps
+
+1. **Deploy** — depending on target:
+   - **Streamlit in Snowflake:** Load `$developing-with-streamlit-in-snowflake` skill
+   - **SPCS:** Load `$deploy-to-spcs` skill
+   - **Snowflake App Runtime:** Load `$snowflake-apps` skill
+   - **Other platforms:** Follow platform-specific steps or check for relevant available skills
+
+2. **Verify accessibility** — confirm the deployment is reachable. Provide URL/endpoint to operator.
+
+3. **Record** — note deployment URL, version/commit, and rollback instructions in WI notes.
+
+---
+
+## Mode: Share (demos, presentations, ad-hoc artifacts)
+
+For work reaching stakeholders via informal channels.
+
+### Steps
+
+1. **Deliver** — share via the appropriate channel. Ask operator for routing if unclear.
+
+2. **Record** — note what was shared, with whom, and where it lives.
+
+---
+
+## On completion
+
+After delivering, before treating the work as finished: record (update the task file and advance the `Provisional Pathway` `(here)` marker), then **proactively offer the operator the next stage** — Capture (keep durable learnings) then Cleanup (tear down the workspace) — once, dismissable. This is the moment close-out is most often skipped; the offer is the countermeasure. Do not auto-run Cleanup/commit while the operator may still be reviewing.
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Review (operator approved the work) — or operator's direct "ship it" instruction.
+- **Leads to — primary:** Capture (keep durable learnings) → then Cleanup (tear down workspace once accepted). *Capture before teardown.*
+- **Or:** Review (`references/decide-review.md`) if feedback arrives post-delivery.

--- a/plugins/xo/skills/xo/references/core-guidelines.md
+++ b/plugins/xo/skills/xo/references/core-guidelines.md
@@ -1,0 +1,64 @@
+---
+name: core-guidelines
+description: Cross-cutting operating rules for all XO stages — grounding discipline, source order, gates, storage, and per-phase invariants. Loaded at session start with save-protocol.
+---
+
+# Core Guidelines
+
+Operating rules that apply across all stages. Load at session start. Individual stage references add their own procedure on top of these.
+
+Routing/navigation discipline (triage, load-the-reference, gates, no-skip) lives in the SKILL.md Hard rules. This file is execution discipline *within* a stage.
+
+## Grounding and the bounding box
+
+The Observe and Orient stages establish the facts pertinent to the task before any commitment to action. **The bounding box** = the scope of facts pertinent to the task: Survey establishes its edges, Analyse establishes the facts inside it, Workshop tests implications inside it.
+
+- **Ground every claim.** Cite the evidence obtained for it — a file read, a command run, a path traced. A claim stated as fact without obtained evidence is an assumption; an assumption presented as fact is a **silent failure** (a defect that reads as success).
+- **Stay inside the box.** Report only facts and failure modes the artifact and request support. Do not add speculative risks they do not exhibit.
+- **Set depth by the box, not by confidence.** Calibrate effort to what the downstream stage requires. Confidence and token count are not evidence of sufficient coverage.
+
+## Source order (local-first)
+
+Check local sources before external services: (1) active WI notes (read directly), (2) the vault — notes/tasks/diary — by known identity directly, or by terms/topic/concept via **Recall** (`references/observe-recall.md`), (3) `/memories/` via the in-context `MEMORY.md` index, (4) external. Record negative results ("checked X for Y — none found") — they prevent re-traversal.
+
+**tgrep (optional accelerator, interactive only):** when searching the vault or a code repo interactively and a warm `tgrep` index is available, `tgrep` semantic/keyword search is a fast meaning-ranked complement (Desktop; needs Snowflake embed access). It does **not** replace the above — Recall stays the vault default, and grep/Recall remain the fallback whenever tgrep is unavailable, the index is cold (it says so), the context is unattended/hook, or you need exact-literal matching.
+
+## Freshness and concurrency
+
+XO is multi-session: the vault and other shared files may be edited by concurrent sessions at any time. **Having read a file is not the same as having its current state.** A read of a shared file — the WI index, another WI's task, the WI counter, shared code, repo files — is valid only for the turn it was made. Re-read immediately before editing or relying on it; never act on a read from an earlier turn or from before a subagent dispatch. Treat tallies, greps, and `git status` as point-in-time snapshots, not durable truth.
+
+Exception: a work item's own attached files — its task file, notes file, and `Scratch:` dir — are effectively owned by the session working that WI and are not normally touched by others. You can treat them as stable within your session without re-reading every time.
+
+**Remote objects have a discussion surface that also goes stale.** For a PR, a commented document, or a thread, the code or artifact is only half the state — the comments, reviews, and thread resolutions are the other half, and they move independently (an automated reviewer or a human may comment while you work, even with no new commit). Before any irreversible action against such a target (post, push, merge, publish), re-fetch **both** surfaces and reconcile. Treat "the commit hasn't changed" as insufficient evidence that the object is unchanged.
+
+## Survey before create (reflexive)
+
+Before ANY novel work (skill, doc, flow, fix, design): check whether it already exists or is already solved. Survey internally first (existing skills, workspace inventory, prior WIs/notes via Recall, the relevant repos), then externally (established patterns, MCP, Knowledge bases, etc.). Extend existing work rather than duplicate it. Reflexive — survey before creating, not after being prompted.
+
+## Execution discipline
+
+- **Edit with the tools, not the shell.** Use Edit/Write for normal files (notes, tasks, code); reserve shell append (`>>`) for the append-only diary. Never edit prose via `sed`/`echo`.
+- **Stage edits reviewably.** Discuss prose edits before making them; change in small reviewable steps. No mass rewrites or blind find-replace.
+- **Never present untested as confirmed.** A proposed solution is not a verified one — say "untested" until proven; build and run a reference implementation rather than caveating in place of testing.
+- **A correction signals an upstream failure.** When the operator corrects you, check if the findings or spec were wrong — fix and re-validate those first; do not assume a freshly-found source is the answer and re-implement on it. If that correction edits already-produced work, classify the diff's materiality (TRIVIAL vs SUBSTANTIVE per `references/refs-complexity-gate.md`) as an automatic reflex; surface the verdict to the operator in one line, override-able. A SUBSTANTIVE edit re-enters the Act loop — re-critique first, then re-prove — before the operator gate; TRIVIAL edits may fast-path but are still noted. When you present at the gate, summarise what the re-critique found and what changed since the operator's feedback.
+- **Never broad-search `~` or `Projects/`.** Do not recurse the home or projects tree with a slow search; if you cannot find something, ask the operator for the path.
+- **Never `gh auth switch` the shared global account.** Scope GitHub auth per call (`GH_TOKEN=…`) — parallel worktrees and sessions clobber the global `gh` auth and break each other.
+
+## Gates and phase boundaries
+
+- **Spec and Plan are operator gates.** No execution begins without an approved spec (and, for significant work, plan) or explicit operator direction.
+- **Stop and report at phase boundaries.** Produce the current stage's output and let the operator decide whether to continue. Do not run ahead into the next phase inside the current one.
+
+## Storage
+
+- **Scratch (transient):** use the `Scratch:` path from the WI task file (`$XOCORTEX_HOME/tmp/wi{N}/`) for subagent outputs, drafts, and intermediates. If the field or dir is missing, `ls` then `mkdir -p` once — never invent an alternative path. When dispatching subagents, the OUTPUT_PATH/WORKTREE you hand them must sit under this scratch dir — never a system-temp path (`/tmp`, `$TMPDIR`, `/var/folders`), `$HOME`, or an arbitrary location. The agent templates are contracted to confine every write to the paths they are given and to write nothing to system temp, `$HOME`, or arbitrary locations; do not undercut that by handing them an out-of-scratch path.
+- **Durable:** keep-worthy artifacts go to `notes/{YYYY-MM}/`.
+- **Memory namespace (`/memories/…`):** the memory-tool store — reached **only** via the `memory` tool (`memory view` / `memory create`), never the host filesystem. `/memories/…` is a tool namespace, **not** an absolute path: the host has no `/memories`, so never `ls`/`cat`/`grep` it from the shell. In prose it is always tool-attributed so it never reads as a host path; shown as a `memory` command argument it is the literal `path` you pass.
+- **Reviewable artifacts.** Every stage writes something the operator can check.
+
+## Per-phase invariants
+
+- **Observe** — every finding records how it was reached (source trace). Do not start Orient inside Observe.
+- **Orient** — Distil traces to observed facts, not inference. Workshop synthesis stays with the orchestrator and operator; sub-agents report angle findings but never the final recommendation.
+- **Decide** — Review is a critical evaluation, not a writeup: a cold Critic evaluates the artifact and its work-chain against the spec; approval on passing tests alone is prohibited. Capture is the expected close-out of shipped work — offered proactively and operator-gated (declinable, not skipped by default).
+- **Act** — Provision before production (never produce in the operator's main environment without permission). Build requires a spec; Document requires findings. Cleanup is the last step; do not leave workspaces, scratch, or deployed infra behind unrecorded.

--- a/plugins/xo/skills/xo/references/decide-capture.md
+++ b/plugins/xo/skills/xo/references/decide-capture.md
@@ -1,0 +1,163 @@
+---
+name: decide-capture
+description: Capture stage — keep durable learnings, operating rules, and environment facts for next time. Learnings → workspace notes; operating rules → memory (for Curate to place); environment facts (CLI profiles, paths) → the open project's AGENTS.md. Optional promote-out to a shared system; reflexive nudges on workflow events.
+---
+
+# Capture
+
+Decide what to keep. Capture is a triggered reminder to consolidate useful context into a form the next session can find and use — without ceremony and without requiring a curated knowledge base.
+
+The workspace notes are the knowledge base. Capture writes to them explicitly, with enough structure that a future grep or read will surface what was learned.
+
+## When to use this stage
+
+- After Review or Workshop, when a clear learning emerged that should survive beyond this session
+- After an investigation that uncovered useful facts about a system, repository, or process
+- When you had to ask for or rediscover an environment fact (CLI profile, repo/log path, service name) you will need again
+- When the operator says "capture this" or "I want to remember that"
+- When a reflexive sub-mode surfaces the reminder (see below)
+
+---
+
+## Mode: capture a learning (default)
+
+Decide whether the learning warrants a durable note.
+
+| Finding type | Worth capturing? | Why |
+|---|---|---|
+| Investigated a system in depth; will access again | Yes | Saves re-discovery |
+| Discovered repository standards (build, test, CI, conventions) during Survey or reconnaissance | Yes | Future sessions use cached conventions; add a refresh note so it can be updated when the repo changes |
+| Found a useful access pattern with nuance | Yes | Routing guidance |
+| Validated or invalidated a prior assumption | Yes | Update the record |
+| Trivial or one-off lookup | No | Not worth maintaining |
+| Too uncertain to commit | No | Note it in the active WI notes instead |
+
+---
+
+## Writing the durable note
+
+Write to `notes/{YYYY-MM}/_capture-[topic].md` (distinct from WI-specific notes):
+
+```markdown
+# [Topic] — [brief title]
+
+**Captured:** [date]
+**Context:** [brief: what prompted this capture]
+**Confidence:** high / medium / low
+
+## What is true
+
+[The key findings, stated as facts with evidence.]
+
+## How to access / use
+
+[If this is about a system or tool: how to reach it, what commands work, gotchas.]
+
+## Expires / review
+
+[When this might go stale: "review if X changes", "likely valid for ~6 months"]
+
+## Source
+
+[Link to the WI notes or diary entry where the full investigation lives.]
+```
+
+---
+
+## Mode: capture an operating rule
+
+Distinct from a learning (a fact about a system). An **operating rule** is an instruction, preference, or constraint on *how to work* — usually surfaced when the operator corrects you or states a standing preference ("never do X", "always do Y first").
+
+When one emerges, propose recording it — do **not** place it durably yourself (placement is Curate's job, in Cleanup):
+
+1. **Propose the default:** record it to memory as `/memories/feedback-<slug>.md` (a `type: feedback` entry, with a one-line **Why** and **How to apply**) so it survives this session and can be placed by the next Curate pass.
+2. **Offer a redirect gate:** "I'll record this rule to memory so it persists — or do you want it somewhere specific (this project's `AGENTS.md`)?" The operator accepts the default or redirects.
+3. **Record per the operator's choice.** If recorded to memory, add it to `/memories/MEMORY.md` so it is indexed.
+
+Capture detects and records the candidate; it does not classify local / project / plug-in or place it. That is **Curate** (in Cleanup). Recording to memory is the safe default; Curate places it later.
+
+---
+
+## Mode: capture an environment fact
+
+An **environment fact** is a stable, project- or machine-specific operational detail the agent needs to act correctly and repeatedly has to ask for or rediscover: a required CLI profile or flag (e.g. which AWS profile to use, or always invoking Python via `uv`), a repo/checkout/log/asset path, a connection or service name. Distinct from a *learning* (how something works) and a *rule* (how to behave).
+
+Record it in the **open project's `AGENTS.md`** under an `## Environment` section. `AGENTS.md` is auto-loaded, so the fact stays in context every session with no lookup step. Usually a few lines.
+
+1. Offer when you had to ask for it or found it by trial: "Record this in the project `AGENTS.md` so I have it next session? — e.g. which AWS profile to use, or 'always run Python via uv'."
+2. On yes: append a terse keyed line under `## Environment` (create the section if absent). Factual and short.
+3. The operator corrects it on demand ("that path moved — update it").
+
+Treat entries as provisional: confirm a path or profile still resolves before relying on it, and update the line if it has drifted.
+
+Example `## Environment` block:
+```
+## Environment
+- aws: use the project's designated profile for all `awscli` calls
+- python: always run via `uv`
+- repo: primary checkout at `/path/to/checkout`; logs at `/path/to/logs`
+```
+
+---
+
+## Mode: promote out
+
+When the captured learning is useful beyond the private workspace — for a shared team wiki, a docs site, a Confluence page, a Slack summary:
+
+1. Write the durable note as above
+2. Ask the operator:
+   > "This looks worth sharing more broadly. Want to promote it to [suggested destination - repo, wiki, docs]? I can prepare it for posting."
+3. If yes: prepare a version for the target audience (strip internal references per shared-content policy) and route to the appropriate channel
+
+**Promote is always optional and operator-driven.** Never auto-promote.
+
+---
+
+## Mode: promote artefacts to durable storage
+
+Beyond the distilled learning, decide whether any **artefacts** produced during the work — findings briefs, design explorations, review briefs sitting in `$XOCORTEX_HOME/tmp/wi{N}/` — deserve to survive. Scratch is discarded at Cleanup, so anything worth keeping must be promoted here:
+
+```bash
+mv "$XOCORTEX_HOME/tmp/wi{N}/<artifact>.md" "$XOCORTEX_HOME/notes/$(date +%Y-%m)/wi{N}-<slug>.md"
+```
+
+Capture is where you decide artefact durability; Cleanup executes the teardown of whatever wasn't promoted. Promote selectively — most scratch is transient; keep only the artefacts a future session would genuinely want to re-read.
+
+---
+
+## Reflexive sub-modes
+
+These reminders surface automatically — they are opt-in nudges, not blockers.
+
+### Workflow-event: post-Review reminder
+
+After any Review stage completes, surface once:
+> "Worth capturing any learnings from that review? (e.g. new patterns, access methods, common mistakes found)"
+
+The operator responds or ignores. No follow-up.
+
+### Workflow-event: asked for an environment fact
+
+When you have to ask the operator for an environment fact you will likely need again (a CLI profile/flag, a repo/log path, a service or connection name), offer to record it in the open project's `AGENTS.md` — see *Mode: capture an environment fact*. Surface once, at the point of asking.
+
+---
+
+## Output contract
+
+Write the durable note to `notes/{YYYY-MM}/_capture-[topic].md`.
+
+If the operator declines to capture ("nothing new"), record the explicit skip decision in the active WI notes:
+```markdown
+### Capture
+Skipped — [reason: e.g. "learnings already in WI notes", "too shallow to capture separately", "one-off lookup"]
+```
+
+This makes the skip a conscious decision, not a forgotten step.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Review, Document, Ship, or any substantial work that produced a durable learning or artefacts worth keeping.
+- **Leads to — primary:** Cleanup (terminal teardown — anything not promoted to durable storage is discarded there).
+- **Or:** Promote out (share the learning beyond the workspace — see *Mode: promote out*).

--- a/plugins/xo/skills/xo/references/decide-plan.md
+++ b/plugins/xo/skills/xo/references/decide-plan.md
@@ -1,0 +1,94 @@
+---
+name: decide-plan
+description: Plan stage — turn the approved specification into a production plan using the platform's plan mode. Plan mode (read-only) produces the plan artifact and acts as a cold review/structuring pass over the spec. Operator approves the plan before Act.
+---
+
+# Plan
+
+Turn the approved **specification** (the *what*) into a **production plan** (the *how*) — the sequenced task list the Act phase executes. Plan is where XO meets the platform's plan mode.
+
+## When to use this stage
+
+- After Spec, for significant work (new capabilities, multi-component changes, multi-step deliverables, anything where the path isn't obvious).
+- **Skip** for small, clear spec-driven work — the task NextAction is plan enough; go straight to Act.
+
+## Input contract
+
+- An approved spec (`notes/{YYYY-MM}/{project}-wi{N}-spec.md`), or a clear operator-stated requirement.
+
+## How it works — lean into plan mode
+
+Our specification is the robust, evidence-grounded artifact. Feed it into the platform's **plan mode** rather than hand-authoring a parallel plan:
+
+1. Switch to plan mode (read-only).
+2. Plan mode produces the plan artifact (`create_plan`) from the spec — the sequenced task list. In effect it performs a **cold review-and-structuring pass** over the specification.
+3. The operator approves the plan; then switch to agent mode and execute (Act).
+
+Both artifacts are durable: the spec in `notes/`, the plan under `.snowflake/cortex/plans/`.
+
+## Optional: cold plan critic
+
+For significant or multi-component plans, offer the operator an optional cold pass over the **plan** (distinct from the spec critic, which reviews the spec) before the gate:
+
+> "This is a multi-component plan — want a cold second-pass review of it before Act?"
+
+If accepted, dispatch a fresh `xo-cold-smart` (one that did not produce the plan) before presenting to the operator:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — plan review (you did not produce this plan)
+  REFERENCE: [the approved spec]
+  INPUTS: [the plan artifact + relevant findings / WI notes]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/plan-critique.md
+
+  Review this plan against the spec:
+  - Sequencing: are steps correctly ordered; does any step depend on a later one?
+  - Dependencies: are prerequisites and cross-component seams accounted for?
+  - Assumptions: any unverified assumption, or a spec requirement the plan omits?
+  - Scope: does the plan stay within the spec — nothing dropped, no scope creep?
+  Return APPROVE if the plan is sound, or REVISE with specific gaps.
+")
+```
+
+Fold its findings in before the operator gate. Offered, never mandatory — keep it proportionate to stakes.
+
+## Security review (when triggered)
+
+Check the plan against `references/refs-security-review-triggers.md`'s trigger table. If the plan touches credential handling, cross-boundary writes, sensitive file I/O, new IPC/API surface, sandbox/privilege context, or authentication flow changes, dispatch a security review of the **plan** before Act — the same review Build already runs on the diff, run one stage earlier so a security-relevant design gets checked before implementation, not only after.
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — security (plan review, pre-implementation)
+  REFERENCE: [the approved spec + the plan artifact]
+  INPUTS: [relevant findings / WI notes]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/plan-critic-security.md
+
+  Review the plan for security boundary violations, credential exposure, and trust boundary crossings it would introduce.
+  Map process/trust boundaries the plan implies. Trace where credentials would flow. Evaluate against the security checklist in refs-security-review-triggers.md.
+  Return SAFE, REVISE (specific concern + suggestion), or BLOCK (fundamental design concern).
+")
+```
+
+| Verdict | Action |
+|---|---|
+| SAFE | Proceed to the operator gate |
+| REVISE | Fold feedback into the plan before presenting |
+| BLOCK | Escalate to operator — do not proceed to Act |
+
+This runs independently of the optional cold plan critic above — a plan can warrant a security review without warranting a full sequencing/dependencies review, and vice versa.
+
+## Output contract
+
+- An approved plan (the task list). Update the task `NextAction` to the first Act stage.
+
+## Gate
+
+Operator approves the plan before any Act work begins — *nothing is built before this*.
+
+If the approved spec or approach is stale against current findings or repo state, surface it to the operator before Act.
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Spec (a bounding contract to plan against).
+- **Leads to — primary:** Provision (set up an isolated workspace, then Build), composed per the entry mode (spec-driven, TDD, …).
+- **Or:** Build directly (if no workspace isolation is needed). See `spec.md` for how Spec and Plan relate.

--- a/plugins/xo/skills/xo/references/decide-review.md
+++ b/plugins/xo/skills/xo/references/decide-review.md
@@ -1,0 +1,105 @@
+---
+name: decide-review
+description: Review stage — a cold Critic evaluates a completed artifact and its supporting work-chain against a named reference; a Briefer renders the verdict; the orchestrator self-corrects before the operator gate. Load on the assess-for-gate and respond-to-feedback pathways.
+---
+
+# Review
+
+Review evaluates a completed artifact against a reference and produces a justified verdict. It is the cold-critic counterpart to Build: Build proposes (warm), Review critiques (cold, fresh subagent that did not produce the artifact).
+
+Review is a critical evaluation, not a synthesis of existing notes. Do not approve on the basis of passing tests alone. Review is **read-only**: never edit the code under review, not even an obvious fix — report the finding and make any fix in a separate, gated step.
+
+## Required inputs
+
+1. **Artifact** — the completed work to evaluate (a diff, a Build output, an incoming PR, empirical commits, a document).
+2. **Reference** — the standard to judge against: the spec, plus the source files and the stated intent. If no spec exists (empirical / no-spec work), write a retrospective spec first (state what the work was required to do), then judge against it. Reviewing without a reference is prohibited.
+3. **Work-chain artifacts** — the upstream outputs that justify the artifact: survey/analysis findings, workshop notes, test results. Review assesses these too (see Scope).
+4. **Discussion state (for targets that have one)** — for a PR, a commented document, a Slack or issue thread: the existing comments, reviews, and thread resolutions. This is a first-class Review input, not background — a review of a PR that ignores the PR's own discussion is incomplete.
+
+## Scope — evaluate the whole chain
+
+Evaluate four dimensions, not the implementation alone:
+
+1. **Spec compliance** — which requirements are met, unmet, or diverged; what is out of scope (scope creep).
+2. **Test adequacy** — whether tests exercise the specified behaviour and its edge cases, or only pass; what is untested.
+3. **Foundation soundness** — whether the upstream survey/analysis was sufficient and the chosen approach was justified, or whether the artifact rests on unverified assumptions.
+4. **Risk** — regressions, side effects, necessity of each change, redundancy.
+
+### Congruence with the discussion
+
+Where the target has an existing discussion, evaluate your findings against it before forming the verdict: which points are already raised (by other reviewers or automated review), which are already resolved, which are genuinely new. Congruence is not conformity — you may dissent, but dissent must *engage* the prior comments, not ignore them; do not relitigate points already resolved.
+
+## Step 1: Review Critic
+
+Dispatch `xo-cold-smart` as the Review Critic (has evaluation authority and source access). Do not use `xo-bounded-writer` for this step — it cannot evaluate, only render.
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Reviewer — find where this work fails or is weak against its reference. Do not approve to satisfy; report defects. Your mandate is to find what is weak or wrong, not to ratify completion — dissent is the point.
+  REFERENCE: [spec or retrospective spec + stated intent]
+  INPUTS: [artifact + diff; source files; work-chain artifacts — survey/analysis/workshop notes, test results; discussion state — existing comments/reviews/thread resolutions, for targets that have one]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/review-critique.md
+
+  Evaluate against the reference across four dimensions:
+  - Spec compliance: requirements met / unmet / diverged; scope creep.
+  - Test adequacy: do tests exercise specified behaviour and edge cases, or only pass; what is untested.
+  - Foundation soundness: was upstream survey/analysis sufficient and the approach justified, or does the work rest on unverified assumptions.
+  - Risk: regressions, side effects, necessity, redundancy.
+  - Congruence with the discussion (targets that have one): which findings are already raised or resolved in the existing comments/reviews (including automated review), which are genuinely new. Flag any point that would relitigate a resolved thread. Dissent is allowed but must engage the prior comments.
+  Cite evidence for every finding (file:line, spec section, test name). Rate each: blocker / major / minor.
+  Include a `FILES_REVIEWED:` line listing every file or artifact actually reviewed.
+  Report only findings supported by evidence. Do not assert unverified concerns and do not invent risks the artifact does not exhibit.
+  Claims about the external world (URLs, third-party API behaviour, product/UI names, versions, external docs) are only as current as your training data. If you cannot verify such a claim with the tools available, mark it "unverified — needs live confirmation" and do NOT rate it blocker or major; a fact you could not check must not drive the verdict.
+  Address all four dimensions explicitly — never silently omit one. If a dimension does not apply (e.g. the artifact has no test surface), state "not applicable" and why; do not skip it.
+  End with a verdict (approve / request-changes / reject) and the evidence that supports it.
+")
+```
+
+When the subject requires build/test verification (risk factors present), gather empirical evidence first (load `references/refs-verified-review.md`) and pass it to the Critic as INPUTS.
+
+## Step 2: Briefer
+
+Dispatch `xo-bounded-writer` to render the Critic's findings for the operator. The Briefer renders only; it does not produce or revise the verdict.
+
+```
+runSubagent(subagent_type: "xocortex:xo-bounded-writer", prompt: "
+  PERSONA: Briefer
+  INPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/review-critique.md (and any other review-*.md from this pathway)
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/review-brief.md
+
+  Render an operator brief that states the verdict and the evidence justifying it. Structure:
+  - Verdict (approve / request-changes / reject) + one-line justification.
+  - Scope assessed: which artifact, against which reference.
+  - Spec compliance: met / unmet / diverged.
+  - Weaknesses and risks: each with severity and cited evidence.
+  - Test and foundation adequacy: whether tests and upstream analysis are sufficient to trust the artifact. State test adequacy on its own explicit line — if the artifact has no test surface, say so and why that is acceptable; never omit this line.
+  - For respond-to-feedback pathways: items addressed, items deferred, and the reason for each deferral.
+  Lead with the verdict. State disagreements between findings. Cite sources.
+")
+```
+
+## Step 3: Self-correct, then gate
+
+1. Read `review-brief.md` before presenting it.
+2. **Verify factual findings before you act on them.** If a blocker or major finding rests on a claim about the external world (a URL, third-party API behaviour, a product/UI name, a version, external docs) — especially from a Critic that lacked web/tool access — verify it against a live/authoritative source before it drives the verdict. A claim the Critic could not verify is not a defect until confirmed: downgrade or drop it if verification contradicts it. Then, for a finding that survives verification (unmet requirement, inadequate tests, unsound foundation), return to the relevant stage (Spec / Build / Prove), fix the defect, and re-run Review. Do not present a known-defective artifact to the operator — and do not present a false defect either.
+3. When no blocker or major finding remains, present the brief to the operator, who gates: approve, request changes, or reject.
+4. **Pre-post gate (remote/shared targets).** Before any irreversible action against a remote or shared target (posting a review, publishing, merging), two things must hold: the operator has approved the brief (item 3), and you have reconciled against the target's CURRENT state. Immediately before posting, re-fetch that state — **both code and discussion** — because it may have moved while you analysed; "the commit hasn't changed" is not sufficient evidence the object is unchanged. Reconcile your findings against it:
+   - New commits changed the artifact → re-run the relevant part of Review.
+   - New discussion (comments, reviews, resolutions) already covers your findings → do not duplicate. Switch to a lighter synthesis: endorse or relate to what is there, add only what is genuinely new, state your net position, and prefer leaving a standing review-state in place over re-submitting an echo. (Not a ban on full re-reviews — a full re-review is right when the artifact genuinely changed and the discussion does not already cover it.)
+   - A point you were going to raise has been raised-and-resolved → drop it or acknowledge the resolution; never re-raise as if fresh.
+5. **Verdict must match the action.** When the target supports distinct review actions (a PR: approve / request-changes / comment), submit the event that matches the verdict you presented — approve → approve, request-changes → request-changes, comment-only → comment. Never present "approve" and then post only a comment. After posting, verify the landed review state reflects the intended event.
+
+## Load on demand
+
+| Resource | When to load |
+|---|---|
+| `references/refs-complexity-gate.md` | respond-to-feedback pathway — classify each feedback item as trivial or substantive |
+| `references/refs-verified-review.md` | risk factors present — gather build/test evidence to feed the Critic |
+| `references/refs-author-test-plan.md` | the subject has an author-provided test plan |
+
+## Chaining (soft — reminders, not gates)
+
+- **Before advancing:** if this stage produced a finding worth keeping, update notes + task now.
+- **Usually follows:** a completed artifact to evaluate — a Build, a Ship-candidate, an incoming PR, or empirical commits.
+- **Leads to — primary:** return to Spec / Build / Prove when Review finds defects requiring iteration.
+- **Or:** on acceptance — Capture (durable learnings), then Cleanup. Capture before teardown.

--- a/plugins/xo/skills/xo/references/decide-spec.md
+++ b/plugins/xo/skills/xo/references/decide-spec.md
@@ -1,0 +1,201 @@
+---
+name: decide-spec
+description: Spec stage — write the bounding contract that execution stages consume. Structures intent as Goal/Requirements/Constraints/Output. The operator gates before any execution begins.
+---
+
+# Spec
+
+Write the specification — the **bounding contract** that turns an approved approach into a precise, actionable definition of what will be produced. Every downstream execution stage (Build, Prove, Document) works from the spec; it is the scoping artifact for the Act phase.
+
+A good spec is not about enumerating every detail — it is about bounding the execution space precisely enough that an agent can work on a closed question ("does this satisfy the spec?") rather than an open one ("what should I build?").
+
+## When to use this stage
+
+- An approach has been approved in Workshop and you're ready to commit to execution
+- The operator has stated a clear requirement and you need to formalise it before acting
+- You're using test-driven development: the spec's acceptance criteria become the tests
+
+---
+
+## Input contract
+
+- Workshop proposal (`notes/{YYYY-MM}/{project}-wi{N}-workshop.md`) OR operator-stated requirement
+- Active WI context (task file)
+- Optional: prior spec or related specification for reference
+
+---
+
+## Structure: intent-driven format
+
+Organise the spec around the four blocks of intent-driven development:
+
+```markdown
+# Spec — [brief title]
+
+## Goal
+[One sentence: what outcome this achieves. Not how — what.]
+
+## Requirements
+[What must be true for this to be done. Testable, observable assertions.]
+- R1: [requirement]
+- R2: [requirement]
+
+## Constraints
+[What must NOT be violated. Scope limits, compatibility, safety requirements.]
+- C1: [constraint]
+- C2: [constraint]
+
+## Non-goals
+[What this spec explicitly does NOT cover. Ground in evidence where possible.]
+- NG1: [out-of-scope item] — [evidence: abandoned PR / WONTFIX decision / NOT_SUPPORTED test]
+- NG2: [out-of-scope item]
+
+## Decisions
+[Design decisions made while authoring, and open questions deferred.]
+- Locked: [decision] — [rationale / evidence]
+- Deferred: [open question] — [what would resolve it]
+
+## Source map (chain of evidence)
+[Include when the spec leans on expanded or high-importance concepts that live elsewhere; skip for self-contained specs.]
+**Dereference rule:** Dereference a tagged concept's source before producing for it. Never improvise a tagged term. If a source or anchor is missing, STOP and ask.
+
+### Source keys
+- [KEY] -> [authoritative file/path/section]
+- [KEY2] -> [authoritative file/path/section]
+
+### Concept -> source
+| Spec term / concept | Authoritative source |
+|---|---|
+| [tagged concept] | [KEY] [section / anchor] |
+| [tagged concept] | [KEY2] [section / anchor] |
+
+## Output / Acceptance criteria
+[How we know this is done. What the agent can check. What the operator observes.]
+- Done when: [condition]
+- Anchor-integrity check: [before Build, every tagged concept resolves to a real source and nothing is left to improvisation]
+- Verify by: [how to verify]
+```
+
+**The spec is not a task list.** It defines the desired state; Act stages work out how to get there.
+
+**Non-goals should be evidence-grounded.** When writing non-goals, check the findings brief for abandoned approaches, WONTFIX decisions, and tests that assert unsupported behaviour — these are scope exclusions backed by prior art, not invented declarations. An NGx with evidence is far stronger than a bare declaration.
+
+**Record decisions.** Capture choices made during authoring as Locked (with rationale) and open questions as Deferred (with what would resolve them); review Deferred items before Act, since an unresolved open question is a scope risk.
+
+**Use a source map when the spec depends on shorthand.** If the spec leans on expanded or high-importance concepts that live in other files or sections — framing, numbers, quotes, definitions, redaction fences, named examples — add a `Source map (chain of evidence)` section. It turns shorthand into an explicit dereference contract for downstream execution. If the spec is self-contained and every requirement is stated in full, skip it.
+
+**Dereference before producing.** A tagged concept is a pointer, not a license to paraphrase from memory. Before Build, Document, or Prove use a tagged term, dereference its source and confirm the exact framing, numbers, and limits. If the authoritative source or anchor is missing, stop and ask the operator rather than guessing.
+
+---
+
+## Optional: draft spec critic
+
+For complex or high-stakes specs, dispatch a `xo-cold-smart` critic to challenge the draft before the operator gates it:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — spec review
+  REFERENCE: [the draft spec]
+  INPUTS: [relevant findings brief or prior WI notes]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/spec-critique.md
+  
+  Review this spec draft. For each section (Goal/Requirements/Constraints/Non-goals/Output):
+  - Is the intent clear and unambiguous?
+  - Are requirements testable/observable?
+  - Are there missing constraints or unstated assumptions?
+  - **Are non-goals explicit and evidence-grounded?** Check the findings brief for abandoned approaches, WONTFIX decisions, or prior art that was deliberately excluded — missing non-goals are a scope-creep risk.
+  - **Testing-adequacy: do the acceptance criteria actually verify the goal?** Check each Requirement has a corresponding way to observe it's met — acceptance criteria that can't be checked make the spec unplannable downstream, not just incomplete.
+  
+  Return APPROVE if the spec is sound, or REVISE with specific gaps.
+")
+```
+
+Address any REVISE feedback before presenting to the operator.
+
+## Optional: anchor-integrity verifier
+
+When the spec uses a source map, dispatch a `xo-cold-smart` critic to verify the chain before the operator gates it:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Critic — anchor-integrity check
+  REFERENCE: [the draft spec]
+  INPUTS: [source files or findings the source map cites]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/spec-anchor-integrity.md
+  
+  Review the spec's Source map (chain of evidence).
+  - Does every tagged concept resolve to a real source section or anchor?
+  - Are any tagged terms left to improvisation or unsupported paraphrase?
+  - Do the cited sources actually support the framing, numbers, quotes, and definitions the spec leans on?
+  
+  Return APPROVE if every tagged concept dereferences cleanly, or REVISE with the missing or broken anchors.
+")
+```
+
+Address any REVISE feedback before presenting to the operator.
+
+---
+
+## Operator gate (mandatory)
+
+**No execution begins without operator approval of the spec.**
+
+For build/act-pathway WIs, acceptance criteria must be present and operator-confirmed before Act. Investigation/observe (and other non-build) WIs state the deliverable *form* instead (e.g. "findings brief at the scratch path") and must not be blocked for lacking acceptance criteria.
+
+Present the spec:
+> "Here is the spec for [brief title]. Please review:
+> - Goal: [one line]
+> - [N] requirements, [M] constraints
+> - Done when: [acceptance criteria summary]
+>
+> Approve to proceed to Act, or let me know what to adjust."
+
+| Response | Action |
+|---|---|
+| Approved | Write spec to notes file; update task NextAction; proceed to Act |
+| Correction | Revise spec; re-present |
+| Reject | Return to Workshop (`references/orient-workshop.md`) for approach re-design |
+
+---
+
+## Spec and plan mode
+
+The harness offers a **plan mode** that the agent switches into for significant work (new capabilities, multi-component changes, multi-step deliverables, ambiguous problems). Lean into it — do not fight it or duplicate it. The relationship is:
+
+- **The specification is ours** — the robust, evidence-grounded contract produced by this stage (built on the Observe/Orient chain of evidence). It is more reliable than ad-hoc planning because every requirement traces back to findings.
+- **Plan mode produces the plan from the spec.** For significant work, write the specification first (agent mode, to notes), then **feed it into plan mode**. Plan mode is read-only and emits the plan artifact (`create_plan`) — the sequenced task list. In effect, plan mode performs a **cold review-and-structuring pass over the specification**, turning the contract into executable steps.
+- **On approval**, switch to agent mode and execute (Build/Prove/…). Both artifacts are durable: the spec in `notes/`, the plan under `.snowflake/cortex/plans/`.
+
+**Size picks the mechanism:**
+- *Significant work* → write the spec, then use plan mode to produce the plan from it.
+- *Smaller spec-driven work* (doesn't warrant plan mode) → a lightweight spec note is enough; proceed directly to Build.
+
+Do not author a separate parallel plan inside this stage — the spec is the contract; the **Plan stage** (`references/decide-plan.md`) turns it into the plan via plan mode (or, for small work, the task NextAction carries the steps).
+
+---
+
+## Output contract
+
+Write the approved spec to `notes/{YYYY-MM}/{project}-wi{N}-spec.md`. Update the task file:
+- Add `Spec: notes/{YYYY-MM}/{project}-wi{N}-spec.md` to the task frontmatter
+- Update `NextAction` to the first Act stage (or "produce plan from spec via plan mode" for significant work)
+
+---
+
+## Entry modes and TDD
+
+The spec informs how the Act phase is sequenced:
+
+- **Standard (spec-first)**: Spec → Plan → Provision → Build → Prove → Ship
+- **TDD (bracket-first)**: Spec → Plan → Prove (write failing tests encoding the spec's acceptance criteria) → Build (implement to green) → Prove (verify) → Ship
+- **Empirical (discovery-first)**: No upfront spec; after production, write a retrospective spec and enter Review (Mode C: Self-Validation)
+
+State the intended sequence at the bottom of the spec so the Act phase knows how to compose.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Workshop (an approach was chosen) — or Distil / the operator directly if the approach is obvious.
+- **Leads to — primary:** Plan (turn the spec into implementation steps via plan mode).
+- **Or:** Prove.author (TDD — write tests from the spec before building).

--- a/plugins/xo/skills/xo/references/observe-analyse.md
+++ b/plugins/xo/skills/xo/references/observe-analyse.md
@@ -1,0 +1,103 @@
+---
+name: observe-analyse
+description: Analyse stage — investigation of a known target to establish verified facts. Single-agent depth-first by default; parallel dispatch for large targets at the agent's discretion. Produces a verified-facts file.
+---
+
+# Analyse
+
+Depth-first investigation of a known target. The goal is to **establish what is actually true** about the subject — through careful reading, tracing, and empirical verification where possible. Not opinions; verified facts with cited sources.
+
+## When to use this stage
+
+- You have a specific target to investigate (from Survey or operator direction)
+- You need to establish facts before Distil can synthesise findings
+
+---
+
+## Input contract
+
+- A known target: a repository, a codebase area, a system, a set of files
+- The question to answer: "how does X actually work?", "what does Y actually do?", "is Z present?"
+- Optional: Survey location map from a prior Survey stage
+
+**Before deep analysis, check for a relevant skill.** If the target involves a Snowflake technology or another area with an available skill, prefer leveraging that skill over hand-rolling the investigation — it encodes the right approach and tools.
+
+**If the target is a code repository and the work is feature-level or involves understanding prior decisions**, surface the attendant-services offer before dispatching — see `references/refs-survey-methods.md` Codebase Investigation section. PR history, issue trackers, and wikis are particularly valuable sources of non-goals (WONTFIX decisions, abandoned approaches, deliberate scope exclusions) that feed directly into the Spec stage.
+
+---
+
+## Mode: investigation
+
+Investigation of a known target. By default, a single depth-first pass following connections level-by-level — but for large targets (a monorepo with distinct areas, a stack of PDFs where contract details could be in any of them) dispatch multiple agents in parallel, each scoped to a distinct area. Use judgment: parallel when one agent can't cover the target thoroughly; depth-first when focused precision is what's needed.
+
+### Dispatch (xo-cold-smart)
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Investigator — establish verified facts about [topic]
+  REFERENCE: [the question to answer or the spec to verify against]
+  INPUTS: [target path(s)]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/analyse-[topic].md
+  
+  Investigate [target] to answer: [question].
+  For each finding: cite file:line or specific evidence.
+  Record what you checked and what you found — including negative results.
+  Do not infer or guess; only report what you can cite. Do not speculate beyond the target — invented risks the artifact doesn't support are noise, not findings.
+")
+```
+
+### Empirical mode
+
+When static analysis isn't sufficient (behaviour under real conditions, build output, test results), add a `xo-cold-fast` Tester to run and report:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-fast", prompt: "
+  PERSONA: Tester — run [command or test] and report the output faithfully
+  INPUTS: [what to run, where]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/analyse-empirical-[topic].md
+  
+  Run [command]. Record the exact output. Note pass/fail counts, errors, and any environment issues.
+  Do not interpret — just report.
+")
+```
+
+The `xo-cold-smart` analysis and the empirical results are then synthesised by the orchestrator into the verified-facts file.
+
+---
+
+## Output contract
+
+**Completion condition: grounding.** Analyse is complete when every reported fact cites the evidence obtained for it (file:line, command output, traced path). Do not report recalled or assumed behaviour as fact — that is a silent failure. Set investigation depth by what the downstream stage requires, not by confidence or token count. Report only facts the evidence supports; do not add speculative risk.
+
+Write **verified facts** to `notes/{YYYY-MM}/wi{N}-analysis.md` (or `$XOCORTEX_HOME/tmp/wi{N}/analyse-*.md` for intermediate per-angle files):
+
+```markdown
+## Analysis — [subject] ([date])
+
+### Verified facts
+- [fact 1]
+  - Evidence: [file:line or command output]
+  - Confidence: high/medium/low
+
+### Negative results
+- Checked [X] for [Y] — not found / not present
+
+### Trust warnings
+- [any fact where the source is stale or uncertain]
+
+### Gaps
+- [what remains unknown]
+- [suggested follow-up]
+```
+
+Present findings to the operator. Ask: "Is this sufficient to proceed to Distil, or should we investigate [specific gap] further?"
+
+**If analysis returned nothing or far less than expected:** do not conclude absence. Check: did your approach cover the full target — different file structures, naming conventions, alternative locations? Test at least one alternative. Then surface the conflict: *"I expected to find [X] but found nothing using [approach]. Because [reason this could be wrong], I also tried [alternative] and found [result]. Possible remaining explanations: [A, B]. Shall I investigate further?"* Incomplete coverage is a gap to flag; a confident negative from an incomplete search is a fabrication.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Survey (the territory is mapped). Analyse can also be the entry point for a focused, single-target investigation.
+- **Leads to — primary:** Distil (synthesise the verified facts into a findings brief).
+- **Or:** Workshop (if the facts exposed a genuine design fork); Capture (if it was a one-off learning worth keeping). For traversal patterns and trust signals, load `references/refs-survey-methods.md`.

--- a/plugins/xo/skills/xo/references/observe-recall.md
+++ b/plugins/xo/skills/xo/references/observe-recall.md
@@ -1,0 +1,86 @@
+---
+name: observe-recall
+description: "Recall — the memory-vault retrieval primitive. Dispatches xo-cold-fast to expand a query into keywords, grep notes/tasks/diary, and return ranked full-path hits with excerpts. Canonical define-once pattern; invoked by Triage (fuzzy-recall resolution) and Survey (local-sources rung)."
+---
+
+# Recall
+
+**Recall is how XO searches its own memory vault.** It pairs with recording (the save protocol *writes* the vault; Recall *reads* it). The mechanism is zero-dependency at its floor: the LLM does the semantic work (expanding a vague query into the concrete terms likely to appear in the notes), and `grep` does the cheap literal matching — no native deps, no index to maintain, and it works everywhere, including unattended hook contexts. When a warm `tgrep` index is available (interactive Desktop with Cortex embed access), the expanded terms are also run through `tgrep` keyword/hybrid search, which meaning-ranks the hits and often lifts the strongest note above what literal matching finds. `grep` stays the guaranteed fallback: whenever tgrep is unavailable, its index is cold (it will say so), or you need exact-literal matching, Recall still works with no infrastructure at all.
+
+## When to use
+
+- **Triage:** the operator makes a fuzzy recall reference — "I vaguely remember we looked at X", "didn't we hit this before?", "that thing about Y". Resolve it to a concrete WI/note *before* routing.
+- **Survey:** the local-sources discovery rung — find what the vault already knows about a topic.
+- **Anytime reflex:** you wonder "have we seen this before?" mid-task.
+
+Not for: deep investigation of a known target (that's Analyse), or external/web discovery (that's Survey's external rung).
+
+---
+
+## The dispatch
+
+Dispatch `xo-cold-fast` (auto-fast model — keeps Recall cheap) with the Recall persona. **Recall returns results in-context, NOT to a file** — it is a fast interactive lookup, so override the agent's default OUTPUT_PATH behaviour explicitly:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-fast", prompt: "
+  PERSONA: Recall — search the operator's memory vault
+  INPUTS: query = '[the operator's query, verbatim or lightly cleaned]'
+          scope = $XOCORTEX_HOME/notes, $XOCORTEX_HOME/tasks, $XOCORTEX_HOME/diary
+
+  Step 1 — EXPAND the query into 4-10 keyword/phrase candidates: synonyms,
+  likely technical terms, class/product/customer names, and rephrasings that
+  would appear in the actual notes. (e.g. 'that idle-session housekeeping thing'
+  -> SessionIdleService, idle, timeout, hook, CronScheduler, housekeeping.)
+  Avoid ultra-generic terms that match everything (build, data, the).
+
+  Step 2 — SEARCH the scope (markdown only) for each candidate. If a warm tgrep
+  index is available, run the expanded terms through tgrep (keyword or hybrid
+  mode) and use its ranking; if tgrep is unavailable or reports a cold index,
+  GREP for each candidate instead. Either way, rank files by how many DISTINCT
+  candidates they contain (tie-break: total occurrences). Prefer prose notes over
+  machine-generated data dumps — discount artifact files (e.g. *-artifacts/*.json)
+  that rank on keyword density rather than relevance.
+
+  Step 3 — RETURN IN-CONTEXT (do not write a file). Top 5-8 hits, each:
+    - full path RELATIVE to \$XOCORTEX_HOME (e.g. notes/2026-06/wi314-...md) —
+      NEVER a bare basename (basenames collide: notes/ and tasks/ both hold
+      wi308-session-end-closure-hooks-investigation.md)
+    - a 1-2 line excerpt around the strongest match
+    - a one-line 'why relevant'
+  If nothing scores, say so plainly — do not pad with weak hits.
+
+  Single pass. Do not follow threads or read files deeply — that is Analyse.
+")
+```
+
+This is one bounded dispatch: expand -> grep -> rank -> return. Fast by design.
+
+---
+
+## Pairing with the memory index (segregated trust)
+
+The vault (notes/tasks/diary) is **authoritative** — it has passed the operator. `/memories` is **provisional agent scratch** — it may be stale or never sanctioned. Never blend them.
+
+Recall (the subagent) covers the **vault only**. For `/memories`, you already have the curated `MEMORY.md` index in your context at session start — glance it directly (and `memory view` a specific file if a pointer looks relevant). Do **not** send the subagent into `/memories`: it would lose the curated-index advantage and muddy the trust boundary.
+
+Present the two sources as **clearly-labelled separate groups**:
+
+```markdown
+**From the vault (checked — authoritative):**
+- notes/2026-06/wi314-kafka-binary-headers.md — little-endian Int64 header decode
+- ...
+
+**Also in agent scratch (/memories — provisional, verify before relying):**
+- [memory pointer], if any looked relevant
+```
+
+If there is nothing relevant in memory, omit the second group rather than padding it.
+
+---
+
+## Bounding
+
+- **Scope is fixed:** notes/tasks/diary under `$XOCORTEX_HOME`. No skills, no knowledge-base, no external, no `/memories` (handled by the index glance above).
+- **One pass, fast model.** No iterative deepening, no thread-following.
+- **Full relative paths always** — the single most important output rule (basename collisions are real in this workspace).
+- The orchestrator decides what to do with hits — Recall surfaces *associations ranked by overlap*, not verified answers.

--- a/plugins/xo/skills/xo/references/observe-survey.md
+++ b/plugins/xo/skills/xo/references/observe-survey.md
@@ -1,0 +1,127 @@
+---
+name: observe-survey
+description: Survey stage — breadth-first discovery to locate where the subject lives. Dispatches xo-cold-fast. Produces a location map / inventory file. Use before Analyse when the target location is not yet known.
+---
+
+# Survey
+
+Breadth-first discovery. The goal is to **map the territory** — locate where the subject lives, what sources contain relevant information, and what the inventory looks like — without going deep on any thread. Depth comes in Analyse.
+
+## When to use this stage
+
+- The target location is unknown ("where do we have anything about X?")
+- You need to map a domain before investigating it
+- Building an inventory for the operator to review before deciding what to dig into
+
+---
+
+## Input contract
+
+- Task intent or question from the operator
+- Optional: prior WI notes to check first (load them if they exist)
+
+**If the target includes a code repository and the work is substantive** (new feature, understanding prior decisions), surface the attendant-services offer before dispatching — see `references/refs-survey-methods.md` Codebase Investigation section. Skip this for bug fixes and quick targeted lookups.
+
+---
+
+## Mode: breadth scan (default)
+
+Scan across sources breadth-first. Collect pointers. Produce a map.
+
+### Source order (local-first, then broad)
+
+Survey ranges widely to find *where* a topic lives and *what* is already known. Check what we already have before re-discovering, then cast across external discovery surfaces.
+
+| Order | Source | How to check |
+|---|---|---|
+| 1 | Active WI notes | Read `notes/{YYYY-MM}/{project}-wi{N}-*.md` directly if a WI is active |
+| 2 | The vault (notes + tasks + diary) | **Recall** (`references/observe-recall.md`) — not a bare grep. Recall expands the query into candidate terms, then greps; it bridges the vocabulary gap a literal grep misses. |
+| 3 | `/memories/` directory | Glance the in-context `MEMORY.md` index; `memory view` a specific file if a pointer looks relevant. Do not send Recall here — its scope is the vault only. |
+| 4 | External discovery surfaces | Glean, wiki/Confluence, Google Docs, the web, code repositories, and any connected MCP sources — to locate where the topic lives and what's documented |
+
+**Check local first** (1–3) so you don't re-discover what we already know — but Survey's job is breadth: once local is checked, range across whatever external surfaces and MCP tools are available. No results means "not yet documented" — not "nothing exists."
+
+Before you range outward, consult any registered knowledge sources relevant to the topic and suggest them to the operator rather than auto-searching them. Use the survey context to frame the offer plainly: *"You've previously found [source] useful for [domain] — want me to include that in this survey?"*
+
+### Reach for available skills
+
+When the topic touches unfamiliar territory — especially Snowflake technologies (Cortex, semantic views, Snowpark, Iceberg, Streamlit, etc.) — a relevant **skill** very likely already exists. Treat *"is there a skill for this?"* as a first-class part of the survey: check the available skills and prefer using a matching one over improvising your own approach. The strong default is to use the capability that exists rather than hand-roll.
+
+### Dispatch (xo-cold-fast)
+
+For broad scans across multiple sources or a large codebase, dispatch one or more `xo-cold-fast` agents in parallel — one per distinct source area:
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-fast", prompt: "
+  PERSONA: Surveyor — scan for all references to [topic]
+  INPUTS: [source area path or system]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/survey-[source-area].md
+  
+  Scan [source area] for any content related to [topic]. 
+  Record what you find, where it lives, and any pointers to related material.
+  Record negative results: what you checked and found nothing relevant.
+")
+```
+
+Run multiple dispatches in parallel when covering genuinely distinct areas. Each writes its findings to `$XOCORTEX_HOME/tmp/wi{N}/survey-[area].md`.
+
+### Inline survey (single source, quick)
+
+For a single focused source, survey inline without dispatching a sub-agent:
+1. Cast wide with a broad grep/glob
+2. Collect pointers (paths, section names, document titles)
+3. Do NOT read deeply — just locate
+
+---
+
+## Mode: targeted sweep
+
+When you know the general area but need a complete inventory of everything in it:
+
+1. Identify the root path or source system
+2. Dispatch `xo-cold-fast` with PERSONA: "Surveyor — complete inventory of [area]"
+3. Agent enumerates all relevant items with brief descriptions
+
+---
+
+## Output contract
+
+**Survey establishes the edges of the bounding box** (the scope of pertinent facts). Report where the subject lives and what is in scope. Do not verify internals — that is Analyse. A gap in the map is an unbounded region: report it as a gap, do not omit it.
+
+Write a **location map / inventory** to `notes/{YYYY-MM}/{project}-wi{N}-survey.md`:
+
+```markdown
+## Survey — [topic] ([date])
+
+### Sources checked
+- [source 1]: [what was checked] — [result: found X / no relevant results]
+- [source 2]: ...
+
+### Location map
+- [item]: [where it lives] — [brief note]
+- ...
+
+### Gaps
+- [what wasn't checked and why]
+- [suggested next: Analyse on [specific target]?]
+```
+
+Present the map to the operator and ask: proceed to Analyse on [target], or Survey more?
+
+**If the survey returned nothing or far less than expected:** treat this as a conflict to surface, not a conclusion to report. State what you searched, how you searched it, and why the result might be wrong (wrong location? wrong terms? wrong source system?). Suggest an alternative: *"I expected to find [X] but found nothing. Possible reasons: [A, B]. Shall I try a different search strategy?"* It is not acceptable to report a null result and stop — the user cannot act on a finding they don't have.
+
+---
+
+## Next step
+
+Load `references/observe-analyse.md` to go deep on a specific finding from this survey.
+
+Load `references/refs-survey-methods.md` for detailed traversal patterns and trust signals.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Triage (a research or investigation intent) — Survey is often where Observe starts.
+- **Leads to — primary:** Analyse (go deep on a specific finding).
+- **Or:** Distil (if breadth already answered the question and you just need to write it up); or stop, if the question is now answered.

--- a/plugins/xo/skills/xo/references/orient-distil.md
+++ b/plugins/xo/skills/xo/references/orient-distil.md
@@ -1,0 +1,109 @@
+---
+name: orient-distil
+description: Distil stage — Compiler archetype (xo-bounded-writer). Takes raw evidence files and produces a findings brief, the scoping artifact consumed by Workshop and Decide. Output is findings.md.
+---
+
+# Distil
+
+Compile raw evidence into a clean statement of findings. The output — `findings.md` — is a **scoping artifact**: it pins down what was actually observed, so every downstream stage (Workshop, Spec, Build, Document) works from the same grounded basis rather than diverging on assumptions.
+
+## When to use this stage
+
+- You have raw survey or analysis output from Observe and need to synthesise it
+- You need a coherent findings brief before designing an approach (Workshop) or writing a spec
+- The raw evidence is spread across multiple sub-agent outputs and needs compiling into one document
+
+---
+
+## Input contract
+
+- One or more evidence files (`$XOCORTEX_HOME/tmp/wi{N}/survey-*.md`, `$XOCORTEX_HOME/tmp/wi{N}/analyse-*.md`, notes from observation passes)
+- The question that was being investigated
+- Optional: the active WI task file for context
+
+---
+
+## Mode: compile (default)
+
+Dispatch `xo-bounded-writer` to compile the evidence into a findings brief. The bounded-writer has no codebase-exploration tools — it can only read its inputs and write its output, which structurally prevents it from adding ungrounded claims.
+
+```
+runSubagent(subagent_type: "xocortex:xo-bounded-writer", prompt: "
+  PERSONA: Compiler — synthesise evidence into a findings brief
+  INPUT_PATH: [path(s) to evidence files — survey outputs, analysis files, observation notes]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/findings.md
+  
+  Read all evidence files. Write a findings brief that:
+  1. States each key finding with the source evidence it traces to
+  2. Notes contradictions or conflicting sources explicitly
+  3. Lists what was NOT found (negative results)
+  4. Identifies gaps — things the evidence doesn't yet address
+  5. Preserves trust-signal annotations from the source material
+  
+  Do not add claims not present in the input evidence. If the evidence has gaps, name them explicitly
+  rather than filling them with inference.
+")
+```
+
+---
+
+## Mode: inline compile (simple cases)
+
+When the evidence is straightforward (single source, short), compile inline as the orchestrator rather than dispatching a sub-agent:
+
+1. Read all evidence files
+2. Write `$XOCORTEX_HOME/tmp/wi{N}/findings.md` directly in the format below
+3. Present to operator for review before proceeding
+
+Use this for small investigations; use the sub-agent dispatch for rich multi-source evidence.
+
+---
+
+## Output contract
+
+Write a **findings brief** to `$XOCORTEX_HOME/tmp/wi{N}/findings.md`:
+
+```markdown
+# Findings — [topic] ([date])
+
+## Key findings
+
+### F1: [finding title]
+- **Finding**: [what is true]
+- **Evidence**: [source file:line or specific observation]
+- **Confidence**: high / medium / low
+- **Notes**: [any caveats or trust warnings]
+
+### F2: [finding title]
+[...]
+
+## Negative results
+- [what was looked for and not found] — prevents re-investigation
+
+## Gaps
+- [what the evidence doesn't address]
+- [what would need to be investigated to fill this gap]
+
+## Contradictions
+- [source A says X; source B says Y — flag for operator resolution]
+```
+
+**Every claim in this brief must trace to evidence.** If something isn't in evidence, put it in Gaps, not Findings.
+
+This file is the scoping contract for Workshop and Spec. Do not proceed without operator review.
+
+---
+
+## Next step
+
+Present `$XOCORTEX_HOME/tmp/wi{N}/findings.md` to the operator. Ask: "Does this capture what we found accurately? Ready to proceed to Workshop?"
+
+Then load `references/orient-workshop.md` to design the approach.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Analyse (and/or Survey) — Distil needs evidence to synthesise.
+- **Leads to — primary:** Workshop (explore candidate approaches from the findings).
+- **Or:** Spec (if the approach is already clear); Build (empirical-improvement: findings inform what to change); Document (doc-a-feature: Analyse → Distil → Document); Review (self-validation against the findings).

--- a/plugins/xo/skills/xo/references/orient-workshop.md
+++ b/plugins/xo/skills/xo/references/orient-workshop.md
@@ -1,0 +1,157 @@
+---
+name: orient-workshop
+description: Workshop stage — dispatch xo-cold-smart agents on parallel angles, then synthesise with the human. Produces the approach proposal and plan artifact. The orchestrator and operator do the final synthesis — no sub-agent provides the recommendation.
+---
+
+# Workshop
+
+Parallel exploration of candidate approaches, synthesised into a proposal by the orchestrator and operator together. The sub-agents establish the facts about each angle; the **human makes the judgment call**.
+
+This is the stage where XO's "bounded work to sub-agents; creative synthesis to human" principle is most explicit. Sub-agents tell you what the landscape looks like on each angle; they do not recommend which path to take.
+
+## When to use this stage
+
+- You have findings (from Distil or equivalent) and need to explore the design space
+- A proposed approach needs stress-testing before committing to a spec
+- The operator has asked "what are our options here?"
+
+---
+
+## Input contract
+
+- `$XOCORTEX_HOME/tmp/wi{N}/findings.md` (from Distil) OR equivalent grounded findings
+- The question or problem to explore approaches for
+- Optional: a proposed approach to stress-test
+
+---
+
+## Mode: parallel exploration (default)
+
+Dispatch multiple `xo-cold-smart` agents simultaneously — one per angle. Each returns a findings report to its OUTPUT_PATH. All dispatches go in a **single message** to run truly in parallel.
+
+### Default angles
+
+| Angle | Prompt persona | Question to answer |
+|---|---|---|
+| Existing Patterns | Investigator: Existing Patterns | How does the codebase / system already solve similar problems? What can be reused? |
+| Edge Cases | Investigator: Edge Cases | What could go wrong? What are the boundary conditions and failure modes? |
+| Alternative Approaches | Investigator: Alternative Approaches | What other solutions exist? What has been tried and abandoned? What are simpler or safer alternatives? |
+| Integration Impact | Investigator: Integration Impact | How does the proposed approach affect the rest of the system? Who else needs to change? |
+
+Custom angles replace or supplement defaults per the WI context. Consider whether you want to include any common additions: Security Surface, Performance, Migration Path, Team Impact.
+
+### Dispatch (all in a single message)
+
+**Angle discipline (applies to every dispatched agent):** (1) Cite the evidence for each claim (file, code path, source examined); an unverified claim stated as fact is a silent failure. (2) Report only implications the artifact and findings support; do not invent failure modes the artifact does not exhibit. For the Edge Cases angle: trace error paths present in the code, not hypothetical scenarios. (3) Record off-angle discoveries under Gaps, not in the angle's own section.
+
+**Scratch paths**: OUTPUT_PATHs are under the canonical per-WI scratch dir `$XOCORTEX_HOME/tmp/wi{N}/` — the `Scratch:` path recorded in the WI task file (allocated at WI creation). The orchestrator assigns each agent a unique, fully-formed path under it; agents write there directly with the `write` tool and never create directories. If the dir is somehow missing (legacy/ad-hoc WI), the orchestrator `ls`/`mkdir -p`s it once before dispatching — never invent an alternative path.
+
+```
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Investigator — Existing Patterns angle
+  REFERENCE: [findings brief from Distil or problem description]
+  INPUTS: [scope — repo paths, system description, relevant codebase areas]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/workshop-angle-existing-patterns.md
+  
+  Investigate the Existing Patterns angle. Answer: how does this codebase or system already solve similar problems? What can be reused, and what looks reusable but has hidden constraints?
+  Evidence first. Every finding must cite a source. Stay on your angle — note off-angle discoveries under Gaps.
+")
+
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Investigator — Edge Cases angle
+  REFERENCE: [findings brief]
+  INPUTS: [scope]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/workshop-angle-edge-cases.md
+  
+  Investigate the Edge Cases angle. Answer: what could go wrong? Trace error paths, boundary conditions, concurrent access, partial failures, backward compatibility risks.
+  Evidence first. Stay on your angle.
+")
+
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Investigator — Alternative Approaches angle
+  REFERENCE: [findings brief]
+  INPUTS: [scope]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/workshop-angle-alternatives.md
+  
+  Investigate the Alternative Approaches angle. Identify at least 2-3 viable alternatives to the proposed solution. For each: describe the approach, assess complexity, identify risks. Check git log and closed PRs for abandoned approaches.
+  Evidence first. Stay on your angle.
+")
+
+runSubagent(subagent_type: "xocortex:xo-cold-smart", prompt: "
+  PERSONA: Investigator — Integration Impact angle
+  REFERENCE: [findings brief]
+  INPUTS: [scope]
+  OUTPUT_PATH: $XOCORTEX_HOME/tmp/wi{N}/workshop-angle-integration-impact.md
+  
+  Investigate the Integration Impact angle. Trace callers and dependents of modified code. Check API contracts, configuration surface, cross-repo impact. Answer: what breaks or changes behaviour outside the immediate change?
+  Evidence first. Stay on your angle.
+")
+```
+
+---
+
+## Synthesis (orchestrator only — MANDATORY)
+
+**This step is done by the orchestrator in conversation with the operator. Do not dispatch a sub-agent for synthesis.**
+
+After all angle agents return, read all four output files and synthesise:
+
+```markdown
+## Workshop — [problem] ([date])
+
+### Angle summaries
+- **Existing Patterns**: [key finding] — [implication for the approach]
+- **Edge Cases**: [key finding] — [implication]
+- **Alternatives**: [key finding] — [implication]
+- **Integration Impact**: [key finding] — [implication]
+
+### Cross-angle insights
+- [patterns that emerged across multiple angles — e.g., "all three angles point to X as the riskiest aspect"]
+- [contradictions that need resolution before choosing]
+
+### Candidate approaches
+
+**A: [name]**
+- Description: [what this approach does]
+- Pros: [evidence-backed]
+- Cons: [evidence-backed]
+- Risk: [from edge-cases angle]
+
+**B: [name]**
+[...]
+
+### Recommendation
+[Approach A/B/C] — because [reasoning citing angle findings].
+
+[State what the human needs to decide: "This recommendation assumes X is acceptable; if not, Approach B is the safer option."]
+```
+
+Present to the operator for judgment. The recommendation is yours to make; the decision is theirs.
+
+---
+
+## Mode: single-angle investigation
+
+When only one dimension needs exploration, dispatch a single `xo-cold-smart` with the appropriate angle persona rather than the full four-way or more parallel. Synthesise inline.
+
+---
+
+## Output contract
+
+**Completion condition: grounding.** Workshop is complete when each angle's claims are evidence-backed and every candidate approach's pros, cons, and risks trace to angle findings rather than assertion. Report complications the artifact exhibits; do not invent ones it does not. Set the number of angles and depth by what the downstream decision requires.
+
+Write the synthesis to `notes/{YYYY-MM}/{project}-wi{N}-workshop.md` and update the task NextAction to point to Spec (`references/decide-spec.md`).
+
+---
+
+## Next step
+
+Operator approves the approach → proceed to **Spec** (`references/decide-spec.md`) to write the bounding contract.
+
+---
+
+## Chaining (soft — reminders, not gates)
+
+- **Usually follows:** Distil (grounded findings to explore from).
+- **Leads to — primary:** Spec (commit the chosen approach to a bounding contract).
+- **Or:** back to Analyse (if the angles exposed missing facts that must be established first).

--- a/plugins/xo/skills/xo/references/refs-author-test-plan.md
+++ b/plugins/xo/skills/xo/references/refs-author-test-plan.md
@@ -1,0 +1,157 @@
+---
+name: refs-author-test-plan
+description: "Detailed protocol for handling author-provided test plans. Applicable in any review-type pathway where the subject has an author-provided test plan — not only interactive testing. Extraction patterns, merge logic, classification examples, and edge cases."
+---
+
+# Author Test Plan Protocol
+
+When PR authors provide test plans, this protocol ensures consistent handling across all review modes.
+
+## Extraction Patterns
+
+### Common Test Plan Formats
+
+**Explicit Section:**
+```markdown
+## Test plan
+- [ ] Step 1
+- [ ] Step 2
+```
+
+**Checkbox List in Body:**
+```markdown
+Changes:
+- Added feature X
+
+Testing:
+- [ ] Verify X works
+- [ ] Check Y doesn't break
+```
+
+**Inline Instructions:**
+```markdown
+To test: run `npm test` and verify output includes...
+```
+
+**Linked Document:**
+```markdown
+See [testing guide](link) for verification steps.
+```
+
+### Extraction Rules
+
+1. Look for headings containing: "test", "verify", "check", "how to"
+2. Look for checkbox lists (`- [ ]` or `- [x]`)
+3. Look for numbered steps following "to test" or "verification"
+4. If no explicit test plan, check PR template sections
+
+## Code-Derived Test Generation
+
+### Mapping Code Changes to Tests
+
+| Code Change | Implied Test |
+|-------------|--------------|
+| New component/class | Instantiate and verify basic behaviour |
+| New render method | Verify output in all states (loading, success, error, empty) |
+| New event handler | Trigger event and verify response |
+| New conditional branch | Exercise both true and false paths |
+| New error handling | Trigger error condition, verify handling |
+| State persistence change | Verify save and restore |
+| API endpoint change | Call endpoint, verify response shape |
+| CSS/styling change | Visual verification of affected elements |
+
+### Example: UI Component PR
+
+Code changes:
+```typescript
+// New card component with expand/collapse
+class SqlToolCard {
+  render() { ... }
+  onHeaderClick() { this.expanded = !this.expanded }
+  renderError(error: Error) { ... }
+}
+```
+
+Code-derived tests:
+1. Card renders with correct initial state
+2. Click header → card expands
+3. Click header again → card collapses
+4. Error state renders with error styling
+5. Card state persists across re-renders
+
+## Merge Logic
+
+### Priority Rules
+
+| Scenario | Action |
+|----------|--------|
+| Author item matches derived item | Keep single entry, mark as "validated" |
+| Author item not derivable from code | Keep (author knows undocumented intent) |
+| Derived item not in author plan | Add with note "code-derived" |
+| Author item contradicts code | Flag for clarification |
+
+### Conflict Resolution
+
+If author's test and code-derived test conflict:
+```markdown
+**Conflict detected:**
+- Author says: "Verify card is always expanded"
+- Code shows: `expanded` defaults to `false`
+
+Resolution needed: Is the default behaviour correct, or is the test plan outdated?
+```
+
+Present conflict to operator before proceeding.
+
+## Classification Examples
+
+### AUTOMATED
+
+- Run SQL query, check output contains expected fields
+- Call API endpoint, verify response status
+- Execute command, check exit code
+- Read file after operation, verify content
+
+### INTERACTIVE
+
+- Click button, verify visual feedback
+- Hover element, verify tooltip appears
+- Drag item, verify drop zone highlights
+- Resize panel, verify responsive behaviour
+- Check accessibility (screen reader, keyboard nav)
+
+### HYBRID
+
+- Agent runs SQL → operator verifies card renders correctly
+- Agent triggers error → operator verifies error styling
+- Agent performs action → operator verifies animation/transition
+- Agent saves state → operator closes/reopens app → agent checks restore
+
+## Edge Cases
+
+### No Test Plan Provided
+
+If PR has no test plan:
+1. Generate code-derived plan
+2. Present to operator: "Author provided no test plan. Code-derived plan below. Proceed?"
+3. Consider commenting on PR to request author's test plan
+
+### Test Plan Too Vague
+
+If test plan is non-actionable (e.g., "test it works"):
+1. Expand with code-derived specifics
+2. Note: "Author plan expanded with specific test cases"
+
+### Test Plan References External System
+
+If test plan requires access we don't have:
+1. Mark those items as BLOCKED
+2. Note blocker in test report
+3. Proceed with testable items
+
+### Flaky or Environment-Dependent Tests
+
+If a test might produce inconsistent results:
+1. Mark as potentially flaky
+2. Run multiple times if AUTOMATED
+3. Note environment requirements if INTERACTIVE

--- a/plugins/xo/skills/xo/references/refs-complexity-gate.md
+++ b/plugins/xo/skills/xo/references/refs-complexity-gate.md
@@ -1,0 +1,75 @@
+---
+name: refs-complexity-gate
+description: "TRIVIAL vs SUBSTANTIVE classification criteria for review feedback or correction-driven edit diffs. Determines whether fast-path or full production workflow applies. Works for PR comments, document review, config review, or any feedback on produced artifacts."
+---
+
+# Complexity Gate
+
+The complexity gate is the key decision point when responding to feedback on any produced artifact or classifying a correction-driven edit diff to produced work. It determines whether a review comment or edit diff can be addressed directly (fast-path) or requires routing to **Build** (`references/act-build.md`, the proposer → critic cycle) for deeper consideration.
+
+## Classification Criteria
+
+### TRIVIAL (Fast-Path)
+
+Changes that are **mechanical, localised, and low-risk**. The change is fully specified by the review comment or edit diff itself — no design judgment required.
+
+| Example | Why Trivial |
+|---------|-------------|
+| Rename or swap a term (e.g., deprecated name → current) | Mechanical substitution |
+| Remove a line or table row the reviewer flagged | Reviewer specified exactly what to remove |
+| Fix a typo, formatting issue, or broken link | No semantic change |
+| Adjust wording per reviewer's suggestion | Reviewer provided the replacement |
+| Add a missing entry the reviewer explicitly specified | Reviewer provided the content |
+| Apply a one-line correction the operator fully specified in the edit diff | Mechanical edit diff; no design judgment |
+
+**Key test**: Could someone apply this review item or edit diff without understanding the broader system? If yes, it's trivial.
+
+### SUBSTANTIVE (Full Process)
+
+Changes that require **design judgment, affect multiple files, or introduce new behaviour**.
+
+| Example | Why Substantive |
+|---------|----------------|
+| Rewrite a section or add new content | Requires understanding of what to write |
+| Change control flow or logic | Risk of unintended consequences |
+| Add or modify tests | Requires understanding test patterns |
+| Restructure document organisation | Affects other sections |
+| Comment implies broader architectural concern | Scope extends beyond the comment |
+| Rework control flow across multiple call sites to apply a correction-driven edit diff | Edit diff has ripple effects and needs design judgment |
+
+**Key test**: Does this review item or edit diff require reading code, making design decisions, or considering ripple effects? If yes, it's substantive.
+
+This gate applies equally when classifying a correction-driven edit diff to already-produced work, not just a reviewer comment.
+
+## Edge Cases
+
+| Scenario | Classification | Reasoning |
+|----------|---------------|-----------|
+| "Add a null check here" | TRIVIAL | Fully specified, single location |
+| "This needs better error handling" | SUBSTANTIVE | Vague, requires design choices |
+| "Update this import" | TRIVIAL | Mechanical |
+| "This approach won't scale" | SUBSTANTIVE | Architectural concern |
+| "Move this to a helper function" | SUBSTANTIVE | Requires deciding what to extract and where |
+| "s/foo/bar" | TRIVIAL | Explicit substitution |
+
+## Process for Mixed Reviews
+
+When a single review contains both trivial and substantive comments:
+
+1. **Separate** — list trivial items and substantive items explicitly
+2. **Fast-path trivial** — propose trivial fixes to operator, apply if approved
+3. **Commit trivial** — separate commit for trivial fixes
+4. **Assess substantive** — route substantive items to Build (`references/act-build.md`, proposer → critic cycle) before applying
+
+If addressing any comment requires *substantive creation or design judgment*, route that work through **Build** (`references/act-build.md`) regardless of classification.
+
+This prevents substantive items from blocking trivial fixes that could be pushed immediately.
+
+## Operator Approval
+
+Even trivial changes require operator approval before applying. The agent proposes the specific changes, explaining:
+- What the reviewer asked for
+- What the proposed fix is
+- Why it's classified as trivial
+
+The operator can reclassify any item as substantive if they disagree with the classification.

--- a/plugins/xo/skills/xo/references/refs-findings-contract.md
+++ b/plugins/xo/skills/xo/references/refs-findings-contract.md
@@ -1,0 +1,53 @@
+---
+name: refs-findings-contract
+description: "Design rationale for the findings-as-contract pattern. Why the drafter is isolated from the codebase, how claim tracing works, and what error classes this prevents."
+---
+
+# Findings as Contract
+
+The findings brief is the interface between codebase exploration and guide writing. This design prevents the most common documentation error: **unbacked claims** — statements in a guide that sound plausible but were never verified against the source.
+
+## The Problem
+
+When an agent writes documentation with full codebase access, it can:
+1. Read code, form an understanding, and write a claim
+2. Hallucinate details that "seem right" based on naming patterns
+3. Mix verified observations with inferred behaviour
+
+The reader cannot distinguish case 1 from case 2. Both look equally authoritative in the final guide.
+
+## The Solution: Structural Isolation
+
+The `xo-bounded-writer` (Drafter) has **no `grep`, `glob`, or `bash` tools**. It literally cannot access the codebase. Its only input is the findings brief written by `xo-bounded-writer` (Compiler) from verified test results.
+
+This creates a hard contract:
+- If a fact is in findings → drafter can state it
+- If a fact is NOT in findings → drafter cannot state it (it has no way to discover it)
+
+### Error Classes Prevented
+
+| Error Class | Definition | How Prevented |
+|-------------|-----------|---------------|
+| **Unbacked claim** | Guide states something not verified | Drafter can only reference findings entries |
+| **Contradiction** | Guide contradicts verified evidence | Critic compares guide claims against findings |
+| **Stale claim** | Guide states outdated behaviour | Test stage verifies current behaviour, not cached knowledge |
+
+### Error Class NOT Prevented
+
+| Error Class | Definition | Why Not Prevented |
+|-------------|-----------|-------------------|
+| **Missing coverage** | Guide omits important behaviour | Requires scope/survey completeness — addressed in Survey and Step 0 (Load context) |
+
+## Claim Tracing
+
+Every factual claim in the guide should be traceable:
+
+```
+Guide claim → Findings entry → Test result → Source observation
+```
+
+The critic performs the first link (guide → findings). If a claim cannot be linked to a findings entry, it is flagged as UNBACKED.
+
+## When to Bypass
+
+For internal notes, design documents, and intent-expressing documents (which describe what SHOULD be, not what IS), write directly without the pipeline. The findings-as-contract pattern is for documentation that makes **factual claims about system behaviour**.

--- a/plugins/xo/skills/xo/references/refs-guide-frontmatter.md
+++ b/plugins/xo/skills/xo/references/refs-guide-frontmatter.md
@@ -1,0 +1,69 @@
+---
+name: refs-guide-frontmatter
+description: "Frontmatter template for externally-contributed guides produced by the Document stage. Applied at Promote to embed provenance metadata in the output document."
+---
+
+# Guide Frontmatter
+
+Every guide produced by the Document stage and contributed to an external repository must carry YAML frontmatter that identifies how, when, and from what sources it was produced. This serves two purposes:
+
+1. **Freshness assessment** — a reader can check if the code has diverged since verification
+2. **Process discovery** — naming XO docs explicitly helps others find and reuse the system
+
+If the output format does not support frontmatter or metadata, note this to the user as a non-blocking consideration.
+
+## Template (Code-Verified Mode)
+
+```yaml
+---
+title: "{title}"
+generated_by: Document stage (code-verified)
+generated_at: {YYYY-MM-DD}
+verified_against: {commit SHA}
+source_paths:
+  - {path/to/examined/file1}
+  - {path/to/examined/file2}
+---
+```
+
+## Template (Source-Cited Mode)
+
+```yaml
+---
+title: "{title}"
+generated_by: Document stage (source-cited)
+generated_at: {YYYY-MM-DD}
+source_refs:
+  - {source description 1}
+  - {source description 2}
+---
+```
+
+## Field Definitions
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | Yes | Human-readable document title |
+| `generated_by` | Yes | Must be `Document stage (code-verified)` or `Document stage (source-cited)` |
+| `generated_at` | Yes | Date the guide was produced |
+| `verified_against` | Code-verified only | Git commit SHA the guide was verified against |
+| `source_paths` | Code-verified only | List of source files examined during verification |
+| `source_refs` | Source-cited only | List of external sources consulted |
+
+## Staleness Check
+
+For code-verified guides, a reader can assess freshness by running:
+
+```
+git diff {verified_against}..HEAD -- {source_paths}
+```
+
+If the diff is non-empty, the code has moved on and the guide may need revalidation.
+
+## What NOT to Include
+
+- **Test or finding counts** — without the actual evidence, these are appeal to authority
+- **Pipeline internals** — subagent names, stage numbers, working directories
+- **Scores or confidence ratings** — subjective and unverifiable by the reader
+
+The frontmatter should contain only what a reader needs to assess provenance and freshness.

--- a/plugins/xo/skills/xo/references/refs-security-review-triggers.md
+++ b/plugins/xo/skills/xo/references/refs-security-review-triggers.md
@@ -1,0 +1,119 @@
+---
+name: refs-security-review-triggers
+description: "When and how to invoke security review during coding workflow. Trigger conditions, boundary mapping methodology, credential flow tracing, and output format."
+---
+
+# Security Review Triggers
+
+Invoked by the orchestrator after the Build Critic (`xo-cold-smart`) approves changes that touch security-sensitive areas, before handing off to the Prove stage. Can also be invoked during plan review (pre-implementation).
+
+## When to Invoke
+
+The orchestrator MUST invoke a security review when ANY of these conditions are met:
+
+### Trigger Conditions
+
+| Condition | Description |
+|-----------|-------------|
+| **Credential handling** | Change reads, writes, transforms, or passes authentication credentials (passwords, tokens, private keys, API keys, session tokens) |
+| **Cross-boundary writes** | Change modifies how data flows between process boundaries (IPC, network, inter-service) |
+| **Sensitive file I/O** | Change writes to files that contain or could contain secrets (`~/.snowflake/`, credential caches, token files, `.env`, key files) |
+| **New IPC/API surface** | Change adds new methods to an IPC interface, REST endpoint, or inter-process communication channel |
+| **Sandbox/privilege context** | Change runs in a sandboxed context (Electron renderer, browser extension, WASM) and interacts with privileged resources |
+| **Authentication flow changes** | Change modifies how users authenticate, how tokens are exchanged, or how sessions are managed |
+| **Desktop process boundary** | Electron apps: any change touching both renderer (sandboxed) and main (privileged) processes |
+
+### Skip Conditions
+
+Do NOT invoke security review for:
+- Pure UI/styling changes
+- Documentation changes
+- Test-only changes
+- Read-only data display changes that don't touch credentials
+
+---
+
+## Review Procedure
+
+### Step 1: Map Process/Trust Boundaries
+
+Identify all processes and contexts involved in the change:
+
+```
+[Context A] ──boundary──► [Context B]
+   (what trust level?)       (what trust level?)
+```
+
+For Electron apps:
+```
+Renderer (sandboxed) ──IPC──► Main (privileged) ──fs──► Disk
+```
+
+### Step 2: Trace Credential Flow
+
+Follow credentials through the change path:
+
+1. Where do credentials originate? (UI input, file read, env var, token exchange)
+2. How do credentials move through the change? (function calls, IPC messages, network requests)
+3. Where do credentials terminate? (disk write, API call, memory only)
+4. Are credentials ever logged, serialised to an unexpected format, or exposed to a lower-privilege context?
+
+### Step 3: Assess Change Impact
+
+Compare before/after:
+
+| Aspect | Before | After | Risk |
+|--------|--------|-------|------|
+| Boundary crossings | [list] | [list] | New crossing? |
+| Credential exposure surface | [list] | [list] | Expanded? |
+| IPC methods | [list] | [list] | New surface? |
+| File I/O on sensitive paths | [list] | [list] | New writes? |
+
+### Step 4: Produce Checklist
+
+Evaluate each item — all must pass:
+
+- [ ] No new IPC methods exposing credentials to renderer
+- [ ] No credential values logged at any log level
+- [ ] No credentials persisted in unexpected locations
+- [ ] No credentials passed to lower-privilege contexts
+- [ ] No new file writes to credential storage paths without proper permissions
+- [ ] Token/secret lifetimes not extended beyond necessity
+- [ ] Error paths do not leak credential content in error messages
+- [ ] Existing security invariants preserved (no regression)
+- [ ] Sandbox boundaries not weakened
+
+### Step 5: Verdict
+
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| **Safe to proceed** | All checklist items pass, no new risk | Continue to Prove stage |
+| **Needs changes** | Fixable issues found | Return to Build generator with security findings |
+| **Blocked** | Fundamental design concern | Escalate to operator |
+
+---
+
+## Integration Points
+
+| Context | When | How |
+|---------|------|-----|
+| **Plan review** (pre-implementation) | When plan touches credential/boundary code | Invoked by `decide-plan.md`'s Security review step — review plan before Build |
+| **Post-critic** (Build → Prove) | When Build Critic (`xo-cold-smart`) approved changes touching triggers | Review diff before Prove stage |
+| **PR review** (Review) | When PR touches credential/boundary code | Review diff as part of PR assessment |
+
+---
+
+## Example: Electron Credential Flow
+
+**Example — connection config CRUD:**
+
+**Boundary map**:
+```
+Renderer ──IPC TOML──► Main ──IFileService──► Disk (~/.snowflake/connections.toml)
+```
+
+**Finding**: SDK uses Node.js `fs` directly — cannot be called from sandboxed renderer. Must replicate logic independently in main process.
+
+**Checklist**: 9 items, all passing. No credential flow changes — credentials stay in main process, only non-secret config metadata crosses IPC.
+
+**Verdict**: Safe to proceed.

--- a/plugins/xo/skills/xo/references/refs-survey-methods.md
+++ b/plugins/xo/skills/xo/references/refs-survey-methods.md
@@ -1,0 +1,225 @@
+---
+name: refs-survey-methods
+description: "Discovery traversal patterns, local-first source checking, trust signals, and source tracing. Supporting reference loaded by survey.md and analyse.md."
+---
+
+# Survey Methods
+
+Two discovery modes, each with different traversal strategies. The mode depends on operator intent and the shape of the question.
+
+## Discovery Modes
+
+### Survey Mode (Breadth-First)
+
+**Trigger**: open-ended questions — "what do we know about X?", "what's the landscape for Y?", "who's working on Z?"
+
+**Goal**: map the territory. Cast wide across source categories, collect signals, identify clusters of relevance before going deep on any one thread.
+
+**Traversal**: scan across source categories (local → services → external), collecting pointers. Do NOT follow any single thread deep until the breadth pass is complete. Present the map to the operator, who decides where to go deep.
+
+**When to use**: new topics, cross-cutting investigations, landscape mapping, "what exists" questions.
+
+### Investigate Mode (Depth-First from Target)
+
+**Trigger**: specific target — "investigate this repo", "what can we learn about service X?", "trace the history of this feature"
+
+**Goal**: build out from a known starting point. Follow connections: who contributed → what teams → what related repos → what docs exist → what PRs are open → what decisions were made.
+
+**Traversal**: start at the target, identify its connections, follow each connection one level, then decide which threads warrant further depth. Each level of depth should be a conscious choice, not automatic.
+
+**When to use**: given a specific repo, service, team, PR, or system to understand in depth.
+
+### Mode Selection
+
+| Operator Language | Mode | Reason |
+|-------------------|------|--------|
+| "what do we know about…", "survey", "landscape" | Survey | Open question, need breadth |
+| "investigate repo X", "look into service Y" | Investigate | Specific target, need depth |
+| "find out who's working on Z" | Survey → Investigate | Start broad (who?), then follow specific threads |
+| "what's changed recently in area A" | Investigate | Temporal focus on known area |
+
+When unclear, default to survey — it's safer to go broad first than to tunnel into the wrong thread.
+
+---
+
+## Source Tracing
+
+Every finding must record how it was reached. This serves two purposes: (1) the operator can verify the chain, (2) future sessions don't re-traverse the same path.
+
+### Trace Format
+
+In the notes file, record the discovery chain:
+
+```markdown
+### Source Trace
+- Started: {initial query or target}
+- Found: {finding} via {source system} → {specific query or path}
+  - Led to: {next finding} via {connection type}
+    - Led to: {deeper finding} via {connection type}
+```
+
+When a source yields nothing, record that too: `{source}: searched for "{query}" — no relevant results`. This prevents re-searching.
+
+---
+
+## Local Sources (Check All Before External)
+
+**MANDATORY**: Before querying ANY external service, check ALL local sources. Do not short-circuit — gather from all, then assess which is most trustworthy.
+
+### Check Order
+
+| Order | Source | How to Check | Staleness Signal |
+|-------|--------|--------------|------------------|
+| 1 | Active WI notes | Read `notes/{YYYY-MM}/{project}-wi{N}-*.md` directly | Most recent by definition |
+| 2 | The vault (notes + tasks + diary) | **Recall** (`references/observe-recall.md`) — not a bare grep | Recall returns dates; check StatusNote/recency on hits |
+| 3 | `/memories/` directory | Glance the in-context `MEMORY.md` index; `memory view` a specific file if relevant | No metadata — may be stale or abandoned |
+| 4 | External sources | Codebases, docs, APIs | After local is exhausted |
+
+### Notes as Knowledge Base
+
+Search the accumulated workspace with **Recall** (`references/observe-recall.md`) rather than a bare keyword grep — Recall expands the query into candidate terms first, so it bridges the vocabulary gap between how you phrase the search and how the note was written:
+
+```
+Recall: query = "[topic]"  → ranked full-path hits across notes/tasks/diary
+```
+
+Use a direct grep only for an exact known literal — a specific filename, error string, or identifier. For any topic or concept search, use Recall: a bare grep misses the vocabulary gap.
+
+No results means "not yet documented" — NOT "nothing exists." Recall covers the authoritative vault (notes/tasks/diary); `/memories` is checked separately via the in-context memory index (provisional scratch — keep it labelled apart).
+
+After checking local sources, consult any registered knowledge sources that match the topic and suggest them to the operator before searching them. Suggest, do not auto-search: *"You've previously found [source] useful for [domain] — want me to include it in this survey?"* Registered sources live in the same durable places as other XO references; use them as prompts for breadth, not as a silent routing override.
+
+### Why Check All
+
+- **Notes are current but narrow**: only recent WI context
+- **Memories have no metadata**: could be from abandoned session, superseded, or still relevant
+- **Contradictions are signals**: if two sources disagree, surface it to the operator
+
+### Assessing Conflicting Sources
+
+When multiple local sources have information:
+
+1. **Check recency** — look at the date of the notes file or diary entry
+2. **Check memory file age** — file modification date is only a proxy for freshness
+3. **Note contradictions** — surface them to operator rather than silently choosing
+
+---
+
+## External Services
+
+For specifics on each service (endpoints, table paths, tool lists), search prior WI notes and diary for any service investigations already done. This reference covers only the discovery process.
+
+### Source Categories
+
+| Category | What it Contains |
+|----------|------------------|
+| **Systems** | Repositories, platforms, container entities |
+| **Services** | Access patterns, APIs, query tools |
+| **Refs** | Point references, conventions, patterns |
+| **External** | Public docs, upstream projects |
+
+### Before Using a Service
+
+Search accumulated notes for any prior investigation of this service with **Recall** (`references/observe-recall.md`):
+```
+Recall: query = "[service-name]"  → ranked hits across notes/tasks/diary
+```
+If found, use cached access methods and conventions.
+If not, investigate directly and consider writing a durable note via Capture (`references/decide-capture.md`).
+
+### Codebase Investigation
+
+When the target is a specific repository:
+
+1. Search notes/tasks for an existing article or prior investigation of that repo
+2. If found, use cached conventions (AGENTS.md location, test commands, etc.)
+3. If not, investigate directly; consider writing a durable note via Capture (`references/decide-capture.md`)
+
+Standard locations to check in any repo:
+- `AGENTS.md` / `CLAUDE.md` — agent-specific guidance
+- `README.md` — project overview
+- `.github/instructions/` — coding standards
+- `CONTRIBUTING.md` — contribution guidelines
+- `package.json` / `Cargo.toml` / etc. — dependencies, scripts
+
+**For substantive work (new features, understanding prior decisions), surface the offer to check attendant services before expanding scope:**
+> "I'm about to survey [repo]. For feature-level work it's worth checking attendant services — PR history, issue tracker, wiki, Jira — to surface prior decisions, non-goals, and abandoned approaches. Do you want me to include those, or just the codebase?"
+
+Skip the offer for bug fixes and targeted lookups where breadth of prior art is irrelevant. When the operator says yes, specifically look for: WONTFIX decisions, abandoned PRs and their reversal reasons, and any tests or docs that explicitly assert "NOT SUPPORTED" — these are the evidence for non-goals in the spec.
+
+**If Survey surfaces reusable standards or knowledge sources (test commands, build conventions, CI setup, AGENTS.md location, PR workflow, doc styles, a useful KB, Glean collection, Confluence space, or MCP), these are candidates for Capture** regardless of the depth of investigation. Offer once: *"I found conventions or reference sources worth keeping — want me to record them so future sessions don't have to re-discover?"* Persist global sources as a `reference`-type memory entry; persist repo- or customer-specific sources in that repo's `AGENTS.md` domain note. Keep it operator-gated: propose the capture, do not auto-persist. See Capture (`references/decide-capture.md`). Notes written this way can be refreshed deliberately when the repo changes.
+
+---
+
+## Traversal Patterns
+
+| Pattern | When | Example |
+|---------|------|---------|
+| **Breadth scan** | Survey mode — map the territory | Local sources → services → external, collecting pointers |
+| **Depth chase** | Investigate mode — follow a thread | Repo → contributors → their other repos → related docs |
+| **Hypothesis test** | After first pass reveals a pattern | "I think team X owns this" → verify via multiple sources |
+| **Contrast** | Comparing approaches | How does repo A solve this vs repo B? |
+| **Temporal** | Understanding change over time | Git log → PR timeline → ticket history |
+
+### Deciding Breadth vs Depth
+
+After each discovery pass, present findings and ask the operator:
+- **"Go wider"** → next source category in the breadth scan
+- **"Go deeper on X"** → switch to investigate mode on that thread
+- **"Sufficient"** → proceed to Orient
+
+The operator controls traversal. Do not automatically chase every thread — present the map and let the operator choose where to invest attention.
+
+---
+
+## Source Reliability
+
+Discovery surfaces what exists — but not all sources are equally trustworthy. Present trust signals alongside findings.
+
+### Trust Signals
+
+| Signal | Where to Check | Implication |
+|--------|---------------|-------------|
+| **Last updated** | Git log, page metadata, captured-note date | >1 year = flag as potentially stale |
+| **Activity level** | Commit frequency, PR activity, edit history | Active = higher trust; dormant = skepticism |
+| **Source type** | What kind of artifact | Code > tests > internal docs > wiki > old Confluence |
+| **Note recency** | Date stamp on a captured note or diary entry | Recent = more likely current |
+| **Contradictions** | Multiple sources say different things | Flag for operator resolution |
+
+### Source Type Hierarchy
+
+| Tier | Source Type | Trust Level | Rationale |
+|------|-------------|-------------|-----------|
+| 1 | Active code, passing tests | Highest | Compiles, runs, verified by CI |
+| 2 | Recent PRs, code review discussions | High | Current thinking, actively debated |
+| 3 | Recent captured notes (this WI or recent sessions) | Medium-high | Written from verified findings |
+| 4 | AGENTS.md, README in active repos | Medium-high | Maintained alongside code |
+| 5 | Recent Confluence (<6 months), Jira tickets | Medium | May lag behind code changes |
+| 6 | Older captured notes (prior WIs, undated) | Medium-low | Better than nothing, verify currency |
+| 7 | Old Confluence (>1 year), archived wikis | Low | Likely stale, may contradict current state |
+| 8 | Memories (no metadata) | Low | Unknown staleness, may be abandoned |
+| 9 | Slack threads, email snippets | Lowest | Ephemeral, context-dependent |
+
+### Annotating Findings
+
+When presenting findings, include trust signals:
+
+```markdown
+### Key Findings
+- {finding}
+  - Source: {where} | Updated: {when} | Trust: {signal}
+  - ⚠️ Stale: last updated 2+ years ago
+  - ⚠️ Contradicts: {other source says X}
+  - ✓ Active: 15 commits this month
+  - ✓ Confirmed: captured note dated 2026-03-01
+```
+
+---
+
+## What Discovery Does NOT Do
+
+Discovery surfaces what exists and flags trust signals. It does NOT:
+- Block progress on unvalidated findings (that's the operator's call)
+- Guarantee correctness (it finds *interesting*, not *verified*)
+
+When the operator needs to capture a durable learning, route to **Capture** (`references/decide-capture.md`).

--- a/plugins/xo/skills/xo/references/refs-terminology.md
+++ b/plugins/xo/skills/xo/references/refs-terminology.md
@@ -1,0 +1,71 @@
+---
+name: refs-terminology
+description: "Standard terminology across xo-* skills. Defines the lexicon for artifacts, actions, and concepts."
+---
+
+# XO Cortex Terminology
+
+Standard terms used across xo-* skills. Consistent terminology helps agents understand what artifacts to produce and helps operators know what to expect.
+
+## Artifacts
+
+| Term | Nature | Audience | Purpose |
+|------|--------|----------|---------|
+| **Brief** | Summary for decision-making | Operator | Present findings, recommendations, or status for approval/awareness |
+| **Spec** | Intent/requirements document | Agent (current or future) | Define what should be built and why |
+| **Findings** | Raw discoveries, not yet synthesised | Internal/working | Capture what was learned during investigation |
+| **Notes** | Persistent working memory | Agent recovery | Accumulated understanding of a work item |
+| **Diary** | Session activity log | Agent recovery | What happened, when, organised by session |
+| **Task** | Work item state file | Agent recovery | Current state, next action, status of a work item |
+
+### Artifact Hierarchy
+
+```
+Findings → Brief → Operator decision
+   ↓
+Notes (persisted for recovery)
+```
+
+- **Findings** are raw — what you discovered
+- **Brief** synthesises findings for the operator — what it means and what you recommend
+- **Notes** persist understanding across context resets — what the agent needs to remember
+
+## Actions as Verbs
+
+These terms describe processes, not outputs:
+
+| Verb | Meaning | Output |
+|------|---------|--------|
+| **Assess** | Evaluate against criteria | Brief |
+| **Analyse** | Investigate in depth | Findings (then Brief) |
+| **Review** | Examine for correctness/quality | Brief |
+| **Investigate** | Explore to understand | Findings |
+| **Validate** | Confirm against reference | Brief |
+
+Example: "Assess the PR" → process is assessment → output is a brief.
+
+## Roles
+
+| Term | Meaning |
+|------|---------|
+| **Operator** | The human directing the work (senior in the relationship) |
+| **Agent** | The AI performing the work (reports to operator) |
+| **Orchestrator** | The top-level agent coordinating subagents |
+| **Subagent** | A specialist agent dispatched for a specific task |
+
+## Recording Terms
+
+| Term | Meaning |
+|------|---------|
+| **Savepoint** | The act of recording state across all three layers (diary + task + notes) |
+| **Context state** | The stored context fullness percentage (triggers savepoint reminders) |
+| **Checkpoint** | VS Code's session rollback feature (not an xo-cortex term) |
+
+## Workflow Terms
+
+| Term | Meaning |
+|------|---------|
+| **Fast-path** | Direct action without full deliberative process |
+| **Deliberative** | Multi-agent process (proposer/critic/validator/etc.) for quality assurance |
+| **Empirical** | Code-first approach — build then document |
+| **Verified** | Tested through execution, not just static analysis |

--- a/plugins/xo/skills/xo/references/refs-verified-review.md
+++ b/plugins/xo/skills/xo/references/refs-verified-review.md
@@ -1,0 +1,77 @@
+---
+name: refs-verified-review
+description: "Build-and-test protocol for verified PR review. Risk factor assessment, empirical evidence gathering, before/after comparison."
+---
+
+# Verified Review Process
+
+Full build-and-test protocol for PR review when static analysis is insufficient.
+
+## When to Use Verified Review
+
+| Risk Factor | Present? | Implication |
+|-------------|----------|-------------|
+| API or spec changes | Yes → verified | Downstream consumers may break |
+| Breaking change potential | Yes → verified | Need empirical confirmation |
+| Downstream consumers exist | Yes → verified | Must check generated artifacts |
+| Annotation/metadata changes | Yes → verified | Static analysis can be misleading |
+| Doc/typo/cosmetic only | Yes → static | No runtime impact |
+| Time-constrained | Yes → static | Note the caveat in assessment |
+
+**Key lesson**: Static analysis of annotation changes may predict HIGH risk, but empirical build can reveal actual impact is LOW (e.g., spec unchanged). However, builds also catch *other* breaking changes missed by static analysis. Always prefer verified when risk factors are present.
+
+## Procedure
+
+### Step 1: Static Baseline
+
+Checkout and inspect the PR normally. Read the diff, understand the intent. This gives you a hypothesis to test empirically.
+
+### Step 2: Build the Project
+
+Follow the project's build instructions:
+- Maven: `mvn clean install -DskipTests` (build first, test separately)
+- npm/yarn: `npm ci && npm run build`
+- Other: check CONTRIBUTING.md, Makefile, or CI config
+
+Record: does it build cleanly? Any new warnings?
+
+### Step 3: Generate Downstream Artifacts
+
+If the project produces artifacts consumed by others:
+- API specs (Swagger/OpenAPI): generate and compare before/after
+- Client SDKs: regenerate and diff
+- Docker images: build and compare layers
+- Package manifests: check dependency changes
+
+### Step 4: Before/After Comparison
+
+Diff the generated artifacts against the main branch versions:
+- Spec files: structural diff (not just text diff)
+- Client code: check for signature changes, new/removed endpoints
+- Config files: check for semantic changes vs cosmetic
+
+### Step 5: Run Test Suite
+
+Run the project's test suite:
+- Full suite if practical
+- Targeted suite if full suite is too slow (document what was skipped)
+- Record: pass/fail counts, new failures, flaky tests
+
+### Step 6: Revise Risk Assessment
+
+Update the initial static risk assessment with empirical findings:
+
+| Aspect | Static Assessment | Empirical Finding | Revised |
+|--------|------------------|-------------------|---------|
+| [area] | [initial call] | [what build/test showed] | [updated] |
+
+Feed the empirical findings table to the review Briefer as additional context when producing the review brief.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong |
+|-------------|---------------|
+| Skipping build because "it's just annotations" | Annotations can affect codegen, specs, clients |
+| Trusting CI alone | CI may not run all downstream checks |
+| Verified review without before/after diff | Build success doesn't mean no breaking changes |
+| Static-only when downstream consumers exist | Risk of silent breakage |

--- a/plugins/xo/skills/xo/references/refs-workspace-setup.md
+++ b/plugins/xo/skills/xo/references/refs-workspace-setup.md
@@ -1,0 +1,116 @@
+---
+name: refs-workspace-setup
+description: "Worktree management, branch creation, and commit conventions for development workflows."
+---
+
+# Workspace Setup Reference
+
+Setting up a clean workspace for development work. Load this when provisioning the workspace, not at Ship time.
+
+## Worktree Workflow
+
+Use this guidance for EXTERNAL shared repositories. Do not apply worktree/base-ref procedures to the private `xocortex` vault.
+
+Use git worktrees to create isolated workspaces per work item. This keeps the main working directory clean, avoids branch-switching side effects, and prevents cross-contamination between concurrent work items.
+
+### Placement
+
+Worktrees default to the XO scratch directory — the per-WI scratch dir (`Scratch:` in the task file) already exists, allocated at WI creation; it is write-approved, gitignored, and cleaned up by the Cleanup stage. The operator can override to a different location.
+
+| Pattern | Path | When |
+|---------|------|------|
+| **XO scratch (default)** | `$XOCORTEX_HOME/tmp/wi{N}/<repo-name>/` | Standard — write-approved, lifecycle-managed |
+| **Operator override** | Whatever the operator specifies | Record in notes for future sessions |
+
+**Why XO scratch?** In editor mode (single project open), creating a sibling folder in the project parent may trigger a permissions prompt or appear as a separate project to the IDE. `$XOCORTEX_HOME` is already approved and scoped. Cleanup stage handles removal after merge.
+
+**Constraint:** The worktree must be on the same filesystem as the target repo (git links via absolute paths). This is almost always true for local dev.
+
+When proposing a worktree to the operator:
+> "I'll create a worktree at `$XOCORTEX_HOME/tmp/wi{N}/<repo-name>/` — or would you prefer a different location?"
+
+### Commands
+
+```bash
+# The scratch parent ($XOCORTEX_HOME/tmp/wi{N}) already exists from WI allocation.
+# Insurance for legacy WIs only — guarded so it never prompts when already present:
+ls "$XOCORTEX_HOME/tmp/wi{N}" >/dev/null 2>&1 || mkdir -p "$XOCORTEX_HOME/tmp/wi{N}"
+
+# Resolve and fetch the remote default branch before compare/review/PR work.
+base_ref=$(git -C <repo> symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's#^refs/remotes/origin/##')
+if [ -z "$base_ref" ]; then
+  base_ref=$(git -C <repo> remote show origin | sed -n 's/.*HEAD branch: //p' | head -n 1)
+fi
+git -C <repo> fetch origin "$base_ref"
+
+# Create worktree for a work item (default location)
+git -C <repo> worktree add "$XOCORTEX_HOME/tmp/wi{N}/<repo-name>" -b agent/wi{N}-<slug>
+
+# Example — WI-235 on myproject:
+git -C ~/Projects/myproject worktree add \
+  "$XOCORTEX_HOME/tmp/wi235/myproject" -b agent/wi235-worktree-placement
+
+# List active worktrees
+git -C <repo> worktree list
+
+# Remove after merge (also handled by Cleanup stage)
+git -C <repo> worktree remove "$XOCORTEX_HOME/tmp/wi{N}/<repo-name>"
+git -C <repo> branch -d agent/wi{N}-<slug>
+```
+
+The worktree is a full working directory with its own checkout. Work in `<worktree-path>` without disrupting the main checkout.
+
+### SWITCH
+
+Switch between the primary checkout and a worktree only after checking both paths with `git -C <path> status --short --branch`.
+
+### HEALTH-CHECK
+
+Before Build, Review, compare, or PR work: verify the worktree exists, `git -C <worktree-path> rev-parse --abbrev-ref HEAD` matches the expected branch, `origin/$base_ref` is freshly fetched, and `git -C <worktree-path> status --short` is empty.
+
+### Primary checkout audit
+
+After worktree work, verify the primary checkout with `git -C <repo> status --short --branch`; if it is dirty or left on a stray feature branch, report it and ask if the user wants to restore the expected branch and clean state before leaving the repo.
+
+---
+
+## Branch Naming
+
+**For xo-tracked work items**, use `agent/wi{N}-<slug>` — the WI number traces back to internal tracking, the slug makes the branch self-documenting for anyone reading the remote.
+
+Examples: `agent/wi235-worktree-placement`, `agent/wi318-local-vector-search`
+
+**For other work**, check prior notes for any recorded branch naming conventions via **Recall** (`references/observe-recall.md`, query the repo name).
+
+**If no standards found**, fall back to conventional patterns:
+
+| Change Type | Pattern | Example |
+|-------------|---------|---------|
+| XO work item | `agent/wi{N}-<slug>` | `agent/wi235-worktree-placement` |
+| Bug fix | `fix/<short-description>` | `fix/agents-md-preview` |
+| Feature | `feat/<short-description>` | `feat/context-ring-logging` |
+| Refactor | `refactor/<description>` | `refactor/hook-decomposition` |
+| Documentation | `docs/<description>` | `docs/hooks-guide` |
+
+---
+
+## Commit Conventions
+
+Before committing, check the repo's conventions:
+
+1. Check prior notes for recorded commit conventions via **Recall** (`references/observe-recall.md`, query the repo name)
+2. If none, check `CONTRIBUTING.md`, `AGENTS.md`, or recent `git log`
+
+Common patterns:
+- Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`
+- Component prefix: `[component] description`
+- Issue reference: `description (#123)`
+
+```bash
+git add -A
+git commit -m "<message per repo conventions>"
+```
+
+Do NOT reference internal WI numbers in commits to external repositories.
+
+

--- a/plugins/xo/skills/xo/references/save-context-urgency.md
+++ b/plugins/xo/skills/xo/references/save-context-urgency.md
@@ -1,0 +1,161 @@
+---
+name: save-context-urgency
+description: "Hook system internals for context monitoring and savepoint reminders. Covers urgency thresholds, state machine, configuration, and debugging."
+---
+
+# Context Urgency Protocol
+
+The context urgency system uses Cortex Code plugin hooks to monitor context fullness and inject escalating savepoint reminders. Two hooks work together: `UserPromptSubmit` (fires on user turns) and `PostToolUse` (fires during autonomous tool-use cycles). Hooks are registered automatically when the xocortex plugin is loaded via `settings.json plugins[]`.
+
+## Architecture
+
+### Files
+
+| File | Location | Role |
+|------|----------|------|
+| `settings.json` env block | `~/.snowflake/cortex/settings.json` | `XOCORTEX_HOME` env var: memory repo path |
+| `_common.js` | `xo/plugin/hooks/_common.js` | Input parsing, config, logging, path derivation |
+| `_context-monitor.js` | `xo/plugin/hooks/_context-monitor.js` | Token extraction, context state machine, urgency thresholds |
+| `reindex-tasks.js` | `xo/plugin/hooks/reindex-tasks.js` | Task reindexer (also callable directly) |
+| `sessionstart.js` | `xo/plugin/hooks/sessionstart.js` | Injects context, reindexes tasks, handles compact/resume |
+| `userpromptsubmit.js` | `xo/plugin/hooks/userpromptsubmit.js` | User-turn savepoint with verbose urgency reminders |
+| `posttooluse.js` | `xo/plugin/hooks/posttooluse.js` | Autonomous-turn savepoint with concise reminders |
+| `hooks.json` | `xo/plugin/hooks/hooks.json` | Hook registration — loaded automatically by plugin system |
+
+### Data Flow
+
+1. **Session starts** — `sessionstart.js` fires, reindexes work items, injects context sources. On `compact`, recovery instructions are injected.
+2. **Each user prompt** — `userpromptsubmit.js` computes context %, injects full savepoint instructions if urgency threshold met.
+3. **Each tool response** — `posttooluse.js` uses the same state file and thresholds, injects concise context annotations.
+4. **Agent acts** — writes diary/notes/task per the recording model.
+5. **Post-reset** — `sessionstart.js` fires with `source=compact` or `source=summarize`, injects recovery instructions.
+
+### Shared Context Engine
+
+`_context-monitor.js` is the core engine. Values are passed via environment variables before requiring:
+
+| Variable | userpromptsubmit | posttooluse |
+|----------|-----------------|-------------|
+| `PROMPT_TOKENS_EST` | `prompt_length / 4` | `0` |
+| `RESPONSE_BUFFER` | `2000` | `0` |
+| `HOOK_SOURCE` | `"userprompt"` | `"posttool"` |
+
+The engine exports `MONITOR_RESULT` (`"fire"` or `"skip"`), `LEVEL`, `REPORTED_PCT`, `PROJECTED_PCT`.
+
+## Urgency Thresholds
+
+| Level | Context % | Condition | Behaviour |
+|-------|-----------|-----------|-----------|
+| (silent) | < 50% | any | No reminder injected |
+| `[routine]` | 50-69% | delta ≥ 10% | Record progress when convenient |
+| `[urgent]` | 70-79% | any | Write savepoint before continuing |
+| `[critical]` | 80-84% | any | Write immediately — all three layers |
+| `[final]` | ≥ 85% | any | Last chance — context reset at ~90% |
+
+Deduplication at routine level uses delta from last savepoint. Higher levels (70%+) always fire. Both hooks share the same context state file.
+
+## Context State Machine
+
+### State File
+
+Each session stores a single integer in `/memories/context-state/{session-id}`:
+
+| Value | Meaning |
+|-------|---------|
+| `0` | No baseline yet — will be set from next `response_metadata` |
+| `N` | Last baseline was N% context fullness |
+
+### Delta: The Decision Metric
+
+```
+delta = current_pct − last_baseline_pct
+```
+
+- **Positive delta (+15%)**: Context growing. Fire if large enough.
+- **Small positive (+3%)**: Suppress to avoid noise.
+- **Negative delta (−40%)**: Context dropped (compaction/summarisation). Reset baseline.
+
+### State Transitions
+
+```
+startup       → (no context state file yet)
+prompt 1      → no response_metadata → no action
+prompt 2      → baseline_set N% → file contains N
+prompt 3+     → cycle_check → delta comparison → fire or skip
+tool use      → same cycle_check logic → shared state file
+compact       → context drops, metadata stale for 1 cycle
+next event    → current < baseline → baseline_reset → file contains M%
+summarisation → context drops mid-session (no lifecycle event)
+next event    → current < baseline → baseline_reset
+```
+
+### Negative Delta: Detecting Context Drops
+
+Negative delta reliably detects context drops from any cause: compaction, summarisation, stale metadata. When `current_pct < baseline`, the system resets the baseline to the new (lower) percentage and resumes normal tracking.
+
+This is strictly better than sentinel values because summarisation drops context mid-session without triggering any lifecycle event. Only delta comparison catches it.
+
+## Configuration
+
+The `XOCORTEX_HOME` environment variable (set in `settings.json` env block) provides the memory repo path. All other paths are derived:
+
+```
+XOCORTEX_HOME=~/Projects/xocortex
+```
+
+Derived paths:
+- `diary`: `${XOCORTEX_HOME}/diary/${YYYY-MM}/${YYYY-MM-DD}.md`
+- `tasks_dir`: `${XOCORTEX_HOME}/tasks`
+
+Context state files: `${SNOWFLAKE_HOME:-~/.snowflake}/cortex/memory/context-state/`
+
+
+## Hook Input Format
+
+All hooks receive JSON on stdin from Desktop:
+
+```json
+{
+  "session_id": "uuid",
+  "cwd": "/path/to/workspace",
+  "hook_event_name": "PostToolUse",
+  "response_metadata": {
+    "usage": {
+      "tokens_consumed": [{
+        "input_tokens": {"total": 145000},
+        "output_tokens": {"total": 8500},
+        "context_window": 200000
+      }]
+    }
+  }
+}
+```
+
+`response_metadata` is a **trailing indicator** — reflects the previous turn, not the current one. Without it (first prompt, CLI/SDK), hooks exit silently.
+
+## Debugging
+
+### Log Location
+
+`~/.snowflake/cortex/logs/YYYY-MM-DD-hooks.log`
+
+### Useful Filters
+
+```bash
+grep "SESSION_ID" ~/.snowflake/cortex/logs/YYYY-MM-DD-hooks.log
+grep "→ fire" ~/.snowflake/cortex/logs/YYYY-MM-DD-hooks.log
+grep "posttool:.*→ fire" ~/.snowflake/cortex/logs/YYYY-MM-DD-hooks.log
+grep "baseline_reset" ~/.snowflake/cortex/logs/YYYY-MM-DD-hooks.log
+```
+
+## Limitations
+
+- Context % is `(input_tokens.total + output_tokens.total) / context_window` — may not exactly match Desktop UI ring
+- First prompt has no `response_metadata` — no decisions until at least one response
+- `response_metadata` fields are not always fully populated — best-effort
+- CLI/SDK does not expose `response_metadata` to hooks — Desktop only
+
+## Dependencies
+
+- Node.js built-ins (`fs`, `os`, `path`) — used by JS hooks for JSON parsing and file I/O
+- Cortex Code Desktop (minimum build with hooks `response_metadata` passthrough)

--- a/plugins/xo/skills/xo/references/save-protocol.md
+++ b/plugins/xo/skills/xo/references/save-protocol.md
@@ -1,0 +1,301 @@
+---
+name: save-protocol
+description: "**[REQUIRED]** Recording discipline for multi-session agent work. Handles savepoints, notes, diary, task updates, and session recovery. Load this FIRST in any work session. Triggers: savepoint, save, record, resume, recover, pick up, continue WI."
+---
+
+# Save Protocol (Recording)
+
+**Why:** Context resets (compaction, summarisation) destroy working memory. Without disciplined recording, you lose investigation state, hypotheses, and accumulated understanding — and start over each time. This protocol gives a three-layer system (diary, task, notes) that lets you recover quickly and continue where you left off, even across multiple sessions.
+
+**Not for:** User-facing documentation (use Document — `references/act-document.md`) or durable learnings capture (use Capture — `references/decide-capture.md`). This is operational recording for agent continuity.
+
+---
+
+Recording discipline that enables agent work to span multiple context windows. Without this, context resets (compaction or summarisation) destroy working memory and multi-phase workflows degrade to "start over."
+
+## Session Prerequisites
+
+Before recording operations, you need workspace context. However, do NOT read these files automatically on session start — only read what you need, when you need it:
+
+- `tasks/index.md` — read when you need to orient on the portfolio or find a WI number
+- `diary/{YYYY-MM}/{YYYY-MM-DD}.md` — read when resuming work or writing a diary entry
+- Your session ID — use in diary headings: `## [{session-id}] WI-N: description`
+
+Paths are relative to the xocortex workspace root.
+
+### Resolving the Workspace Root
+
+The xocortex workspace root is where `tasks/`, `notes/`, and `diary/` directories live. It is **NOT** the xo plugin source directory or the current project directory. Resolve it using this precedence:
+
+1. **`XOCORTEX_HOME` environment variable** — if set, use this path directly
+2. **Fallback** — `~/.snowflake/cortex/memory/xocortex/`
+
+To discover the value at runtime:
+```bash
+echo "${XOCORTEX_HOME:-$HOME/.snowflake/cortex/memory/xocortex}"
+```
+
+**Verification**: The resolved path MUST contain a `tasks/` directory. If it does not, the path is wrong — search for the correct xocortex repo before writing any files.
+
+**Common mistakes to avoid**:
+- Do NOT write to the xo plugin source repo (where SKILL.md lives)
+- Do NOT write to the operator's current working directory or project directory
+- Do NOT create tasks/notes/diary directories in a new location — find the existing ones
+
+---
+
+## Routing Table
+
+| User Language | Operation | Action |
+|---------------|-----------|--------|
+| "savepoint", "save progress", "record what we did" | Write Savepoint | Follow [Savepoint Write](#savepoint-write) |
+| "pick up WI-N", "continue WI-N", "resume" | Recovery | Follow [Session Recovery](#session-recovery) |
+| "new work item", "create WI" | Create WI | Follow [Create Work Item](#create-work-item) |
+| "update status", "mark done", "close WI" | Update Task | Follow [Update Task File](#update-task-file) |
+| "what's the recording model?", "how do savepoints work?" | Explain | **Load** `references/save-three-layer.md` |
+
+---
+
+## Savepoint Write
+
+When triggered — by hook reminder, operator request, or workflow gate:
+
+**The diary layer always fires; the notes and task layers are WI-tracked.** Append a diary entry for every session that did substantive work — even a lightweight one with no work item. The entry hangs on the short session id, so it does not need a WI. Update the notes and task files only when the session is tracked under a work item (Steps 1–2); for a WI-less session, do Step 3 alone.
+
+### Step 1: Update Notes File (when tracked under a WI)
+
+**Path**: `notes/{YYYY-MM}/{project}-wi{N}-*.md`
+
+Write or append:
+- Current understanding and progress
+- Key decisions with rationale
+- Evidence, hypotheses, architecture context
+- Anything a recovering agent needs to continue at full depth
+
+The notes file is the deep record. **Expand as needed** — there is no length ceiling.
+
+If no notes file exists yet, create one:
+```
+# WI-{N}: {Title} — {Description}
+
+## Session {session_id} ({YYYY-MM-DD}): {Phase}
+
+{content}
+```
+
+### Step 2: Update Task File (when tracked under a WI)
+
+**Path**: `tasks/current/{project}-wi{N}-*.md`
+
+Update these fields in-place:
+- `Status` — current lifecycle state
+- `StatusNote` — at-a-glance progress commentary
+- `NextAction` — one concrete next step for the next session
+- `Blocker` — if anything blocks progress
+
+Keep compact. A cold-start agent reads this to know **what to do next**, not the full history.
+
+**Load** `references/save-task-conventions.md` if creating a new task file or unsure of field ordering.
+
+### Step 3: Append Diary Entry (always — including WI-less sessions)
+
+**Path**: `diary/{YYYY-MM}/{YYYY-MM-DD}.md`
+
+⚠️ **APPEND ONLY** — use `echo "..." >>` or append mode. Never read-edit-write.
+
+```markdown
+## [{session_id}] WI-{N}: {title}
+- {1-2 line summary of what was accomplished}
+- {Key decision, if any}
+- Status: {current status}
+- Notes: `notes/{YYYY-MM}/{project}-wi{N}-*.md`
+```
+
+For a lightweight session with no work item, key the entry on the session id alone — omit the `WI-{N}:` prefix and the notes pointer:
+
+```markdown
+## [{session_id}] {short description of what the session did}
+- {1-2 line summary of what was accomplished}
+- {Key decision, if any}
+- Status: {e.g. one-off — no WI}
+```
+
+**Maximum 5-10 lines.** The diary is a savepoint index, not a design document.
+
+Do NOT put in the diary:
+- Files-changed lists
+- Architecture discussion
+- Detailed fix descriptions
+- Duplicated task file content
+
+---
+
+## Session Recovery
+
+When resuming work after context reset (compaction, summarisation), new session, or cold start:
+
+**Post-reset (same session):**
+1. Read task file → current state and `NextAction`
+2. Read notes file → accumulated understanding (this is the deep record, not the conversation summary)
+3. Read today's diary, find `[{session-id}]` entries → what happened this session
+4. Resume from `NextAction`
+
+The agent knows its own session ID. After reset, diary entries with matching `[{session-id}]` headings are from this session.
+
+**Cold start (new session):**
+1. Operator direction or read `tasks/index.md` → which WI
+2. Read task file → status, NextAction
+3. Read notes file → deep understanding
+4. Read recent diary entries → momentum (session IDs won't match yours)
+5. Present active items to operator if no direction given
+
+### Recovery Fallback
+
+If recovery files disagree, are missing, or the operator corrects you ("no, we weren't working on that"):
+
+1. **Check the memory store** (`memory view /memories/`) — may have scratch files or working state from prior sessions
+2. **Surface confusion** — tell the operator: "The recovery state is unclear. Would you like me to inspect the conversation history?"
+3. **With operator approval**, load `$session-history` skill to analyze the conversation log
+
+The conversation history is structured JSON but verbose — it's log exhaust, not curated reasoning. The notes file is intentionally written to preserve understanding; the conversation history captures everything including exploration paths and false starts. Use it as a fallback, not a primary source.
+
+**Load** `references/save-recovery.md` for detailed procedures including reset detection and stale metadata handling.
+
+---
+
+## Create Work Item
+
+### Step 1: Assign Number
+
+Allocate the next WI number using the `memory` tool.
+
+**Happy path** — memory counter:
+1. `memory view /memories/xo/wi-counter.txt` → read value N (the next number to allocate)
+2. `memory str_replace` to change `N\n` → `{N+1}\n` in the same file
+3. Use N as the new WI number
+
+Because `str_replace` requires an exact match, two concurrent sessions cannot both claim the same N — the loser's replace will fail and it falls through to the fallback.
+
+**Fallback** — authoritative scan of existing tasks (use whenever the counter is missing, out of sync, or the str_replace fails):
+1. `glob` for `*wi*.md` across `tasks/current/` and `tasks/archive/**/`
+2. Extract the numeric portion (the digits after `wi`) of each filename and sort **numerically** (not alphabetically — `wi99` < `wi100`)
+3. `N = max + 1`
+4. Seed the counter by writing `{N+1}\n` to `/memories/xo/wi-counter.txt` via `memory create`, so future calls take the happy path
+
+The scan is the source of truth; the counter is just a fast cache. If they ever disagree, the scan wins.
+
+**Multi-session race guard.** Allocation is not a lock — XO is multi-session and other sessions allocate concurrently (the counter `str_replace` only guards the counter path, not two simultaneous scans). Immediately before creating the task file (Step 2), confirm no `*wi{N}-*.md` already exists in `tasks/current/` or `tasks/archive/`; if one does, the number was claimed concurrently — re-run the fallback scan for a fresh `max + 1`. If a collision surfaces later, the unstarted/uncommitted WI yields its number.
+
+### Step 2: Create Task File
+
+**Path**: `tasks/current/{project}-wi{N}-{kebab-slug}.md`
+
+Where `{project}` is the leaf name of the current project directory (kebab-cased). This groups work items alphabetically by project when working across multiple repos.
+
+Example: working in `~/Projects/my-cool-app/` → prefix is `my-cool-app`. Working in `~/Projects/my-org/xo/` → prefix is `xo`.
+
+Derivation: `basename` of the repo root (or working directory if not in a git repo), lowercased, spaces/underscores to hyphens.
+
+**Load** `references/save-task-conventions.md` for required fields and ordering.
+
+Minimum viable task file:
+```markdown
+# WI-{N}: {Descriptive Title}
+
+- Project: {project}
+- Priority: {Now | Next | Later}
+- Status: Ready
+- StatusNote: {brief description}
+- Blocker: None
+- Category: {Investigation | Bug fix | Process | Idea | etc.}
+- NextAction: {first concrete step}
+- Scratch: $XOCORTEX_HOME/tmp/wi{N}/
+```
+
+The `Scratch:` field is the **authoritative per-WI scratch path** — the transient handoff surface every stage uses for subagent outputs, drafts, and intermediate artifacts. Recording it here means downstream stages read it and use it directly, without checking or guessing. See `references/save-task-conventions.md`.
+
+### Step 3: Allocate Scratch Space
+
+Create the scratch directory once, now, so the rest of the system can rely on it existing:
+
+```bash
+ls "$XOCORTEX_HOME/tmp/wi{N}" 2>/dev/null || mkdir -p "$XOCORTEX_HOME/tmp/wi{N}"
+```
+
+This is the **one expected `mkdir` approval moment** for this WI — in context, at allocation. After this, stages read the `Scratch:` path from the task file and use it directly: no `ls`, no `mkdir`, no further approval. The canonical path is always `$XOCORTEX_HOME/tmp/wi{N}/` — stages must never invent an alternative location (e.g. `/.xo/`, repo-local dirs).
+
+### Step 4: Diary Entry
+
+Append a creation entry to today's diary.
+
+Note: The index is updated automatically when the SessionStart hook fires — do not manually update `index.md`.
+
+---
+
+## Update Task File
+
+Read the current task file, then update fields in-place per operator instruction. Common operations:
+
+| Intent | Fields to Update |
+|--------|------------------|
+| "mark done" | Status → Done, StatusNote → completion summary, then **archive** |
+| "blocked on X" | Status → Blocked, Blocker → description |
+| "shipped it" (PR opened / doc circulated / design staged, awaiting others) | Status → Shipped, StatusNote → name the awaited party + artifact (e.g. "awaiting reviewer X on PR #N") |
+| "reviewer requested changes" | Status → InProgress (re-deliver → back to Shipped) |
+| stage completed | advance `Provisional Pathway` (move the `(here)` marker) + refresh NextAction; if the stage looks done, offer the natural next stage once (dismissable) |
+| "promote to Now" | Priority → Now |
+| "fold into WI-N" | Status → Done, StatusNote → "Folded into WI-{N} — {reason}", then **archive** |
+
+### Archiving Completed Work Items
+
+When a work item reaches terminal state (Status: Done), ask the user if they want to archive it.
+
+If so, first update the Priority to Archived, then move it from `current/` to the month-coded archive:
+
+```bash
+mv tasks/current/{project}-wi{N}-*.md tasks/archive/{YYYY-MM}/
+```
+
+Use the current month (when the work was completed), not the creation month. Check if the month directory exists first (`ls tasks/archive/`); only create it if missing.
+
+After updating, the index will be refreshed automatically at next session start.
+
+---
+
+## Savepoint Urgency Levels
+
+Hook reminders arrive at escalating urgency. Three independent signals fire checkpoints — whichever reaches the higher level wins, and the hook tells you which one triggered:
+
+| Level | Context % | Output-Δ tokens | Turns since last | Agent Response |
+|-------|-----------|-----------------|------------------|----------------|
+| `[routine]` | 50-69% (+Δ≥10%) | ≥20K | ≥10 | Record progress at next milestone |
+| `[urgent]` | 70-79% | ≥40K | ≥25 | Write savepoint before continuing |
+| `[critical]` | 80-84% | ≥70K | ≥50 | Write immediately — all three layers |
+| `[final]` | ≥85% | ≥110K | ≥75 | STOP. Savepoint NOW. Compaction imminent. |
+
+The multi-signal design catches long autonomous runs on large context windows (where pure % would stay low for hundreds of turns) and long sustained output sessions (where the agent has written a lot but the window is not yet full).
+
+At `[critical]` and `[final]`, prioritize savepoint over task completion. Incomplete work can be resumed; lost context cannot.
+
+---
+
+## Mandatory Behaviors
+
+1. **Notes before diary, when there are notes.** For WI-tracked work, update the notes file before the diary so the diary entry references what's in notes rather than duplicating it. A lightweight WI-less session has no notes file — just append the diary entry.
+2. **Diary is append-only.** Never read-edit-write the diary. Multiple sessions may savepoint concurrently.
+3. **Task file stays compact.** If it exceeds ~50 lines, content should migrate to the notes file.
+4. **Savepoint on milestones and gates.** Savepoint when completing significant work (a feature, a fix, a decision) and before workflow gates — these are recoverable states.
+5. **Savepoint on context warnings.** When hook reminders fire, treat them as interrupts — save state, then continue.
+6. **Check before create for directories.** Before writing to any path under `notes/`, `diary/`, `tasks/archive/`, or `tmp/`, first `ls` the parent directory to see if it already exists. Only create the directory if `ls` confirms it is missing. An `ls` is low-friction (auto-approved); a `mkdir` requires user approval — so always prefer checking first.
+
+---
+
+## Reference Index
+
+| Reference | Purpose | When to Load |
+|-----------|---------|-------------|
+| `references/refs-terminology.md` | Standard terminology across stages: artifacts, actions, roles, workflow terms | When clarifying what a term means or ensuring consistent language |
+| `references/save-three-layer.md` | Recording model design: diary/task/notes separation, what goes where, recovery patterns | When explaining the model or training a new user |
+| `references/save-context-urgency.md` | Hook system internals: urgency thresholds, context monitoring, state machine, configuration | When debugging savepoint behavior or adjusting thresholds |
+| `references/save-recovery.md` | Detailed recovery procedures: context reset detection, stale metadata, session lifecycle | When recovering from compaction/summarisation or debugging recovery failures |
+| `references/save-task-conventions.md` | Task file schema: mandatory fields, contextual fields, category patterns, field ordering | When creating or restructuring task files |

--- a/plugins/xo/skills/xo/references/save-recovery.md
+++ b/plugins/xo/skills/xo/references/save-recovery.md
@@ -1,0 +1,197 @@
+---
+name: save-recovery
+description: "Detailed recovery procedures for resuming work after context reset (compaction or summarisation), new session, or cold start. Covers reset detection, stale metadata, and session lifecycle."
+---
+
+# Recovery Protocol
+
+Procedures for resuming agent work after context loss. The recording model (diary/task/notes) provides the recovery surface — this reference covers how to use it.
+
+## Recovery Scenarios
+
+### 1. Cold Start — New Session, Assigned Work Item
+
+The operator has told you which WI to work on.
+
+**Steps:**
+
+1. **Read task file** — glob for `tasks/current/*wi{N}-*.md` (the project prefix varies; match on the WI number)
+   - Identify: Status, NextAction, Blockers
+   - This tells you **what to do next**
+
+2. **Read notes file** — glob for `notes/**/*wi{N}-*.md` (may be in any month directory)
+   - This carries the deep understanding: decisions, evidence, architecture context
+   - Read the most recent session section for the latest state
+   - This tells you **what you know**
+
+3. **Read recent diary entries** for momentum
+   - Session IDs in diary headings won't match yours (this is a new session)
+   - Look for recent activity on this WI
+
+4. **Resume** from the `NextAction` in the task file
+   - The notes file provides the context needed to execute that action intelligently
+
+### 2. Cold Start — New Session, No Assigned Work Item
+
+No specific WI assigned. Orient on the portfolio.
+
+**Steps:**
+
+1. **Read task index** at `tasks/index.md`
+   - Scan for `Now` priority items — these are the current focus
+   - Scan for `Next` priority items — these are queued
+   - Note any `InProgress` status items — these may need continuation
+
+2. **Read today's diary** at `diary/{YYYY-MM}/{YYYY-MM-DD}.md`
+   - Understand what's been happening today
+   - Identify momentum and recent decisions
+
+3. **Present** active work items to operator:
+   ```
+   Active work items:
+   - Feature-X [Now, InProgress]: API Refactor — NextAction: write tests
+   - Bug-123 [Now, Ready]: Cache Fix — NextAction: reproduce issue
+   
+   Which would you like to work on?
+   ```
+
+### 3. Post-Reset — Same Session, Context Lost
+
+Context window was reset (compaction or summarisation) mid-session. The conversation summary provides a thin approximation of what was happening.
+
+**Steps:**
+
+1. **Read the conversation summary** — understand what the system thinks you were doing
+2. **Read task file** — ground truth for current state (more reliable than summary)
+3. **Read notes file** — the deep record that the summary compressed away
+4. **Read today's diary** — find entries with your session ID `[{session-id}]`
+   - You know your own session ID
+   - Diary entries with matching session ID are from this session
+5. **Reconcile** — if the summary and notes disagree, trust the notes file
+6. **Resume** from NextAction, informed by notes context
+
+### 4. Resume — Session Restored from Disk
+
+Desktop restored a prior session from its local storage. Context is preserved but may be stale.
+
+**Steps:**
+
+1. **Check diary** for any entries since the session was last active
+   - Other sessions may have advanced the WI
+2. **Re-read task file** — status may have changed
+3. **Continue** from where you left off, adjusting for any external changes
+
+## Compact Detection
+
+The hook system detects context resets (compaction or summarisation) via **negative delta** in context monitoring:
+
+| Signal | Meaning |
+|--------|---------|
+| `sessionstart.sh` fires with `source=compact` or `source=summarize` | Explicit context reset lifecycle event |
+| Context % drops significantly between events | Summarisation (no lifecycle event) |
+| `response_metadata` reports values > 100% | Stale pre-reset data (transient, 1-2 events) |
+
+After context reset, the first 1-2 `response_metadata` readings may be stale (reporting pre-reset values). The context urgency system handles this automatically via baseline reset.
+
+## Stale Metadata Handling
+
+`response_metadata` is a trailing indicator — it reports the previous turn's state. After context reset:
+
+```
+Event 1 post-compact: reported=122% (stale) → baseline_reset
+Event 2 post-compact: reported=25% (fresh) → baseline_set
+Event 3+: normal tracking resumes
+```
+
+The agent should not be alarmed by >100% readings immediately after context reset. They settle within 3-5 events.
+
+## Session Lifecycle Events
+
+| Event | Hook | Action |
+|-------|------|--------|
+| `startup` | `sessionstart.sh` | Fresh session. Inject context sources, reindex tasks. |
+| `compact` | `sessionstart.sh` | Context was compacted. Inject recovery instructions + session extract. |
+| `resume` | `sessionstart.sh` | Session restored from disk. Preserve context state. |
+
+### Session Start Injection
+
+On every session start, `sessionstart.sh` injects:
+- Path to today's diary
+- Path to tasks directory
+- Task index content (if under size threshold)
+- Session ID for diary headings
+
+On `compact`, additionally injects:
+- Recovery instructions directing the agent to read task + notes files
+- Pre-reset session extract (if available)
+
+## Recovery Verification
+
+After recovering, verify your understanding before proceeding:
+
+1. **State the current WI and status** — confirm with operator if uncertain
+2. **State your understanding of next action** — "I believe the next step is X. Correct?"
+3. **Identify any gaps** — "The notes mention Y but I'm unclear on Z. Can you clarify?"
+
+This prevents the failure mode where a recovering agent confidently proceeds in the wrong direction based on an incomplete summary.
+
+## Recovery Fallback
+
+When the three-layer model is insufficient — files disagree, are missing, or the operator corrects you:
+
+### Fallback Hierarchy
+
+| Priority | Source | When to Use | Characteristics |
+|----------|--------|-------------|-----------------|
+| 1 (Primary) | Task → Notes → Diary | Always try first | Structured, curated, authoritative |
+| 2 (Fallback) | `/memories/` (memory tool) | If primary files incomplete | May have scratch files, working state |
+| 3 (Last Resort) | Conversation history | If files disagree or operator corrects | Structured JSON, but verbose log exhaust |
+
+The agent knows its own session ID. After reset, diary entries with matching `[{session-id}]` headings are from this session — use these to understand what happened before the reset.
+
+To inspect conversation history, load `$session-history` skill which provides Python tools for conversation.json analysis.
+
+### When to Escalate to Conversation History
+
+- Task and notes files contradict each other
+- Operator says "no, we weren't working on that"
+- Recovery files are missing or clearly stale
+- Agent cannot make sense of the state from primary sources
+
+### How to Use Conversation History
+
+1. **Surface confusion** — don't silently fall back. Tell the operator:
+   > "The recovery state is unclear — the task file says X but the notes suggest Y. Would you like me to inspect the conversation history?"
+
+2. **Wait for approval** — conversation history is verbose; the operator may prefer to clarify verbally
+
+3. **With approval**, load `$session-history` skill:
+   - Provides Python tools for conversation.json analysis
+   - Search for recent WI references
+   - Look for the last savepoint message
+   - Identify what was actually being worked on
+
+4. **Reconcile** — once you understand the true state:
+   - Update task file with correct status/NextAction
+   - Append clarification to notes file
+   - Inform operator of corrections made
+
+### Why This Is Last Resort
+
+The conversation history is:
+- **Verbose** — full turns, tool calls, exploration paths
+- **Log exhaust** — captures everything, not curated reasoning
+- **Low signal-to-noise** — includes false starts, abandoned approaches, raw tool output
+
+The notes file is intentionally written to preserve understanding. The conversation history is what happened, not what matters. The three-layer model exists precisely to avoid re-processing log exhaust. Use this fallback sparingly, and when you do, update the primary files so future recovery doesn't need it.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Correct Approach |
+|-------------|-------------|-----------------|
+| Trust conversation summary over notes | Summary is a lossy compression | Read notes file — it's the deep record |
+| Skip reading notes for "simple" tasks | Depth of understanding is invisible | Always read notes — you can't assess what you've lost |
+| Re-derive understanding from code | Burns context on rediscovery | Read notes first — prior analysis is preserved |
+| Savepoint only to diary | Diary is too thin for recovery | All three layers: notes (deep), task (status), diary (index) |
+| Read-edit-write the diary | Race condition with concurrent agents | Append-only operations |
+| Silently fall back to conversation history | Operator unaware of confusion | Surface confusion, ask for approval |

--- a/plugins/xo/skills/xo/references/save-task-conventions.md
+++ b/plugins/xo/skills/xo/references/save-task-conventions.md
@@ -1,0 +1,145 @@
+---
+name: save-task-conventions
+description: "Task file schema for work items. Covers mandatory fields, contextual fields, category patterns, and field ordering conventions."
+---
+
+# Task File Conventions
+
+Work item files live in `tasks/current/{project}-wi{N}-{kebab-slug}.md`. The `{project}` prefix is the leaf name of the project directory (kebab-cased), providing alphabetical grouping by project. Each file is the single source of truth for one unit of work — readable by both human supervisors and agent operators.
+
+## Design Principles
+
+1. **Human scanning**: A supervisor dispatching parallel agents needs to assess priority, status, and next action within seconds.
+2. **Agent recovery**: An agent resuming after context reset (compaction or summarisation) needs enough context to continue without re-reading the full conversation history.
+
+The file should be **compact but complete** — a recovering agent reads this to know what to do next, not to understand the full investigation history (that lives in the notes file).
+
+## File Structure
+
+### Heading
+
+```
+# WI-{N}: {Descriptive Title}
+```
+
+Specific enough that a human scanning the index understands the purpose without opening the file.
+
+### Mandatory Fields
+
+Every work item, in this order:
+
+```markdown
+- Priority: {Now | Next | Later | Archived}
+- Status: {Ready | InProgress | Shipped | Blocked | Done}
+- StatusNote: {brief progress commentary or empty}
+- Blocker: {None | description}
+```
+
+**Priority** — scheduling signal: when should an agent work on this?
+**Status** — lifecycle maturity: `Ready → InProgress → Shipped → Done`. `Blocked` is orthogonal — it can interrupt any active state. A reviewer requesting changes moves `Shipped → InProgress`; re-delivery returns it to `Shipped`.
+**StatusNote** — at-a-glance context that surfaces in the index table
+**Blocker** — explicit dependency naming
+
+### `Shipped` vs `Blocked` vs `Done`
+
+Easy to conflate, but distinct:
+
+- **`Shipped`** — our deliverable is out (PR opened, doc circulated, design staged) and is awaiting others' review, merge, or acceptance. Our part is *done*; there is no further work from us until they respond. Use `StatusNote` to name the awaited party and artifact (e.g. "awaiting reviewer X on PR #N"). This is the status to grep for a daily "what am I waiting on others to accept?" check.
+- **`Blocked`** — our work is *stalled mid-flight*: we need someone's input, a fix, or access to continue building. The ball is in someone else's court to unblock **us**.
+- **`Done`** — accepted and closed.
+
+Key test: if our part is finished and we only await sign-off → `Shipped`. If we still have work queued (even if also waiting on someone) → `InProgress` or `Blocked`. Because `Status` is orthogonal to `Priority` (urgency), a `Shipped` item still carries a Priority signalling how hard to chase it.
+
+### Contextual Fields
+
+Include whichever fields serve the work's category and complexity:
+
+| Field | When to Use | Purpose |
+|-------|-------------|---------|
+| `Category` | Always helpful | Work type (Investigation, Bug fix, Process, Idea, etc.) |
+| `Deadline` | Time-sensitive items | Target date — agent should remind operator as it approaches |
+| `Observed` | Ideas and evidence-driven items | Date of first capture |
+| `Evidence` | Items accumulating observations | Timestamped list of findings |
+| `Context` | Items needing background | Bullet list of relevant background |
+| `Decision` | Items where a choice was made | What was decided and rationale |
+| `Scope` | Items with defined deliverables | Numbered steps. ~~Strikethrough~~ marks completed. |
+| `Progress` | Multi-session items | Bullet list of accomplishments |
+| `Remaining` | Items with known outstanding work | Bullet list of what's left |
+| `Root Cause` | Bug investigations | Structured analysis of underlying problem |
+| `Fixes Applied` | Bug fixes | Named fixes with file locations |
+| `Fix Confirmation Status` | Bug fixes under test | Which fixes are confirmed vs. awaiting |
+| `Artifacts changed` | Broad-impact changes | List of modified files/systems |
+| `Artifacts` | Items producing references | Links to PRs, notes, memory files |
+| `NextAction` | Almost always | One concrete next step |
+| `Provisional Pathway` | Substantial multi-stage work | The projected arc of stages, current one marked `(here)` — e.g. `Spec → Build (here) → Prove → Ship → Capture → Cleanup`. Revisable, not a commitment; advanced at each stage boundary; read it to know the natural next step. |
+| `ValidationRequired` | Items with quality gates | `Yes` or `No` |
+| `ValidationAction` | When ValidationRequired is Yes | Specific acceptance criteria |
+| `Related` | Items with connections | Cross-references to related WIs |
+| `Notes` | Items with deep records | Path to notes file in `notes/{YYYY-MM}/` |
+| `Scratch` | Set at allocation | Authoritative per-WI scratch dir (`$XOCORTEX_HOME/tmp/wi{N}/`) — the transient handoff surface stages use for subagent outputs, drafts, and intermediates. Recorded so downstream stages use it directly without checking or inventing a path. |
+| `Promotion trigger` | Idea-stage items | What would promote this to a real WI |
+
+### Provisional Pathway
+
+The arc of stages we currently expect this work to move through, with the current stage marked explicitly by `(here)`:
+
+```
+- Provisional Pathway: Survey → Spec → Build (here) → Prove → Ship → Capture → Cleanup
+```
+
+**Projected, not a contract.** It records what we currently think the path is — revise it freely as facts change; it is not necessarily agreed with the operator and carries no obligation to follow. Stages left of `(here)` are done, stages right are upcoming (explicit `(here)`, no symbols/strikethrough). Its purpose is to make "what's the natural next step?" a *lookup* rather than something to re-derive under load: the agent advances `(here)` as part of the recording it does at each stage boundary, and consults it when a stage looks complete — e.g. to offer close-out (Capture, then Cleanup) after shipping. Only on substantial multi-stage work; small or reactive tasks omit it.
+
+## Field Ordering Convention
+
+Top-down reading order:
+
+1. **Identity**: Priority, Status, StatusNote, Blocker
+2. **Scheduling**: Category, Deadline
+3. **Background**: Observed, Evidence, Context
+3. **Decisions**: Decision
+4. **Work definition**: Scope, Progress, Remaining, Root Cause, Fixes
+5. **Pointers**: NextAction, Provisional Pathway, Artifacts, Notes, Related
+6. **Quality**: ValidationRequired, ValidationAction
+
+## Category Patterns
+
+### Idea (lightweight idea capture)
+
+```markdown
+- Priority: Later
+- Status: Ready
+- StatusNote: {one-line assessment}
+- Blocker: None
+- Category: Idea
+- Observed: {date}
+- Evidence:
+  - {date}: {observation}
+- Promotion trigger: {what would make this worth investigating}
+```
+
+### Investigation
+
+Emphasises Evidence, Context, and often evolves a Root Cause section. Notes file is essential.
+
+### Bug Fix
+
+Emphasises Context (symptoms), Root Cause (analysis), Fixes Applied (implementation), and ValidationAction (acceptance criteria). Most structured category.
+
+### Process / Documentation
+
+Emphasises Decision (what was chosen), Scope (deliverables), and Artifacts changed (impact).
+
+### Reactive Work (email, Slack, PR review)
+
+Minimal — often just mandatory fields plus NextAction.
+
+## Size Convention
+
+A task file that grows beyond ~50 lines signals that content should migrate to a notes file. The task file then points to it via the `Notes` field.
+
+## Relationship to Notes Files
+
+- Task file answers **"what should I do?"**
+- Notes file answers **"what do we know and how did we get here?"**
+
+Task files stay compact. When investigation depth, design reasoning, or detailed analysis accumulates, it belongs in the notes file at `notes/{YYYY-MM}/{project}-wi{N}-{description}.md`.

--- a/plugins/xo/skills/xo/references/save-three-layer.md
+++ b/plugins/xo/skills/xo/references/save-three-layer.md
@@ -1,0 +1,139 @@
+---
+name: save-three-layer
+description: "Recording model design for multi-session agent work. Explains diary/task/notes separation, what content goes where, and how recovery uses each layer."
+---
+
+# Three-Layer Recording Model
+
+Progress is recorded across three artifact types, each with a distinct role. The separation prevents duplication and keeps each artifact lean enough for its purpose.
+
+## Layer Summary
+
+| Layer | Artifact | Role | Lifecycle | Ceiling |
+|-------|----------|------|-----------|---------|
+| **Diary** | `diary/{YYYY-MM}/{YYYY-MM-DD}.md` | Thin chronological savepoint log | Append-only | 5-10 lines per entry |
+| **Task file** | `tasks/current/{project}-wi{N}-*.md` | Living current state of work item | Updated in-place | Compact (~50 lines max) |
+| **Notes file** | `notes/{YYYY-MM}/{project}-wi{N}-*.md` | Structured knowledge and reasoning | Append or rewrite per phase | As long as needed |
+
+## Diary: Chronological Savepoint Log
+
+The diary answers **"what happened today, in what order?"** Each entry is a savepoint marker, not a design document.
+
+### Format
+
+```markdown
+## [{short_session_id}] Bug-123: Chat Overlap — Fixes F+G
+- Applied orphaned DOM cleanup (Fix F) and tool pinning leak fix (Fix G)
+- Decision: cleanup at diff-render level, not aggressive node clear
+- Status: InProgress — awaiting user testing of multi-monitor scenario
+- Notes updated: `notes/2026-03/wi46-chat-overlap-bug-investigation.md`
+```
+
+The diary always gets an entry for a session that did substantive work, keyed on the short session id. A WI reference is included when the session is tracked under a work item; a lightweight WI-less session drops the WI prefix and the notes pointer and keys on the session id alone.
+
+### A Diary Entry Contains
+
+- **Session ID + optional WI reference** (the heading — WI included only when the session is tracked under one)
+- **1-2 line summary** of what was accomplished
+- **Key decision** (if any, one line)
+- **Current status** (one line)
+- **Pointer to notes file** (if detailed content was written)
+
+### A Diary Entry Does NOT Contain
+
+- Files changed lists (belong in task file or commit)
+- Architecture discussion (belongs in notes)
+- Duplicated status fields (task file is source of truth)
+- Detailed fix descriptions (belongs in notes)
+- Reproduction steps, hypotheses, evidence (belongs in notes)
+
+### Concurrency Safety
+
+The diary is a single file per day. Multiple parallel sessions append to it. Short entries minimise conflict surface.
+
+**CRITICAL:** Diary writes must be append-only operations.
+- Bash: `echo "..." >> diary.md` or `cat >> diary.md << 'EOF'`
+- Never use `edit`, `multi_edit`, or any tool that reads the file first
+- This prevents race conditions when multiple agents savepoint concurrently
+
+## Task File: Living Current State
+
+The task file answers **"what is the current state of this work item?"**
+
+It is the source of truth for status, blockers, next action, and validation criteria. A cold-start agent reads this to understand **what to do next**, not the full investigation history.
+
+Key properties:
+- Updated in-place by the working session
+- Stays compact — migrate content to notes file if it exceeds ~50 lines
+- Per-WI, so no concurrency issues
+- See `references/save-task-conventions.md` for schema
+
+## Notes File: Reasoning History and Structured Knowledge
+
+The notes file answers **"what do we know about this work item and how did we get there?"**
+
+This is the deep record of investigation, design reasoning, architecture context, hypotheses, evidence, and decisions. It is the primary vehicle for preserving understanding across context windows.
+
+### Why Notes Files Are Critical
+
+- The conversation history is verbose; notes are condensed-to-what-matters
+- A recovering agent reads notes to regain the depth of understanding it had before context reset (compaction or summarisation)
+- Structured notes are more efficient than re-reading conversation transcripts
+- Notes accumulate across sessions — each session appends its section
+
+### Notes Files Should Contain
+
+- Architecture context and code path analysis
+- Root cause analysis and hypothesis tracking
+- Design decisions with rationale
+- Evidence tables and test results
+- Fix descriptions with file locations and line numbers
+- Chronological progress sections (what was tried, what worked, what didn't)
+
+### Notes File Structure
+
+```markdown
+# WI-{N}: {Title} — {Description}
+
+## Session {session_id} ({YYYY-MM-DD}): {Phase}
+
+### Findings
+{content}
+
+### Decisions
+{content}
+
+### Open Questions
+{content}
+```
+
+Each session appends a new section header. The file grows over the lifetime of the work item.
+
+## Recovery Patterns
+
+| Recovery Scenario | What Agent Reads | Why |
+|-------------------|-----------------|-----|
+| Cold start (no assigned WI) | Task index → diary | Orient on portfolio and recent momentum |
+| Cold start (assigned WI) | Task file → notes file | Understand current state and accumulated knowledge |
+| Post-reset (same session) | Task file → notes file → diary `[{session-id}]` entries | Resume with full context from this session |
+| Operator review | Diary | Scan the day's activity chronologically |
+
+## Design Rationale
+
+### Why Three Layers (Not One)
+
+A single file would either be too verbose for scanning (diary use case) or too compressed for recovery (notes use case). The separation allows each artifact to optimize for its reader:
+
+- **Diary** → optimized for human scanning across multiple WIs
+- **Task file** → optimized for agent cold-start orientation
+- **Notes file** → optimized for agent deep-context recovery
+
+### Why Notes Are Separate From Task Files
+
+Task files stay compact because they serve two masters: human supervisors scanning the index, and agents needing quick orientation. Deep reasoning would bloat the task file and make scanning harder.
+
+Notes files grow freely because they serve one master: a recovering agent that needs to reconstruct its understanding. Length is a feature, not a bug.
+
+### Why Diary Is Append-Only
+
+Multiple agents may savepoint to the same daily diary file concurrently. Read-edit-write creates race conditions where one agent's edits overwrite another's. Append-only operations are atomic at the filesystem level.


### PR DESCRIPTION
## Summary
Adds the **XO plugin** under `plugins/xo/` — an operator workflow system (an "AI harness") for Cortex Code: durable cross-session memory, composable OODA-loop workflow stages, and specialised proposer/critic/verifier subagents. Artifact-type-neutral (code, docs, Snowflake objects, configs, apps).

## Depends on #81
Per DevRel review, the `plugins/` **convention** is split into a prequel: **#81 "Establish a plugins/ convention"**. Once #81 merges to `main`, this PR will be **rebased onto `main`** so its diff reduces to **only**:
- `plugins/xo/…` — the plugin (`.cortex-plugin/`, `hooks/`, `agents/`, `skills/xo/`, `README.md`, `SETUP.md`, Apache-2.0 `LICENSE`).
- a single **`xo` row** added to the Plugins table in the repository `README.md`.

Until #81 merges, this PR's diff still shows the convention changes (they can't be excluded across a fork→upstream base). Review of the plugin content can proceed; the rebase is a mechanical follow-up.

## Validation
- `cortex plugin validate plugins/xo` → valid.
- Installs from the catalog and runs; no internal references.
