### PR TITLE
Establish a plugins/ convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Each skill is a folder containing a `SKILL.md` that teaches CoCo a workflow, cod
 
 - [Install these skills](#install-these-skills)
 - [Skill catalog](#skill-catalog)
+- [Plugins](#plugins)
 - [Authoring a skill](#authoring-a-skill)
 - [Repo structure](#repo-structure)
 - [Troubleshooting](#troubleshooting)
@@ -78,6 +79,12 @@ Once installed, invoke a skill by typing `$<skill-name>` followed by your prompt
 | [`mlops`](skills/mlops)               | Router skill for MLOps on Snowflake — maturity assessment, promotion patterns, CI/CD, monitoring, governance. |
 | [`dcr-v1-to-v2`](skills/dcr-v1-to-v2) | Migrate a Data Clean Room from the V1 SAMOOHA Provider/Consumer API to the V2 Collaboration API.              |
 
+
+---
+
+## Plugins
+
+Some contributions are **plugins** rather than single skills. A plugin bundles one or more skills together with hooks, subagents, and other components under `plugins/<name>/`, and installs through CoCo's plugin mechanism (not the single-skill install above). See [`plugins/README.md`](plugins/README.md) for the layout and how to add one.
 
 ---
 

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,35 @@
+# Plugins
+
+Contributions in this folder are **plugins** — richer than a single skill. A plugin bundles one or more skills together with hooks, subagents, and other components, and installs through CoCo's plugin mechanism rather than the single-skill install used for `skills/`.
+
+## Layout
+
+A plugin lives under `plugins/<name>/`:
+
+```
+plugins/
+  your-plugin-name/
+    .cortex-plugin/plugin.json   # required — the plugin manifest
+    hooks/  agents/  skills/     # plugin components, as needed
+    LICENSE  README.md           # recommended
+```
+
+Only `.cortex-plugin/plugin.json` is structurally required; everything else is the author's choice of organisation. Where a file sits on disk is where it ships.
+
+## Adding a plugin
+
+1. Create `plugins/<your-plugin>/` with a `.cortex-plugin/plugin.json` manifest (`name`, `version`, `description`).
+2. Include a `README.md` (what it does, prerequisites) and, if it needs host-side setup, a `SETUP.md`.
+3. Add a `LICENSE` file inside the plugin folder, following the repository's contribution guidelines ([CONTRIBUTING.md](../CONTRIBUTING.md)).
+4. Add a row for your plugin to the **Plugins** table in the repository [`README.md`](../README.md).
+5. Open a PR — see [CONTRIBUTING.md](../CONTRIBUTING.md) for the review checklist.
+
+## Installing a plugin
+
+Point CoCo at the plugin's folder — for example, in the chat:
+
+```
+Install the plugin at https://github.com/Snowflake-Labs/coco-skills/tree/main/plugins/<name>
+```
+
+Then follow any additional setup instructions the plugin bundles (see its `README.md` / `SETUP.md`).


### PR DESCRIPTION
## Summary
Establishes a `plugins/` area in the repo for contributions that are richer than a single skill — bundling one or more skills with hooks, subagents, and other components, installed through CoCo's plugin mechanism rather than the single-skill install.

Per DevRel review, this is split out as a **prequel** so the convention lands on its own, ahead of the first plugin contribution (the XO plugin, in a follow-up PR).

## Changes
- **`README.md`** — table-of-contents entry + a short **Plugins** section linking to the convention doc.
- **`plugins/README.md`** (new) — the convention: the `plugins/<name>/` layout, how to add a plugin, and how to install one. Defers licensing/review to `CONTRIBUTING.md`.

## Notes
- **No plugin is added here** — this only establishes the convention and the folder.
- Follow-up: the XO plugin PR adds `plugins/xo/` and a row to the Plugins table on top of this.
