### PR TITLE
Add check-model-availability skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Once installed, invoke a skill by typing `$<skill-name>` followed by your prompt
 | [`rbac`](skills/rbac)                 | Design Snowflake RBAC hierarchies and access-role patterns.                                                   |
 | [`mlops`](skills/mlops)               | Router skill for MLOps on Snowflake — maturity assessment, promotion patterns, CI/CD, monitoring, governance. |
 | [`dcr-v1-to-v2`](skills/dcr-v1-to-v2) | Migrate a Data Clean Room from the V1 SAMOOHA Provider/Consumer API to the V2 Collaboration API.              |
+| [`check-model-availability`](skills/check-model-availability) | Verify whether a Cortex model is callable in base mode (AI SQL) and in agentic mode (the Cortex Code allow-list), with name-variant fallback. |
 
 
 ---

--- a/skills/check-model-availability/LICENSE
+++ b/skills/check-model-availability/LICENSE
@@ -1,0 +1,22 @@
+Snowflake Skills License
+
+© 2026 Snowflake Inc. All rights reserved.
+
+LICENSE: Use of these materials (including all code, prompts, assets, files, and other components of these skills (collectively, "Skills")) is governed by your agreement with Snowflake for the Service. If no separate agreement exists, use is governed by Snowflake's Terms of Service (available at: https://www.snowflake.com/en/legal/terms-of-service/).
+
+Your applicable agreement is referred to as the "Agreement." "Service" is as defined in the Agreement.
+
+ADDITIONAL RESTRICTIONS: Notwithstanding anything in the Agreement to the contrary, you may not:
+
+- Extract from the Service or retain copies of the Skills outside use with the Service;
+- Reproduce or copy the Skills, except for temporary copies created automatically during authorized use of the Service;
+- Create derivative works based on the Skills;
+- Distribute, sublicense, or transfer the Skills to any third party;
+- Make, offer to sell, sell, or import any inventions embodied in the Skills; nor,
+- Reverse engineer, decompile, or disassemble the Skills.
+
+The receipt, viewing, or possession of the Skills does not convey or imply any license or right beyond those expressly granted above.
+
+Snowflake retains all rights, title, and interest in the Skills, including all copyrights, trademarks, patents, and all other applicable intellectual property rights.
+
+THE SKILLS ARE PROVIDED "AS IS," WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SKILLS OR THE USE OR OTHER DEALINGS IN THE SKILLS.

--- a/skills/check-model-availability/SKILL.md
+++ b/skills/check-model-availability/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: check-model-availability
+title: Check Model Availability
+summary: Verify whether a Cortex model is callable in base mode (AI SQL) and in agentic mode (the Cortex Code allow-list), with name-variant fallback.
+description: |
+  Determines, for one or more Cortex models, whether each is usable in base mode
+  (AI SQL: AI_COMPLETE / SNOWFLAKE.CORTEX.COMPLETE) and in agentic mode (the Cortex
+  Code / CoCo Agent curated allow-list). These are two independent gates that use
+  different name spellings — a model can be GA in base mode yet rejected agentically,
+  and vice-versa. The skill reads SHOW CORTEX BASE MODELS for authoritative names,
+  lifecycle, and regions; probes base mode with a real AI_COMPLETE call; harvests the
+  full agentic allow-list in a single call; retries plausible name variants before
+  declaring a model unavailable; and reports a base/agentic matrix.
+
+  Triggers: check if we have access to a model, are there any new LLM models, any new
+  versions of GPT/Opus/Sonnet/GLM/grok/gemini, test a model to see that it works, is
+  this model available agentically, can I benchmark this model in base and agentic mode.
+
+  Do NOT use for: enabling model access via RBAC/allowlist grants (that is a governance
+  task), Cortex Search or Analyst model selection, or fine-tuned/custom model registration.
+prompt: Check whether the new Cortex models are available in base and agentic mode.
+language: en
+status: Published
+author: Chanin Nantasenamat, Lead Developer Advocate, OSS
+type: snowflake
+tools:
+  - snowflake_sql_execute
+  - Bash
+  - ask_user_question
+---
+
+## Overview
+
+Cortex exposes models through two independent surfaces, each with its own gate and its
+own name spelling:
+
+- **Base mode** — AI SQL functions `AI_COMPLETE` / `SNOWFLAKE.CORTEX.COMPLETE`. Names are
+  UPPERCASE and sometimes carry a `1P-` provider prefix (e.g. `OPENAI-1P-GPT-5.6-SOL`).
+- **Agentic mode** — the curated allow-list enforced by the Cortex Code Agent. Names are
+  lowercase and often drop the `1p-` prefix (`openai-gpt-5.6-sol`).
+
+Base-callable does **not** imply agentic-callable. Presence in `SHOW CORTEX BASE MODELS`
+does not even guarantee base-callable — some listed models return `unknown model` from
+`AI_COMPLETE`. Always confirm with a live probe.
+
+## When to Use
+
+- "Do we have access to `<model>`?" / "Is `<model>` available?"
+- "Are there any new LLM models or new versions of GPT / Opus / Sonnet / GLM / grok / gemini?"
+- "Test `<model>` to see that it works."
+- "Can I benchmark `<model>` in base and agentic mode?"
+
+## When NOT to Use
+
+| Topic | Delegate to |
+|---|---|
+| Granting model access via RBAC / allow-list | a governance / access skill |
+| Choosing a model for Cortex Search or Analyst | those product skills |
+| Registering a fine-tuned or custom model | a model-registry / ML skill |
+
+## Workflow
+
+1. **List authoritative base names, lifecycle, and regions** — Run
+   `SHOW CORTEX BASE MODELS;` then filter with
+   `SELECT "name","lifecycle_status","in_region_availability","cross_region_availability","legacy_date","eol_date" FROM TABLE(RESULT_SCAN(LAST_QUERY_ID())) WHERE "name" ILIKE '%<pattern>%';`
+   Interpret `lifecycle_status`: `GA` = usable; `PUPR`/`PRPR` = preview, usable if the probe
+   succeeds; `LEGACY` = deprecated but callable until `eol_date` (flag it); `EOL` = not
+   callable; `INTERNAL`/`None` = probe to confirm. `in_region_availability: []` with a
+   populated `cross_region_availability` means it needs cross-region inference enabled.
+
+2. **Confirm base mode with a real call** — Set a warehouse only if none is active, then
+   `SELECT AI_COMPLETE('<base-model-name>', 'Reply with the single word: ok') AS resp;`
+   A text reply means base-capable. `unknown model` / `not authorized` /
+   `not available in region` means not base-capable — record the exact message.
+
+3. **Harvest the agentic allow-list in one shot** — Run ONE probe with a bogus model name;
+   the CLI error dumps every allowed agentic model:
+   `cortex exec -m __definitely_not_a_model__ --no-history --max-turns 1 "Reply with exactly: ok" 2>&1 | tail -20`
+   The error body contains `- Available models: <comma-separated lowercase list>`. That
+   list **is** the allow-list. Match your targets against it — this avoids probing each
+   model separately and spending agent turns.
+
+4. **Confirm a specific target agentically** — For a target you want verified end-to-end:
+   `cortex exec -m <agentic-model-name> --no-history --max-turns 3 "Reply with exactly the word ok and nothing else. Do not call any tools." 2>&1 | tail -4`
+   A short reply → agentic-capable. `is not authorized or not available in your region` or
+   `is not an allowed model` → not agentic. `Max tool call iterations reached` → the model
+   works but hit the turn cap; treat as capable.
+
+5. **Apply name-variant fallback** — Before declaring a model unavailable, retry variants:
+   drop/add the `1p-` prefix (`openai-1p-gpt-5.6-sol` ↔ `openai-gpt-5.6-sol`); normalize
+   case (base UPPERCASE vs agentic lowercase); try sibling suffixes (`-sol`, `-terra`,
+   `-luna`); and try version-spelling variants (`opus-4-8` vs `opus-4.8`, family vs
+   `-mini`/`-nano`).
+
+6. **Report the matrix** — One row per model: **Model | Base? | Agentic? | Lifecycle |
+   Notes**. State explicitly whether the user can do base-only or full base + agentic
+   benchmarking, and flag any `LEGACY`/`EOL` models with their dates.
+
+## Common Mistakes
+
+- **Trusting `SHOW` over a probe** — A model can appear in `SHOW CORTEX BASE MODELS` and
+  still return `unknown model` from `AI_COMPLETE`. The live call is the source of truth.
+- **Assuming base implies agentic** — They are separate allow-lists that drift
+  independently. Always harvest the agentic list fresh (Step 3); never cache it.
+- **Comparing raw names** — Base is UPPERCASE with an optional `1P-` prefix; agentic is
+  lowercase without it. Normalize before matching or you will report false negatives.
+- **Probing every model agentically** — Wastes agent turns. Harvest the whole list once,
+  then only probe the specific targets that matter.
+
+## Examples
+
+**Scan for new models across families:**
+> "Are there any new LLM models or new versions for GPT, GLM, Opus, Sonnet?"
+
+Expected output: a base/agentic matrix grouped by family, highlighting agentic-only models
+(e.g. `glm-5.2`), base-only models, and EOL/LEGACY models to avoid.
+
+**Confirm one model both ways:**
+> "Check if we have access to gpt-5.6 and that it works."
+
+Expected output: `SHOW` lifecycle for `OPENAI-1P-GPT-5.6-*`, a base `AI_COMPLETE` probe,
+an agentic `cortex exec` probe on `openai-gpt-5.6-sol`, and a verdict.
+
+**Pre-benchmark check:**
+> "Which of these can I benchmark in both base and agentic mode?"
+
+Expected output: per-model Base?/Agentic? columns and an explicit base-only vs full
+base+agentic recommendation.
+
+## Stopping Points
+
+⚠️ **STOPPING POINT** — If a base call needs a warehouse and none is active, ask which
+warehouse to use before probing.
+
+⚠️ **STOPPING POINT** — If the user cares about only one surface (base OR agentic), skip
+the other probe and say so, to avoid spending agent turns unnecessarily.

--- a/skills/check-model-availability/SKILL.md
+++ b/skills/check-model-availability/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-model-availability
 title: Check Model Availability
-summary: Verify whether a Cortex model is callable in base mode (AI SQL) and in agentic mode (the Cortex Code allow-list), with name-variant fallback.
+summary: Verify whether a Cortex model is callable in base mode (AI SQL) and agentic mode (the Cortex Code allow-list), with name-variant fallback.
 description: |
   Determines, for one or more Cortex models, whether each is usable in base mode
   (AI SQL: AI_COMPLETE / SNOWFLAKE.CORTEX.COMPLETE) and in agentic mode (the Cortex


### PR DESCRIPTION
## Summary

Adds a new `snowflake`-type skill, **`check-model-availability`**, that verifies whether a Cortex model is usable across the two independent surfaces:

- **Base mode** — AI SQL (`AI_COMPLETE` / `SNOWFLAKE.CORTEX.COMPLETE`)
- **Agentic mode** — the Cortex Code / CoCo Agent curated allow-list

These gates drift independently and use different name spellings (base is UPPERCASE with an optional `1P-` prefix; agentic is lowercase without it), so a model being GA in base mode does not mean it is callable agentically — and vice-versa.

### What the skill does
1. `SHOW CORTEX BASE MODELS` for authoritative names, lifecycle (`GA`/`PUPR`/`PRPR`/`LEGACY`/`EOL`), and regions.
2. Probes base mode with a live `AI_COMPLETE` call (a `SHOW` listing alone is not proof — some listed models return `unknown model`).
3. Harvests the **entire** agentic allow-list in one call via a deliberately-bogus-name `cortex exec` probe (its diagnostics dump the full list), avoiding per-model turn spend.
4. Applies name-variant fallback (`1p-` prefix, case, `-sol`/`-terra`/`-luna` siblings, version spellings) before declaring a model unavailable.
5. Reports a base/agentic matrix and states whether base-only or full base+agentic benchmarking is possible.

Every command in the workflow was verified live against a Snowflake account before authoring.

### Files
- `skills/check-model-availability/SKILL.md`
- `skills/check-model-availability/LICENSE` (Snowflake Skills License)
- `README.md` — added a catalog row under **Operations, MLOps & governance**

## Test plan
- [ ] `SHOW CORTEX BASE MODELS` returns names/lifecycle/regions
- [ ] Base probe: `SELECT AI_COMPLETE('claude-opus-4-8', 'Reply with the single word: ok')` returns text
- [ ] Agentic harvest: bogus-name `cortex exec` probe dumps the `Available models` list
- [ ] Name-variant fallback resolves `OPENAI-1P-GPT-5.6-SOL` to `openai-gpt-5.6-sol`
- [ ] Matrix correctly flags agentic-only (e.g. `glm-5.2`) and base-only models
